### PR TITLE
fix(labels): draw the lock washer as a split ring

### DIFF
--- a/src/features/generation/worker/generators/labelPlateIcons.test.ts
+++ b/src/features/generation/worker/generators/labelPlateIcons.test.ts
@@ -140,6 +140,18 @@ describe('SVG conversion fidelity', () => {
     expect(solidVolume('washer')).toBeLessThan(uncutDisc * 0.95);
   });
 
+  // A split washer differs from a plain one by its gap alone, so an outline
+  // that closed the gap — or opened it into a C — would still be a ring of the
+  // right size on the plate. Enclosed area is the only measure that sees it.
+  it('leaves the lock washer a ring with a gap in it', () => {
+    const scale = TEXT_BAND_MM / 10;
+    const gapFraction = 20 / 360;
+    const annulus = Math.PI * (5 ** 2 - 2.6 ** 2) * scale ** 2;
+    // Loose to the path's own 3dp endpoints, tight against what it guards: a
+    // closed gap is 5.6% high, and the C the outline used to draw is 40% low.
+    expect(solidVolume('lockWasher')).toBeCloseTo(annulus * (1 - gapFraction) * SOLID_HEIGHT_MM, 2);
+  });
+
   // The horseshoe's outer boundary meets its legs tangentially, which collapses
   // a true-arc wire to roughly half its area while leaving the bounding box
   // correct. Hence the polyline arch — and hence this guard. A 1% band is far

--- a/src/features/generation/worker/generators/labelPlateIcons.test.ts
+++ b/src/features/generation/worker/generators/labelPlateIcons.test.ts
@@ -147,8 +147,8 @@ describe('SVG conversion fidelity', () => {
     const scale = TEXT_BAND_MM / 10;
     const gapFraction = 20 / 360;
     const annulus = Math.PI * (5 ** 2 - 2.6 ** 2) * scale ** 2;
-    // Loose to the path's own 3dp endpoints, tight against what it guards: a
-    // closed gap is 5.6% high, and the C the outline used to draw is 40% low.
+    // Loose to the path's own 3dp endpoints, tight enough to reject both a ring
+    // with no gap and one opened out into a C.
     expect(solidVolume('lockWasher')).toBeCloseTo(annulus * (1 - gapFraction) * SOLID_HEIGHT_MM, 2);
   });
 

--- a/src/shared/constants/labelIconPaths.ts
+++ b/src/shared/constants/labelIconPaths.ts
@@ -189,8 +189,10 @@ export const LABEL_ICON_PATHS: Readonly<Record<LabelPlateIconId, LabelIconDef>> 
   },
   lockWasher: {
     domain: 'fastener',
-    // Split ring, one end stepped past the other — the spring offset.
-    outline: 'M 0.9 -4.9 A 5 5 0 1 1 0.9 4.9 L 0.9 2.55 A 2.6 2.6 0 1 0 0.9 -2.55 Z',
+    // Split ring: a 20-degree gap on the right is the whole of what separates
+    // it from `washer` at this size, so the ends are radial and nothing else
+    // competes with them.
+    outline: 'M 4.924 0.868 A 5 5 0 1 1 4.924 -0.868 L 2.561 -0.451 A 2.6 2.6 0 1 0 2.561 0.451 Z',
   },
   wingNut: {
     domain: 'fastener',

--- a/src/shared/constants/labelIconPaths.ts
+++ b/src/shared/constants/labelIconPaths.ts
@@ -189,9 +189,8 @@ export const LABEL_ICON_PATHS: Readonly<Record<LabelPlateIconId, LabelIconDef>> 
   },
   lockWasher: {
     domain: 'fastener',
-    // Split ring: a 20-degree gap on the right is the whole of what separates
-    // it from `washer` at this size, so the ends are radial and nothing else
-    // competes with them.
+    // The gap is the whole of what separates this from `washer` at plate size,
+    // so nothing else competes with it: plain radial ends, no spring offset.
     outline: 'M 4.924 0.868 A 5 5 0 1 1 4.924 -0.868 L 2.561 -0.451 A 2.6 2.6 0 1 0 2.561 0.451 Z',
   },
   wingNut: {


### PR DESCRIPTION
The follow-up flagged in #4110.

With the importer honouring both arc flags, `lockWasher` now prints exactly what its picker preview draws — and that preview was never a lock washer.

Its two ends sat 9.8mm apart on a radius-5 circle, so the outer boundary could only ever be a 203-degree arc with a 157-degree mouth. A fat C, in the picker as much as on the plate, under a name that reads "Lock washer" in English and spring washer, Federring, rondella elastica in the other fourteen locales.

## Before / after

| | before | after |
| --- | --- | --- |
| outer boundary | 203-degree arc | 340-degree ring |
| gap | 157 degrees | 20 degrees |
| bounding box | 5.99 x 10.00 | 9.92 x 10.00 |
| enclosed area | 35.91 | 54.12 |

The gap is radial and 20 degrees, which is ~1.5mm at the mean radius once the icon is fitted to the 7.8mm band — well clear of the ~0.8mm a plate resolves, and the only thing distinguishing it from `washer`, which is why nothing else competes with it.

## Test

Enclosed area is the only measure that sees this: a ring with no gap, a ring with the wrong gap and a C all have the same bounding box and all build on a plate. The new check states the 340-degree annulus in closed form, and is tight against both failures either side of it — a closed gap reads 5.6% high, the outline being replaced reads 40% low.

https://claude.ai/code/session_0129Vusm2xfPbqEgLrFskyWi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

