### PR TITLE
fix(designer): reject a fractional compartment grid instead of crashing

### DIFF
--- a/api/lib/designerCompartmentValidation.test.ts
+++ b/api/lib/designerCompartmentValidation.test.ts
@@ -250,7 +250,7 @@ describe('validateCompartments', () => {
 
   it('rejects cols = 0', () => {
     expect(validateCompartments({ cols: 0, rows: 1, thickness: 1.2, cells: [] })).toBe(
-      `compartments.cols must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+      `compartments.cols must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
     );
   });
 
@@ -263,13 +263,13 @@ describe('validateCompartments', () => {
         cells: [],
       })
     ).toBe(
-      `compartments.cols must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+      `compartments.cols must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
     );
   });
 
   it('rejects rows = 0', () => {
     expect(validateCompartments({ cols: 1, rows: 0, thickness: 1.2, cells: [] })).toBe(
-      `compartments.rows must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+      `compartments.rows must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
     );
   });
 
@@ -282,7 +282,23 @@ describe('validateCompartments', () => {
         cells: [],
       })
     ).toBe(
-      `compartments.rows must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+      `compartments.rows must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects a fractional cols', () => {
+    expect(
+      validateCompartments({ cols: 2.5, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3, 4] })
+    ).toBe(
+      `compartments.cols must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects a fractional rows', () => {
+    expect(
+      validateCompartments({ cols: 2, rows: 2.5, thickness: 1.2, cells: [0, 1, 2, 3, 4] })
+    ).toBe(
+      `compartments.rows must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
     );
   });
 

--- a/api/lib/designerCompartmentValidation.ts
+++ b/api/lib/designerCompartmentValidation.ts
@@ -124,15 +124,25 @@ export function validateCompartments(compartments: unknown): string | null {
   if (!isObject(compartments)) return 'compartments must be an object';
   if (
     !isNumber(compartments.cols) ||
-    !inRange(compartments.cols, CONSTRAINTS.MIN_COMPARTMENT_GRID, CONSTRAINTS.MAX_COMPARTMENT_GRID)
+    !inRange(
+      compartments.cols,
+      CONSTRAINTS.MIN_COMPARTMENT_GRID,
+      CONSTRAINTS.MAX_COMPARTMENT_GRID
+    ) ||
+    !Number.isInteger(compartments.cols)
   ) {
-    return `compartments.cols must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`;
+    return `compartments.cols must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`;
   }
   if (
     !isNumber(compartments.rows) ||
-    !inRange(compartments.rows, CONSTRAINTS.MIN_COMPARTMENT_GRID, CONSTRAINTS.MAX_COMPARTMENT_GRID)
+    !inRange(
+      compartments.rows,
+      CONSTRAINTS.MIN_COMPARTMENT_GRID,
+      CONSTRAINTS.MAX_COMPARTMENT_GRID
+    ) ||
+    !Number.isInteger(compartments.rows)
   ) {
-    return `compartments.rows must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`;
+    return `compartments.rows must be integer ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`;
   }
   if (
     !isNumber(compartments.thickness) ||

--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.test.tsx
@@ -166,6 +166,18 @@ describe('BentoWorkspace', () => {
     expect(useDesignerStore.getState().ui.bentoWorkspaceOpen).toBe(true);
   });
 
+  it('rounds a decimal typed into a grid stepper rather than sizing a cell array by it', () => {
+    render(<BentoWorkspace />);
+
+    const cols = screen.getByRole('spinbutton', { name: /columns/i });
+    fireEvent.change(cols, { target: { value: '2.5' } });
+    fireEvent.blur(cols);
+
+    const { compartments } = useDesignerStore.getState().params;
+    expect(compartments.cols).toBe(3);
+    expect(compartments.cells).toHaveLength(3 * compartments.rows);
+  });
+
   it('grid steppers preserve drawn compartments and stash the displaced', () => {
     const id = drawViaStore();
     useDesignerStore.getState().drawBentoCompartment({ col: 3, row: 0, w: 1, h: 2 });

--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.tsx
@@ -260,7 +260,11 @@ export function BentoWorkspace() {
 
   const handleGridChange = useCallback(
     (nextCols: number, nextRows: number) => {
-      const result = setBentoGridPreserving(nextCols, nextRows);
+      // The Stepper commits whatever parses, decimals included (it deliberately
+      // doesn't snap to `step`, so mm fields keep off-grid entries). Cell counts
+      // are whole numbers, so round here rather than let the validator reject a
+      // typed "2.5" and leave the field showing a value the grid never took.
+      const result = setBentoGridPreserving(Math.round(nextCols), Math.round(nextRows));
       if (result === null) {
         addToast({
           message: t('binDesigner.bento.toastGridTooSmall'),

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.test.tsx
@@ -135,6 +135,16 @@ describe('CompartmentEditor', () => {
     expect(setCompartmentGrid).toHaveBeenCalledWith(3, DEFAULT_BIN_PARAMS.compartments.rows);
   });
 
+  it('rounds a typed decimal to a whole column count', () => {
+    const setCompartmentGrid = vi.fn();
+    useDesignerStore.setState({ params: DEFAULT_BIN_PARAMS, setCompartmentGrid });
+    render(<CompartmentEditor />);
+    const cols = screen.getByRole('spinbutton', { name: /columns/i });
+    fireEvent.change(cols, { target: { value: '2.5' } });
+    fireEvent.blur(cols);
+    expect(setCompartmentGrid).toHaveBeenCalledWith(3, DEFAULT_BIN_PARAMS.compartments.rows);
+  });
+
   it('shows 2D grid editor when grid is larger than 1x1', () => {
     useDesignerStore.setState({ params: TWO_BY_TWO });
     render(<CompartmentEditor />);

--- a/src/features/bin-designer/components/CompartmentEditor/useCompartmentGrid.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useCompartmentGrid.ts
@@ -322,7 +322,10 @@ export function useCompartmentGrid() {
   // warning is shown consistently and the selection is reset once.
   const applyGrid = useCallback(
     (newCols: number, newRows: number) => {
-      const droppedLabels = setCompartmentGrid(newCols, newRows);
+      // Rounded for the same reason as the bento header: the Stepper commits
+      // decimals, and a fractional cols/rows builds a cells array shorter than
+      // cols * rows.
+      const droppedLabels = setCompartmentGrid(Math.round(newCols), Math.round(newRows));
       if (droppedLabels > 0) {
         addToast({
           message: t('binDesigner.compartmentEditor.labelsCleared', { count: droppedLabels }),

--- a/src/features/bin-designer/store/designer.scenario.bento.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.bento.test.ts
@@ -166,6 +166,12 @@ describe('DesignerStore - bento draw actions', () => {
       expect(useDesignerStore.getState().history.past).toHaveLength(historyLen);
     });
 
+    it('rejects a fractional dimension rather than sizing a cell array by it', () => {
+      expect(useDesignerStore.getState().setBentoGridPreserving(2.5, 3)).toBeNull();
+      expect(params().compartments.cols).toBe(4);
+      expect(params().compartments.cells).toHaveLength(12);
+    });
+
     it('rejects dimensions that fail the min-compartment-size pre-flight', () => {
       useDesignerStore.getState().setParam('width', 1);
       useDesignerStore.getState().setParam('depth', 1);

--- a/src/features/bin-designer/store/designer.scenario.compartments.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.compartments.test.ts
@@ -34,6 +34,15 @@ describe('DesignerStore - compartment actions', () => {
       expect(params.compartments.cells).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
     });
 
+    it('rejects a fractional grid, which would leave cells shorter than cols x rows', () => {
+      const before = useDesignerStore.getState().params.compartments;
+      useDesignerStore.getState().setCompartmentGrid(2.5, 3);
+
+      const { compartments } = useDesignerStore.getState().params;
+      expect(compartments.cols).toBe(before.cols);
+      expect(compartments.cells).toHaveLength(before.cols * before.rows);
+    });
+
     it('pushes current params to history', () => {
       const { setCompartmentGrid, history } = useDesignerStore.getState();
       expect(history.past).toHaveLength(0);

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -682,6 +682,26 @@ describe('validateCompartmentSizes', () => {
     expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
     expect(error.field).toBe('compartments.rows');
   });
+
+  it('rejects a fractional cols', () => {
+    const result = validateCompartmentSizes(2, 2, 1.2, 2.5, 3, 1.2);
+    const error = expectErr(result);
+    expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
+    expect(error.field).toBe('compartments.cols');
+  });
+
+  it('rejects a fractional rows', () => {
+    const result = validateCompartmentSizes(2, 2, 1.2, 3, 2.5, 1.2);
+    const error = expectErr(result);
+    expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
+    expect(error.field).toBe('compartments.rows');
+  });
+
+  it('rejects NaN, which the range check alone lets through', () => {
+    const error = expectErr(validateCompartmentSizes(2, 2, 1.2, Number.NaN, 3, 1.2));
+    expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
+    expect(error.field).toBe('compartments.cols');
+  });
 });
 
 describe('maxCompartmentsForInner', () => {

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -683,18 +683,20 @@ describe('validateCompartmentSizes', () => {
     expect(error.field).toBe('compartments.rows');
   });
 
-  it('rejects a fractional cols', () => {
+  it('rejects a fractional cols, naming only that axis', () => {
     const result = validateCompartmentSizes(2, 2, 1.2, 2.5, 3, 1.2);
     const error = expectErr(result);
     expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
     expect(error.field).toBe('compartments.cols');
+    expect(error.message).toBe('Compartment grid columns must be a whole number.');
   });
 
-  it('rejects a fractional rows', () => {
+  it('rejects a fractional rows, naming only that axis', () => {
     const result = validateCompartmentSizes(2, 2, 1.2, 3, 2.5, 1.2);
     const error = expectErr(result);
     expect(error.code).toBe('COMPARTMENT_GRID_INVALID');
     expect(error.field).toBe('compartments.rows');
+    expect(error.message).toBe('Compartment grid rows must be a whole number.');
   });
 
   it('rejects NaN, which the range check alone lets through', () => {

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -362,6 +362,16 @@ export function validateCompartmentSizes(
   // Y-axis pitch for non-square grids; defaults to the X pitch (square).
   gridUnitMmY: number = gridUnitMm
 ): Result<undefined, DesignerValidationError> {
+  // Ahead of the range check because NaN fails every comparison: `NaN < 1` is
+  // false, so a NaN would otherwise reach the grid builders, where a
+  // fractional or NaN `cols * rows` throws RangeError from `new Array()`.
+  if (!Number.isInteger(cols) || !Number.isInteger(rows)) {
+    return err({
+      code: 'COMPARTMENT_GRID_INVALID',
+      message: 'Compartment grid columns and rows must be whole numbers.',
+      field: Number.isInteger(cols) ? 'compartments.rows' : 'compartments.cols',
+    });
+  }
   if (cols < 1 || rows < 1) {
     return err({
       code: 'COMPARTMENT_GRID_INVALID',

--- a/src/features/bin-designer/utils/validation.ts
+++ b/src/features/bin-designer/utils/validation.ts
@@ -366,10 +366,11 @@ export function validateCompartmentSizes(
   // false, so a NaN would otherwise reach the grid builders, where a
   // fractional or NaN `cols * rows` throws RangeError from `new Array()`.
   if (!Number.isInteger(cols) || !Number.isInteger(rows)) {
+    const axis = Number.isInteger(cols) ? 'rows' : 'columns';
     return err({
       code: 'COMPARTMENT_GRID_INVALID',
-      message: 'Compartment grid columns and rows must be whole numbers.',
-      field: Number.isInteger(cols) ? 'compartments.rows' : 'compartments.cols',
+      message: `Compartment grid ${axis} must be a whole number.`,
+      field: axis === 'columns' ? 'compartments.cols' : 'compartments.rows',
     });
   }
   if (cols < 1 || rows < 1) {


### PR DESCRIPTION
Fixes #4115.

## The crash

`RangeError: Array size is not a small enough positive integer.` on `/designer`, Safari. PostHog captured no frames, but the chunk name it did capture (`designer-CRHrFIRw.js`) is content-hashed, so a local build reproduced the same file byte for byte. Two `Array(...)` call sites in it, both mapping to `bentoDraw.ts`; the error text is JavaScriptCore's wording for a non-integer array length (V8 says "Invalid array length").

The bento header's Columns / Rows fields are `Stepper`s. `Stepper` commits whatever `parseFloat` accepts and deliberately does not snap to `step`, so mm fields elsewhere can keep off-grid entries like a 0.25mm tolerance. Typing `2.5` into a *cell count* therefore reaches:

```ts
const newCells = new Array<number>(newCols * newRows).fill(-1); // bentoDraw.ts:642
```

which throws for any fractional product. `validateCompartmentSizes` ran first and passed it: `2.5 >= 1`, and the min-cell-size maths is finite for a fractional column count.

## Same root cause, quieter symptom

The sidebar's Grid Dividers steppers funnel into `setCompartmentGrid`, which builds cells with `Array.from({ length: rows * cols })`. That truncates rather than throwing, so `2.5 x 3` stored a 7-element `cells` array against a `2.5 x 3` grid: a config no geometry code expects.

## Changes

- `validateCompartmentSizes` rejects a non-integer `cols`/`rows`. It sits ahead of the existing range check because NaN fails every comparison, so `cols < 1` never caught a NaN either. Both store actions already bail on this validator, so both surfaces are covered, as is any future caller.
- `BentoWorkspace.handleGridChange` and `useCompartmentGrid.applyGrid` round what the Stepper hands them. Without this, typing `2.5` would silently do nothing and leave the field showing a value the grid never took; rounding snaps it to 3.
- `api/lib/designerCompartmentValidation.ts` gains the `Number.isInteger` check its sibling `cellMask` validator already had. Only the cells-length check stood between the server and a fractional grid, and a `2.5 x 2` grid with 5 cells satisfies that.

## Verification

A store-level test reproduced the exact `RangeError` at `bentoDraw.ts:642` before the fix. Tests added at each layer: validator (fractional cols, fractional rows, NaN), both store actions, the sidebar stepper rounding a typed `2.5` to 3, and the server validator.

`src/features/bin-designer` + `api/lib`: 7467 passing. Typecheck clean.

https://claude.ai/code/session_0129Vusm2xfPbqEgLrFskyWi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

