### PR TITLE
fix(designer): keep the cut editor reachable under an underside lightweight floor

### DIFF
--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
@@ -212,6 +212,16 @@ describe('InteriorModeCard', () => {
       render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
 
       expect(screen.getByText('binDesigner.spacerDisablesInterior')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('binDesigner.editCutouts'));
+      expect(mocks.setCutoutEditorOpen).not.toHaveBeenCalled();
+    });
+
+    it('blocks the editor on a base-only bin', () => {
+      setParams({ tile: true });
+      render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
+
+      expect(screen.getByText('binDesigner.tileDisablesInterior')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('binDesigner.editCutouts'));
       expect(mocks.setCutoutEditorOpen).not.toHaveBeenCalled();
     });
   });

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { InteriorModeCard } from './InteriorModeCard';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { BinParams } from '@/shared/types/bin';
 
 vi.mock('./icons', () => ({
   Grid3x3Icon: () => <div data-testid="grid-icon" />,
@@ -23,22 +25,35 @@ vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 const mocks = vi.hoisted(() => ({
   setBentoWorkspaceOpen: vi.fn(),
   setCutoutEditorOpen: vi.fn(),
+  params: {} as BinParams,
 }));
 
-// Mock store — runs the selector against a minimal fake so the workspace
-// launcher cards render (they read compartments and the open actions).
+// Real DEFAULT_BIN_PARAMS rather than a hand-built stub: the solid card asks the
+// constraint engine about `cutouts`, and the engine reads across the whole
+// params tree, so a partial fake answers a different question than the app does.
 vi.mock('@/features/bin-designer/store', () => ({
   useDesignerStore: vi.fn((selector: (s: unknown) => unknown) =>
     selector({
-      params: {
-        compartments: { cols: 3, rows: 2, thickness: 1.2, cells: [0, 0, 1, 2, 3, 4] },
-        base: { lightweight: false },
-      },
+      params: mocks.params,
       setBentoWorkspaceOpen: mocks.setBentoWorkspaceOpen,
       setCutoutEditorOpen: mocks.setCutoutEditorOpen,
     })
   ),
 }));
+
+function setParams(base: Partial<BinParams['base']> = {}, rest: Partial<BinParams> = {}): void {
+  mocks.params = {
+    ...DEFAULT_BIN_PARAMS,
+    ...rest,
+    compartments: { cols: 3, rows: 2, thickness: 1.2, cells: [0, 0, 1, 2, 3, 4] },
+    base: { ...DEFAULT_BIN_PARAMS.base, ...base },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setParams();
+});
 
 describe('InteriorModeCard', () => {
   it('renders collapsed card with icon, title, and description', () => {
@@ -162,6 +177,42 @@ describe('InteriorModeCard', () => {
 
       rerender(<InteriorModeCard card="standard" isExpanded={false} onSelect={vi.fn()} />);
       expect(screen.queryByText('common.experimental')).not.toBeInTheDocument();
+    });
+  });
+  describe('solid card cutout editor', () => {
+    it('opens the editor on a plain bin', () => {
+      render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
+
+      fireEvent.click(screen.getByText('binDesigner.editCutouts'));
+      expect(mocks.setCutoutEditorOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('blocks the editor under an interior lightweight floor', () => {
+      setParams({ lightweight: true, lightweightMode: 'interior' });
+      render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
+
+      expect(screen.getByText('binDesigner.lightweightDisablesCutouts')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('binDesigner.editCutouts'));
+      expect(mocks.setCutoutEditorOpen).not.toHaveBeenCalled();
+    });
+
+    it('keeps the editor open-able under an underside lightweight relief', () => {
+      // The relief shells from below and leaves the interior floor a cutout
+      // cuts into, so it is not one of the things that rules cutouts out.
+      setParams({ lightweight: true, lightweightMode: 'underside' });
+      render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
+
+      expect(screen.queryByText('binDesigner.lightweightDisablesCutouts')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('binDesigner.editCutouts'));
+      expect(mocks.setCutoutEditorOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('blocks the editor on a spacer', () => {
+      setParams({ spacer: true });
+      render(<InteriorModeCard card="solid" isExpanded={true} onSelect={vi.fn()} />);
+
+      expect(screen.getByText('binDesigner.spacerDisablesInterior')).toBeInTheDocument();
+      expect(mocks.setCutoutEditorOpen).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
@@ -12,7 +12,9 @@ import { useTranslation } from '@/i18n';
 import { Badge } from '@/design-system';
 import { ModeCard } from '../shared';
 import { useResponsive } from '@/shared/hooks/useResponsive';
+import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { getFeatureStatus } from '@/shared/constraints';
 import { getDrawnCompartmentIds } from '@/features/bin-designer/utils/bentoDraw';
 import { CompartmentEditor } from '../../CompartmentEditor';
 import { SlotConfigurator } from '../../SlotConfigurator/SlotConfigurator';
@@ -115,22 +117,29 @@ function BentoModeContent() {
 }
 
 function SolidModeContent() {
-  const setCutoutEditorOpen = useDesignerStore((s) => s.setCutoutEditorOpen);
-  const lightweight = useDesignerStore((s) => s.params.base.lightweight);
+  const { setCutoutEditorOpen, params } = useDesignerStore(
+    useShallow((s) => ({
+      setCutoutEditorOpen: s.setCutoutEditorOpen,
+      params: s.params,
+    }))
+  );
   const t = useTranslation();
 
-  // Cutouts cut into the solid top, which is incompatible with a lightweight
-  // floor (mutually exclusive in the constraint engine) — disable the editor
-  // entry with a reason instead of opening it.
-  if (lightweight) {
+  // Asking the engine rather than reading `base.lightweight` directly: three
+  // separate rules rule cutouts out, and the lightweight one fires only in its
+  // interior mode, because the underside relief leaves the floor a cutout cuts.
+  const cutoutStatus = getFeatureStatus(params, 'cutouts');
+  if (!cutoutStatus.available) {
     return (
       <div className="w-full rounded-lg border border-stroke-subtle bg-surface/40 p-3 text-left opacity-70">
         <span className="text-xs font-semibold text-content-secondary">
           {t('binDesigner.editCutouts')}
         </span>
-        <p className="mt-0.5 text-micro leading-relaxed text-content-tertiary">
-          {t('binDesigner.lightweightDisablesCutouts')}
-        </p>
+        {cutoutStatus.reason ? (
+          <p className="mt-0.5 text-micro leading-relaxed text-content-tertiary">
+            {t(cutoutStatus.reason)}
+          </p>
+        ) : null}
       </div>
     );
   }

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
@@ -125,9 +125,10 @@ function SolidModeContent() {
   );
   const t = useTranslation();
 
-  // Asking the engine rather than reading `base.lightweight` directly: three
-  // separate rules rule cutouts out, and the lightweight one fires only in its
-  // interior mode, because the underside relief leaves the floor a cutout cuts.
+  // Asking the engine rather than reading `base.lightweight` directly. Three
+  // separate rules can withhold cutouts, and the lightweight one fires in its
+  // interior mode only, because the underside relief leaves the floor intact
+  // for a cutout to cut into.
   const cutoutStatus = getFeatureStatus(params, 'cutouts');
   if (!cutoutStatus.available) {
     return (


### PR DESCRIPTION
Closes #4124.

## What was wrong

The Interior panel's solid card decided whether to offer the cut editor by reading `params.base.lightweight` directly. That flag is true for both lightweight modes, but only the interior one opens the cavity floor into the cups. The underside relief shells from below and leaves the interior floor exactly as a standard bin has it, so a cutout still has floor to cut into.

The constraint engine already encodes that distinction (`rules.ts`: `p.base.lightweight && !isUndersideRelief(p.base)`). The panel just never asked it.

## What changed

`SolidModeContent` now reads `getFeatureStatus(params, 'cutouts')` and renders the reason the engine gives, rather than re-deriving a gate by hand.

That closes a second gap in the same place. Three rules disable `cutouts`, not one: the interior lightweight floor, a spacer, and a base-only bin. The old flag check only knew about the first, so a spacer or base-only bin offered a launch button into an editor whose cutouts would never be built.

## Verification

Both new tests fail on the parent commit and pass here. `pnpm run typecheck` clean; 2083 tests across `panel/` and `shared/constraints/` pass.

https://claude.ai/code/session_01Azrg5R8TiCRwwrc2jy4VPp

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

