### PR TITLE
fix(feet): print the pin at its stated diameter and keep the mating face flat

### DIFF
--- a/src/features/bin-designer/types/base.test.ts
+++ b/src/features/bin-designer/types/base.test.ts
@@ -6,7 +6,6 @@ import {
   DETACHABLE_PIN_LEAD_IN_MM,
   DETACHABLE_PIN_MEMBRANE_MM,
   DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
-  DETACHABLE_PIN_RIDGE_STEP_MM,
   DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
   detachableFeetFitFloor,
   binFloorMm,
@@ -30,11 +29,9 @@ describe('detachable pin sizes', () => {
     );
   });
 
-  it('leaves every pin solid under its ridges and its taper', () => {
+  it('leaves every pin solid under its lead-in taper', () => {
     const narrowest = Math.min(...DETACHABLE_PIN_DIAMETERS_MM);
-    const tipDiameter =
-      narrowest - 2 * DETACHABLE_PIN_RIDGE_STEP_MM - 2 * DETACHABLE_PIN_LEAD_IN_MM;
-    expect(tipDiameter).toBeGreaterThan(0);
+    expect(narrowest - 2 * DETACHABLE_PIN_LEAD_IN_MM).toBeGreaterThan(0);
   });
 });
 

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -288,7 +288,8 @@ export const DETACHABLE_PIN_HOLE_DIAMETER_MM = 3;
  * stand on the floor, and a floor pattern is cut from the same surface. None of
  * that has to be reasoned about if the interior surface is never broken.
  *
- * Two 0.2mm layers, which is what bridges cleanly over the hole below it. It costs engagement depth — a pin reaches
+ * Two 0.2mm layers, which is what bridges cleanly over the hole
+ * below it. It costs engagement depth — a pin reaches
  * `wallThickness - this` — and that is the right way round: a shallow joint is
  * recoverable with glue, a hole through the scoop is not.
  */

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -288,8 +288,7 @@ export const DETACHABLE_PIN_HOLE_DIAMETER_MM = 3;
  * stand on the floor, and a floor pattern is cut from the same surface. None of
  * that has to be reasoned about if the interior surface is never broken.
  *
- * Two layers at {@link DETACHABLE_PIN_ASSUMED_LAYER_MM}, which is what bridges
- * cleanly over the hole below it. It costs engagement depth — a pin reaches
+ * Two 0.2mm layers, which is what bridges cleanly over the hole below it. It costs engagement depth — a pin reaches
  * `wallThickness - this` — and that is the right way round: a shallow joint is
  * recoverable with glue, a hole through the scoop is not.
  */
@@ -325,17 +324,6 @@ export function binFloorMm(wallThicknessMm: number): number {
 /** Least engagement a detachable bin gives a pin; a thicker wall gives more. */
 export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM =
   GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT - DETACHABLE_PIN_MEMBRANE_MM;
-
-/**
- * How far the pin is relieved between ridge crests, in mm. Steps INWARD from the
- * selected diameter, so {@link DETACHABLE_PIN_DIAMETERS_MM} stays the widest
- * point. Ridge pitch assumes {@link DETACHABLE_PIN_ASSUMED_LAYER_MM}; other
- * layer heights degrade the fit rather than failing visibly.
- */
-export const DETACHABLE_PIN_RIDGE_STEP_MM = 0.2;
-
-/** The layer height {@link DETACHABLE_PIN_RIDGE_STEP_MM} is pitched for. */
-export const DETACHABLE_PIN_ASSUMED_LAYER_MM = 0.2;
 
 /**
  * Length of the tapered lead-in at a pin's tip, in mm. An L foot's three pins

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -178,6 +178,24 @@ describe('detachable foot geometry', () => {
     }
   });
 
+  it('relieves the preview foot too, so the two do not read differently', () => {
+    // The preview is built from the simplified profile — one taper, no vertical
+    // step — and takes the same relief. Without this the mating face could go
+    // back to full width in the viewport while the exported part was set back.
+    const { feet, pinHoles } = feetOf({ forExport: false });
+    const full = buildSingleCellSocket(PITCH - CLEARANCE, PITCH - CLEARANCE);
+    try {
+      const footMesh = meshOf(feet[0]);
+      const integral = extremeAt(meshOf(full), 0, 0);
+      expect(extremeAt(footMesh, 0, 0)).toBeCloseTo(integral - MATING_RIM_RELIEF_MM, 6);
+      expect(boundingBox(footMesh.vertices).minZ).toBeCloseTo(-5, 4);
+    } finally {
+      feet.forEach((f) => f.delete());
+      pinHoles?.delete();
+      full.delete();
+    }
+  });
+
   it('is one closed solid once its pins are on', () => {
     const { feet, pinHoles } = feetOf();
     try {

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -84,7 +84,7 @@ const ARM = footArmMm({ magnetDiameterMm: MAGNET_D, magnetInsetFromEdgeMm: 8, pi
  * rather than the tessellation. Everything a baseplate touches is in this
  * range: only the top 0.25mm, above the widest section, is relieved.
  */
-const PROFILE_Z = [-0.25, -2.4, -4.2, -5];
+const PROFILE_Z = [-(CLEARANCE / 2), -2.4, -4.2, -5];
 
 /** A single L foot on a cell centred at the origin, hugging its +X/+Y corner. */
 const CORNER_L: FootPlacement = {
@@ -166,10 +166,10 @@ describe('detachable foot geometry', () => {
         const integral = extremeAt(fullMesh, 0, axis);
         // The face the bin sits on, inset by the relief.
         expect(extremeAt(footMesh, 0, axis)).toBeCloseTo(integral - MATING_RIM_RELIEF_MM, 6);
-        // ...while the widest section is untouched, which is what the relief
-        // landing on the profile's own breakpoint buys: a relief that narrowed
-        // the whole foot would be one that loosened it in a baseplate.
-        expect(extremeAt(footMesh, -0.25, axis)).toBeCloseTo(integral, 6);
+        // ...while the widest section, where the profile's top step ends, is
+        // untouched: a relief that narrowed the whole foot would be one that
+        // loosened it in a baseplate.
+        expect(extremeAt(footMesh, -(CLEARANCE / 2), axis)).toBeCloseTo(integral, 6);
       }
     } finally {
       feet.forEach((f) => f.delete());
@@ -179,9 +179,9 @@ describe('detachable foot geometry', () => {
   });
 
   it('relieves the preview foot too, so the two do not read differently', () => {
-    // The preview is built from the simplified profile — one taper, no vertical
-    // step — and takes the same relief. Without this the mating face could go
-    // back to full width in the viewport while the exported part was set back.
+    // The preview's simplified profile is a different solid through the same
+    // intersection, so the mating face can go back to full width in the
+    // viewport while the exported part stays set back.
     const { feet, pinHoles } = feetOf({ forExport: false });
     const full = buildSingleCellSocket(PITCH - CLEARANCE, PITCH - CLEARANCE);
     try {

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -41,6 +41,8 @@ import {
 
 import type { DetachableFeetGeometry, DetachableFeetOptions } from './detachableFeetBuilder';
 
+let MATING_RIM_RELIEF_MM: number;
+
 type BuildFeet = (opts: DetachableFeetOptions) => DetachableFeetGeometry;
 type BuildCell = (w: number, d: number) => Shape3D;
 
@@ -50,7 +52,9 @@ let meshOf: (shape: Shape3D) => MeshData;
 
 beforeAll(async () => {
   await initTestKernel();
-  buildDetachableFeet = (await import('./detachableFeetBuilder')).buildDetachableFeet;
+  const feetModule = await import('./detachableFeetBuilder');
+  buildDetachableFeet = feetModule.buildDetachableFeet;
+  MATING_RIM_RELIEF_MM = feetModule.MATING_RIM_RELIEF_MM;
   buildSingleCellSocket = (await import('./socketBuilder')).buildSingleCellSocket;
   const { mesh } = await import('brepjs');
   const { toIndexedMeshData } = await import('./meshUtils');
@@ -74,11 +78,13 @@ const MAGNET_DEPTH = 2;
 const ARM = footArmMm({ magnetDiameterMm: MAGNET_D, magnetInsetFromEdgeMm: 8, pinDiameterMm: PIN });
 
 /**
- * Z of every breakpoint in the socket profile, measured from the foot's top.
- * The loft's sections land exactly here, so a vertex-level comparison at these
- * depths is comparing the profile itself rather than the tessellation.
+ * Z of every socket-profile breakpoint at or below the foot's widest section,
+ * measured from the foot's top. The loft's sections land exactly here, so a
+ * vertex-level comparison at these depths is comparing the profile itself
+ * rather than the tessellation. Everything a baseplate touches is in this
+ * range: only the top 0.25mm, above the widest section, is relieved.
  */
-const PROFILE_Z = [0, -0.25, -2.4, -4.2, -5];
+const PROFILE_Z = [-0.25, -2.4, -4.2, -5];
 
 /** A single L foot on a cell centred at the origin, hugging its +X/+Y corner. */
 const CORNER_L: FootPlacement = {
@@ -132,7 +138,7 @@ function extremeAt(m: MeshData, z: number, axis: 0 | 1): number {
 }
 
 describe('detachable foot geometry', () => {
-  it('reproduces the integral foot profile exactly on the faces it keeps', () => {
+  it('reproduces the integral foot profile exactly below the mating rim', () => {
     const { feet, pinHoles } = feetOf();
     const full = buildSingleCellSocket(PITCH - CLEARANCE, PITCH - CLEARANCE);
     try {
@@ -142,6 +148,28 @@ describe('detachable foot geometry', () => {
         // The outer faces this foot keeps are its +X and +Y ones.
         expect(extremeAt(footMesh, z, 0)).toBeCloseTo(extremeAt(fullMesh, z, 0), 6);
         expect(extremeAt(footMesh, z, 1)).toBeCloseTo(extremeAt(fullMesh, z, 1), 6);
+      }
+    } finally {
+      feet.forEach((f) => f.delete());
+      pinHoles?.delete();
+      full.delete();
+    }
+  });
+
+  it('sets the mating face back from the rim that curls', () => {
+    const { feet, pinHoles } = feetOf();
+    const full = buildSingleCellSocket(PITCH - CLEARANCE, PITCH - CLEARANCE);
+    try {
+      const footMesh = meshOf(feet[0]);
+      const fullMesh = meshOf(full);
+      for (const axis of [0, 1] as const) {
+        const integral = extremeAt(fullMesh, 0, axis);
+        // The face the bin sits on, inset by the relief.
+        expect(extremeAt(footMesh, 0, axis)).toBeCloseTo(integral - MATING_RIM_RELIEF_MM, 6);
+        // ...while the widest section is untouched, which is what the relief
+        // landing on the profile's own breakpoint buys: a relief that narrowed
+        // the whole foot would be one that loosened it in a baseplate.
+        expect(extremeAt(footMesh, -0.25, axis)).toBeCloseTo(integral, 6);
       }
     } finally {
       feet.forEach((f) => f.delete());
@@ -200,6 +228,33 @@ describe('detachable foot geometry', () => {
       expect(widest * 2).toBeLessThanOrEqual(PIN + 1e-4);
       // And reaches it: the bound alone would pass an undersized pin.
       expect(widest * 2).toBeCloseTo(PIN, 3);
+    } finally {
+      feet.forEach((f) => f.delete());
+      pinHoles?.delete();
+    }
+  });
+
+  /**
+   * The shaft holds its stated diameter for its whole length, rather than
+   * dipping between crests. A ridged pin passes every other check here — it is
+   * closed, the right height, and never wider than stated — while presenting
+   * the slicer with a diameter that changes every layer, which is what made the
+   * printed pin measure 2.0mm against a 2.8mm model.
+   */
+  it('holds the full pin diameter all the way up the shaft', () => {
+    // The deep floor, so the shaft is long enough for a column probe to say
+    // something: at the default 1.2mm floor a pin is 0.8mm tall in total.
+    const { feet, pinHoles } = feetOf({ floorThicknessMm: 2.4 });
+    try {
+      const m = meshOf(feet[0]);
+      const [pin] = footPinPositions(CORNER_L, ARM, PIN);
+      const shaftTop = 2.4 - MEMBRANE - DETACHABLE_PIN_LEAD_IN_MM;
+      // Just inside the pin's own surface: solid for the shaft's whole length
+      // on a cylinder, interrupted at every valley on a ridged one.
+      const inside = PIN / 2 - 0.02;
+      expect(isSolidThrough(m, pin.x + inside, pin.y, 0.02, shaftTop - 0.02)).toBe(true);
+      // Just outside it, so the probe above cannot be passing on a fat pin.
+      expect(isSolidThrough(m, pin.x + PIN / 2 + 0.02, pin.y, 0.02, shaftTop - 0.02)).toBe(false);
     } finally {
       feet.forEach((f) => f.delete());
       pinHoles?.delete();

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -52,17 +52,15 @@ const CLIP_MARGIN = 2;
 /**
  * How far the mating face is set back from the foot's widest point, in mm.
  *
- * A foot prints bottom-down, so the last thing off the nozzle is a rim that has
- * just finished a 2.15mm run of 45-degree overhang. Those top layers cool
- * unsupported on their outboard side and curl up — and that rim is the surface
- * the bin sits on, so a foot with a lifted edge rocks instead of seating flat.
+ * A foot prints bottom-down, which leaves the face the bin sits on as the last
+ * thing off the nozzle, straight after a 2.15mm run of 45-degree overhang. That
+ * rim curls, and a curled rim makes the foot rock.
  *
- * The relief does not stop the curl. It moves the mating plane inboard of the
+ * The relief does not stop the curl — it puts the mating plane inboard of the
  * edge that curls, so whatever that edge does happens below the surface that
- * has to be flat. Taken out of the profile's top vertical step, which ends
- * 0.25mm down, so the widest section and every baseplate-facing face are
- * untouched. Sized to clear the two or three layers that lift; larger would
- * eat the contact patch for no more benefit.
+ * has to be flat. It comes out of the profile's top vertical step, which ends
+ * 0.25mm down, leaving the widest section and every baseplate-facing face
+ * untouched.
  */
 export const MATING_RIM_RELIEF_MM = 0.5;
 
@@ -145,15 +143,11 @@ function coveredCorners(
 /**
  * A pin: a plain cylinder at the stated diameter, under a tapered tip.
  *
- * Deliberately featureless. Compliance ridges are the obvious way to tighten a
- * press fit, and at this scale they do not survive slicing: a 0.2mm crest and
- * its valley fall inside one 0.6mm extrusion, so the slicer resolves the shaft
- * as a single thin loop somewhere between the two and the pin prints at 2.0mm
- * against a 2.8mm model. A fit sized off a diameter the printer never produces
- * is a loose one; a cylinder is a diameter it can hold to.
- *
- * {@link DETACHABLE_PIN_DIAMETERS_MM} names the pin's widest point, and with a
- * cylinder that is its only point.
+ * Featureless on purpose. Compliance ridges are the obvious way to tighten a
+ * press fit and do not survive slicing at this scale — a crest and its valley
+ * fall inside one extrusion, so the slicer holds the shaft to neither and the
+ * printed pin lands short of its stated diameter. A cylinder is a diameter the
+ * printer can hold to.
  */
 function buildPin(scope: DisposalScope, diameterMm: number, heightMm: number): Shape3D {
   const r = diameterMm / 2;

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -34,20 +34,37 @@ import {
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Sketch, DisposalScope } from 'brepjs';
 import { CLEARANCE, SOCKET_HEIGHT, COPLANAR_MARGIN, COPLANAR_OVERLAP } from './generatorConstants';
-import { buildSingleCellSocket, buildSimplifiedCellSocket } from './socketBuilder';
+import {
+  buildSingleCellSocket,
+  buildSimplifiedCellSocket,
+  buildSocketRimReliefTool,
+} from './socketBuilder';
 import {
   footCellCentre,
   footPinPositions,
   type FootPlacement,
 } from '@/shared/utils/detachableFeetPlan';
-import {
-  DETACHABLE_PIN_LEAD_IN_MM,
-  DETACHABLE_PIN_RIDGE_STEP_MM,
-  detachablePinEngagementMm,
-} from '@/shared/types/bin';
+import { DETACHABLE_PIN_LEAD_IN_MM, detachablePinEngagementMm } from '@/shared/types/bin';
 
 /** How far a clip box overshoots the cell it trims, so no face is coplanar. */
 const CLIP_MARGIN = 2;
+
+/**
+ * How far the mating face is set back from the foot's widest point, in mm.
+ *
+ * A foot prints bottom-down, so the last thing off the nozzle is a rim that has
+ * just finished a 2.15mm run of 45-degree overhang. Those top layers cool
+ * unsupported on their outboard side and curl up — and that rim is the surface
+ * the bin sits on, so a foot with a lifted edge rocks instead of seating flat.
+ *
+ * The relief does not stop the curl. It moves the mating plane inboard of the
+ * edge that curls, so whatever that edge does happens below the surface that
+ * has to be flat. Taken out of the profile's top vertical step, which ends
+ * 0.25mm down, so the widest section and every baseplate-facing face are
+ * untouched. Sized to clear the two or three layers that lift; larger would
+ * eat the contact patch for no more benefit.
+ */
+export const MATING_RIM_RELIEF_MM = 0.5;
 
 export interface DetachableFeetOptions {
   readonly placements: readonly FootPlacement[];
@@ -126,26 +143,29 @@ function coveredCorners(
 }
 
 /**
- * A pin, as a stack of alternating radii under a tapered tip.
+ * A pin: a plain cylinder at the stated diameter, under a tapered tip.
  *
- * Steps IN from `diameterMm` rather than out past it, so the pin is never wider
- * than the diameter the caller asked for. Sections land every half-ridge, which
- * puts a crest mid-layer rather than on the boundary between two.
+ * Deliberately featureless. Compliance ridges are the obvious way to tighten a
+ * press fit, and at this scale they do not survive slicing: a 0.2mm crest and
+ * its valley fall inside one 0.6mm extrusion, so the slicer resolves the shaft
+ * as a single thin loop somewhere between the two and the pin prints at 2.0mm
+ * against a 2.8mm model. A fit sized off a diameter the printer never produces
+ * is a loose one; a cylinder is a diameter it can hold to.
+ *
+ * {@link DETACHABLE_PIN_DIAMETERS_MM} names the pin's widest point, and with a
+ * cylinder that is its only point.
  */
 function buildPin(scope: DisposalScope, diameterMm: number, heightMm: number): Shape3D {
   const r = diameterMm / 2;
-  const step = DETACHABLE_PIN_RIDGE_STEP_MM / 2;
+  const lead = Math.min(DETACHABLE_PIN_LEAD_IN_MM, heightMm / 3);
 
-  // Too short to carry a ridge: a plain cylinder rather than a degenerate loft.
-  if (heightMm < 2 * step) {
+  // Too short for a lead-in worth lofting: a bare cylinder.
+  if (lead < 0.05) {
     return scope.register(
       translate(scope.register(cylinder(r, heightMm + COPLANAR_OVERLAP)), [0, 0, -COPLANAR_OVERLAP])
     );
   }
 
-  const valley = r - DETACHABLE_PIN_RIDGE_STEP_MM;
-  const lead = Math.min(DETACHABLE_PIN_LEAD_IN_MM, heightMm / 3);
-  const ridgeTopZ = heightMm - lead;
   const section = (radius: number, z: number): Sketch =>
     drawCircle(radius).sketchOnPlane('XY', z) as Sketch;
 
@@ -153,21 +173,12 @@ function buildPin(scope: DisposalScope, diameterMm: number, heightMm: number): S
   // volumetric overlap rather than two coincident planes. Without it OCCT
   // leaves non-manifold junctions all round every pin — the solid stays closed,
   // so only an edge-manifold check sees it, and a slicer would quietly repair
-  // it into something else. Root at the valley radius: the first layer off the
-  // foot's top face squishes out, so it is the last place for the tight fit.
+  // it into something else.
   const sections: Array<[number, number]> = [
-    [-COPLANAR_OVERLAP, valley],
-    [0, valley],
+    [-COPLANAR_OVERLAP, r],
+    [heightMm - lead, r],
+    [heightMm, r - lead],
   ];
-  let ridge = 0;
-  // Half a step short, so the closing section cannot land on the last ridge and
-  // loft between two coincident circles.
-  for (let z = step; z < ridgeTopZ - step / 2; z += step) {
-    sections.push([z, ridge % 2 === 0 ? r : valley]);
-    ridge++;
-  }
-  sections.push([ridgeTopZ, valley]);
-  sections.push([heightMm, valley - lead]);
 
   const start = section(sections[0][1], sections[0][0]);
   try {
@@ -260,11 +271,13 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
       const cellW = p.cellW - CLEARANCE;
       const cellD = p.cellD - CLEARANCE;
 
-      const full = scope.register(
+      const profile = scope.register(
         opts.forExport
           ? buildSingleCellSocket(cellW, cellD)
           : buildSimplifiedCellSocket(cellW, cellD)
       );
+      const rimTool = scope.register(buildSocketRimReliefTool(cellW, cellD, MATING_RIM_RELIEF_MM));
+      const full = scope.register(unwrap(intersect(profile, rimTool)));
       // The clip is expressed about the cell centre, so trim before moving the
       // foot into place rather than translating the clip to meet it.
       const clip = buildClip(scope, p, armMm);

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -45,6 +45,7 @@ import {
   setCellSocketTemplateCache,
 } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
+import { COPLANAR_MARGIN } from './generatorConstants';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
 import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import type { MagnetAnchor } from '@/core/types';
@@ -333,6 +334,47 @@ export function buildSocketTopPrism(cellW_mm: number, cellD_mm: number, heightMm
       0
     ) as Sketch
   ).extrude(heightMm);
+}
+
+/**
+ * Tool that relieves a cell socket's top outer rim.
+ *
+ * Intersect a foot with this and its mating face is set back by `insetMm`, on
+ * the cell boundary only — the tool spans the whole cell, so the faces where a
+ * foot was clipped out of one are not touched.
+ *
+ * The relief lands on the profile's own widest breakpoint, `-CLEARANCE / 2`, so
+ * it consumes the socket's top vertical step and nothing below it: the widest
+ * section, and every face a baseplate meets, comes out bit-identical to an
+ * integral foot's.
+ *
+ * The tool continues above Z=0 at the inset section rather than stopping on the
+ * foot's top plane, so the intersection never has two coincident faces to
+ * resolve.
+ */
+export function buildSocketRimReliefTool(
+  cellW_mm: number,
+  cellD_mm: number,
+  insetMm: number
+): Shape3D {
+  const maxRadius = Math.min(cellW_mm, cellD_mm) / 2 - 0.1;
+  const cornerR = Math.min(CORNER_RADIUS, maxRadius);
+  const sectionAt = (z: number, inset: number): Sketch =>
+    drawRoundedRectangle(
+      cellW_mm - 2 * inset,
+      cellD_mm - 2 * inset,
+      Math.max(cornerR - inset, 0.1)
+    ).sketchOnPlane('XY', z) as Sketch;
+
+  const below = sectionAt(-SOCKET_HEIGHT - COPLANAR_MARGIN, 0);
+  try {
+    return below.loftWith(
+      [sectionAt(-(CLEARANCE / 2), 0), sectionAt(0, insetMm), sectionAt(COPLANAR_MARGIN, insetMm)],
+      { ruled: true }
+    );
+  } finally {
+    below.delete();
+  }
 }
 
 export function buildSingleCellSocket(cellW_mm: number, cellD_mm: number): Shape3D {

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -27,6 +27,8 @@ import {
   SIZE,
   CLEARANCE,
   CORNER_RADIUS,
+  COPLANAR_MARGIN,
+  pocketCornerRadius,
   SOCKET_HEIGHT,
   SOCKET_BIG_TAPER,
   SOCKET_VERTICAL_PART,
@@ -45,7 +47,6 @@ import {
   setCellSocketTemplateCache,
 } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
-import { COPLANAR_MARGIN } from './generatorConstants';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
 import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import type { MagnetAnchor } from '@/core/types';
@@ -354,8 +355,7 @@ export function buildSocketRimReliefTool(
   cellD_mm: number,
   insetMm: number
 ): Shape3D {
-  const maxRadius = Math.min(cellW_mm, cellD_mm) / 2 - 0.1;
-  const cornerR = Math.min(CORNER_RADIUS, maxRadius);
+  const cornerR = pocketCornerRadius(cellW_mm, cellD_mm);
   const sectionAt = (z: number, inset: number): Sketch =>
     drawRoundedRectangle(
       cellW_mm - 2 * inset,

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -344,13 +344,10 @@ export function buildSocketTopPrism(cellW_mm: number, cellD_mm: number, heightMm
  * foot was clipped out of one are not touched.
  *
  * The relief lands on the profile's own widest breakpoint, `-CLEARANCE / 2`, so
- * it consumes the socket's top vertical step and nothing below it: the widest
- * section, and every face a baseplate meets, comes out bit-identical to an
- * integral foot's.
+ * the widest section and every face a baseplate meets survive it untouched.
  *
- * The tool continues above Z=0 at the inset section rather than stopping on the
- * foot's top plane, so the intersection never has two coincident faces to
- * resolve.
+ * The tool continues above Z=0 rather than stopping on the foot's top plane, so
+ * the intersection never has two coincident faces to resolve.
  */
 export function buildSocketRimReliefTool(
   cellW_mm: number,

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -297,7 +297,6 @@ export {
   detachableFeetFitFloor,
   binFloorMm,
   DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
-  DETACHABLE_PIN_RIDGE_STEP_MM,
   DETACHABLE_PIN_LEAD_IN_MM,
 } from '@/features/bin-designer/types';
 


### PR DESCRIPTION
Addresses points 1 and 3 of #4107.

## The pin

It was a stack of alternating radii — 0.2mm crests and valleys, meant to bite the hole. @tg73's sliced-gcode reading is the answer to whether that survives the printer: at a 0.6mm nozzle a crest and its valley fall inside a single extrusion, so the slicer resolves the whole shaft as one thin loop somewhere between the two. A 2.8mm pin came off the bed at 2.0mm, which is a slip fit in a 3mm hole however tight the model looks.

It is a plain cylinder now, under the same tapered tip. `DETACHABLE_PIN_DIAMETERS_MM` already documented itself as the pin's widest point; with a cylinder that is its only point, so the printed diameter is the one the hole was sized for.

Expect the fit to change: it should go from sloppy to snug at the same setting, and 2.7mm is there if 2.8 is now too tight.

## The mating face

A foot prints bottom-down, so the face the bin sits on is the last thing off the nozzle, immediately after a 2.15mm run of 45-degree overhang. That is the edge in the photo, and a rim that lifts even a couple of layers makes the foot rock instead of seating.

The relief does not try to stop the curl — it moves the mating plane 0.5mm inboard of the edge that curls, so whatever that edge does happens below the surface that has to be flat. It is taken out of the socket profile's top vertical step, which ends 0.25mm down, which is the part worth calling out:

| plane | foot | integral foot |
| --- | --- | --- |
| mating face (Z=0) | 20.250 | 20.750 |
| widest section (Z=-0.25) | 20.750 | 20.750 |
| Z=-2.4, -4.2, -5 | unchanged | |

So the widest section and every face a baseplate meets are bit-identical to an integral foot's. The existing profile-parity check still runs at the widest plane, and the three baseplate seating checks (on-grid, half-offset perched, half-offset seated) are untouched.

0.5mm is the number to tune if it reads too shallow or too deep on hardware.

## Tests

Two new checks in `detachableFeet.kernel.test.ts`, both failing before this:

- A column probe just inside the pin's surface is solid for the shaft's whole length, with a probe just outside it as the negative control. A ridged pin passes every other check in that file — closed, right height, never wider than stated — while interrupting this one at every valley.
- The mating face is inset by the relief while the widest section is not.

## Not in this PR

Point 2, the mortise-and-tenon option. The report reads it as downstream of point 1 ("This may be improved by addressing point (1) above"), and a second joint style is a new setting with its own parameter, UI and migration rather than a fix — worth its own issue if the cylinder still breaks.

@tg73 if you print a set, the two things worth measuring are the pin's OD (it should now read close to the 2.8mm the model says) and whether the foot sits flat on the bin without rocking.

https://claude.ai/code/session_0129Vusm2xfPbqEgLrFskyWi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

