### PR TITLE
fix(generation): give a lipped bin its full Gridfinity height

### DIFF
--- a/src/features/bin-designer/components/panel/AssembledHeightBreakdown/AssembledHeightBreakdown.test.tsx
+++ b/src/features/bin-designer/components/panel/AssembledHeightBreakdown/AssembledHeightBreakdown.test.tsx
@@ -53,8 +53,8 @@ describe('AssembledHeightBreakdown', () => {
 
   it('shows the assembled total collapsed by default', () => {
     render(<AssembledHeightBreakdown />);
-    // 6u × 7mm = 42mm body + 4.3mm lip; a plain plate adds nothing.
-    expect(screen.getByText('46.3mm')).toBeInTheDocument();
+    // 6u × 7mm = 42mm body + 4.4mm lip; a plain plate adds nothing.
+    expect(screen.getByText('46.4mm')).toBeInTheDocument();
     expect(screen.queryByText('Stacking lip')).not.toBeInTheDocument();
   });
 
@@ -81,14 +81,14 @@ describe('AssembledHeightBreakdown', () => {
     setPlate({ ...DEFAULT_BASEPLATE_PARAMS, magnetHoles: true, magnetDepth: mm(2) });
     render(<AssembledHeightBreakdown />);
     // MAGNET_FLOOR (0.5) + 2mm sits under the sockets, so the bin rises 2.5mm.
-    expect(screen.getByText('48.8mm')).toBeInTheDocument();
+    expect(screen.getByText('48.9mm')).toBeInTheDocument();
     expect(screen.getByText('7.5mm plate, bin sinks 5mm into it')).toBeInTheDocument();
   });
 
   it('falls back to a standard plate when the layout has none', () => {
     setPlate(undefined);
     render(<AssembledHeightBreakdown />);
-    expect(screen.getByText('46.3mm')).toBeInTheDocument();
+    expect(screen.getByText('46.4mm')).toBeInTheDocument();
   });
 
   it('adds the lid and its stack grid', () => {
@@ -112,17 +112,17 @@ describe('AssembledHeightBreakdown', () => {
     it('reports the spare room when it fits', () => {
       setDrawerHeight(60);
       render(<AssembledHeightBreakdown />);
-      expect(screen.getByText('Fits drawer, 13.7mm to spare')).toBeInTheDocument();
+      expect(screen.getByText('Fits drawer, 13.6mm to spare')).toBeInTheDocument();
     });
 
     it('reports the overflow when it does not', () => {
       setDrawerHeight(40);
       render(<AssembledHeightBreakdown />);
-      expect(screen.getByText('6.3mm taller than drawer')).toBeInTheDocument();
+      expect(screen.getByText('6.4mm taller than drawer')).toBeInTheDocument();
     });
 
     it('treats an exact fit as fitting', () => {
-      setDrawerHeight(46.3);
+      setDrawerHeight(46.4);
       render(<AssembledHeightBreakdown />);
       expect(screen.getByText('Fits drawer, 0mm to spare')).toBeInTheDocument();
     });

--- a/src/features/bin-designer/components/preview/BinDimensions/AssembledBinDimensions.test.tsx
+++ b/src/features/bin-designer/components/preview/BinDimensions/AssembledBinDimensions.test.tsx
@@ -31,7 +31,7 @@ function setPlate(plate: typeof DEFAULT_BASEPLATE_PARAMS | undefined): void {
 describe('AssembledBinDimensions', () => {
   beforeEach(() => {
     useDesignerStore.setState({
-      // 6u body (42mm) + 4.3mm lip.
+      // 6u body (42mm) + 4.4mm lip.
       params: {
         ...DEFAULT_BIN_PARAMS,
         height: 6,
@@ -47,13 +47,13 @@ describe('AssembledBinDimensions', () => {
 
   it('labels the height with the assembled total from the stores', () => {
     render(<AssembledBinDimensions width={2} depth={2} gridUnitMm={42} />);
-    expect(texts()).toContain('46.3mm');
+    expect(texts()).toContain('46.4mm');
   });
 
   it('follows the layout baseplate rather than assuming a plain one', () => {
     setPlate({ ...DEFAULT_BASEPLATE_PARAMS, magnetHoles: true, magnetDepth: mm(2) });
     render(<AssembledBinDimensions width={2} depth={2} gridUnitMm={42} />);
-    expect(texts()).toContain('48.8mm');
+    expect(texts()).toContain('48.9mm');
   });
 
   it('shows no band labels while collapsed', () => {
@@ -66,7 +66,7 @@ describe('AssembledBinDimensions', () => {
       settings: { ...s.settings, showAssembledHeightBreakdown: true },
     }));
     render(<AssembledBinDimensions width={2} depth={2} gridUnitMm={42} />);
-    expect(texts()).toEqual(expect.arrayContaining(['Bin 42mm', 'Stacking lip 4.3mm']));
+    expect(texts()).toEqual(expect.arrayContaining(['Bin 42mm', 'Stacking lip 4.4mm']));
   });
 
   it('passes the stack pitch label straight through', () => {

--- a/src/features/bin-designer/components/preview/LidMesh/lidAnchorZ.ts
+++ b/src/features/bin-designer/components/preview/LidMesh/lidAnchorZ.ts
@@ -51,7 +51,7 @@ export const PREVIEW_Z_OFFSET = 0.1;
  * height double-counts it. The two agree only for a socketless base,
  * where `floorZ` is the skirt or zero. An exterior-wall collar
  * (`extraWallHeightMm`,) raises the walls and the lip with them. With the
- * stacking lip the top face lands `LIP_HEIGHT − LIP_OVERLAP` above the wall;
+ * stacking lip the top face lands `LIP_HEIGHT` above the wall;
  * without it the lid mates with the bare wall. `PREVIEW_Z_OFFSET` accounts for
  * BinMesh's group offset.
  *
@@ -63,7 +63,7 @@ export function binLipTopWorldZ(params: LidSeatSource): number {
 }
 
 /** How far the stacking lip's top face sits above the wall top. */
-const LIP_ABOVE_WALL_MM = GRIDFINITY.LIP_HEIGHT - GRIDFINITY.LIP_OVERLAP;
+const LIP_ABOVE_WALL_MM = GRIDFINITY.LIP_HEIGHT;
 
 /**
  * World-Z of the bin's WALL TOP in the preview frame.

--- a/src/features/bin-designer/hooks/useAssembledHeight.test.ts
+++ b/src/features/bin-designer/hooks/useAssembledHeight.test.ts
@@ -29,7 +29,7 @@ function setDrawerHeight(heightMm: number | undefined): void {
 describe('useAssembledHeight', () => {
   beforeEach(() => {
     useDesignerStore.setState({
-      // 6u body (42mm) with a 4.3mm lip = 46.3mm assembled on a plain plate.
+      // 6u body (42mm) with a 4.4mm lip = 46.4mm assembled on a plain plate.
       params: {
         ...DEFAULT_BIN_PARAMS,
         height: 6,
@@ -46,20 +46,20 @@ describe('useAssembledHeight', () => {
 
   it('derives the total from the design and the layout plate', () => {
     const { result } = renderHook(() => useAssembledHeight());
-    expect(result.current.breakdown.totalMm).toBeCloseTo(46.3, 6);
+    expect(result.current.breakdown.totalMm).toBeCloseTo(46.4, 6);
   });
 
   it('reads the layout baseplate rather than assuming a plain one', () => {
     setPlate({ ...DEFAULT_BASEPLATE_PARAMS, magnetHoles: true, magnetDepth: mm(2) });
     const { result } = renderHook(() => useAssembledHeight());
-    expect(result.current.breakdown.totalMm).toBeCloseTo(48.8, 6);
+    expect(result.current.breakdown.totalMm).toBeCloseTo(48.9, 6);
   });
 
   it('falls back to a standard plate when the layout has none', () => {
     setPlate(undefined);
     const { result } = renderHook(() => useAssembledHeight());
     expect(result.current.breakdown.baseplatePrintedMm).toBe(5);
-    expect(result.current.breakdown.totalMm).toBeCloseTo(46.3, 6);
+    expect(result.current.breakdown.totalMm).toBeCloseTo(46.4, 6);
   });
 
   describe('expansion', () => {
@@ -96,18 +96,18 @@ describe('useAssembledHeight', () => {
       setDrawerHeight(60);
       const { result } = renderHook(() => useAssembledHeight());
       expect(result.current.clearance?.fits).toBe(true);
-      expect(result.current.clearance?.slackMm).toBeCloseTo(13.7, 6);
+      expect(result.current.clearance?.slackMm).toBeCloseTo(13.6, 6);
     });
 
     it('reports negative slack when it does not fit', () => {
       setDrawerHeight(40);
       const { result } = renderHook(() => useAssembledHeight());
       expect(result.current.clearance?.fits).toBe(false);
-      expect(result.current.clearance?.slackMm).toBeCloseTo(-6.3, 6);
+      expect(result.current.clearance?.slackMm).toBeCloseTo(-6.4, 6);
     });
 
     it('counts an exact match as fitting', () => {
-      setDrawerHeight(46.3);
+      setDrawerHeight(46.4);
       const { result } = renderHook(() => useAssembledHeight());
       expect(result.current.clearance?.fits).toBe(true);
     });

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -435,7 +435,7 @@ export interface BaseConfig {
    * narrower than their cells with rounded tops, so nothing else bridges them.
    *
    * That puts the printed height at `SOCKET_HEIGHT + wallThickness` (plus
-   * `LIP_HEIGHT − LIP_OVERLAP` with the lip), which is a fraction of a height
+   * `LIP_HEIGHT` with the lip), which is a fraction of a height
    * unit and therefore NOT expressible via {@link BinParams.height} — `height`
    * is pinned to 1 purely so the existing range validators and their server
    * mirror keep working, and the geometry ignores it. Anything reporting a

--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -1121,7 +1121,7 @@ export interface LidConfig {
    * Carve the lid's seating envelope out of the bin's interior.
    *
    * The top of the cavity's perimeter belongs to the lid: a seated rail hangs
-   * 3.15mm below the wall top and reaches inboard of the inner wall face. With
+   * 3.05mm below the wall top and reaches inboard of the inner wall face. With
    * this on, that ring is cut from the interior as the last operation on the
    * bin, so dividers, label shelves and scoop arcs step aside by construction
    * and the rails run unbroken. With it off, the rails notch around each

--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -1314,10 +1314,10 @@ export const LID_CLICK_RAIL_DROP_BELOW_WALL =
 /**
  * How far below the BIN's wall top a seated lid's click rail reaches (mm) —
  * the band inside the bin's mouth that has to stay clear for the rail to drop
- * into (3.15mm).
+ * into (3.05mm).
  *
  * Seating maps the lid's `anchorZ` onto the bin's lip top, so measuring from
- * the wall top means walking down the lip (`LIP_HEIGHT - LIP_OVERLAP`) and back
+ * the wall top means walking down the lip (`LIP_HEIGHT`) and back
  * up through the mating wall's own depth (`lidWallBottomZ`) before adding the
  * rail's drop. Bin-side code needs the number in bin terms, which is why it is
  * resolved here rather than left as the lid-local pieces.
@@ -1326,7 +1326,7 @@ export const LID_CLICK_RAIL_BAND_BELOW_WALL_TOP =
   LID_CLICK_RAIL_DROP_BELOW_WALL +
   GRIDFINITY_SPEC.LIP_BIG_TAPER +
   GRIDFINITY_SPEC.LIP_VERTICAL_PART -
-  (GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP);
+  GRIDFINITY_SPEC.LIP_HEIGHT;
 
 /**
  * The magnet mating plane in LID-LOCAL Z — the boss's downward face, and one

--- a/src/features/bin-designer/utils/lidCompatibility.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.ts
@@ -524,7 +524,7 @@ export function checkLidCompatibility(params: BinParams): readonly LidCompatibil
 
   // 9. Compartment dividers. A divider is built from the cavity floor
   //    to the interior ceiling, whose top is only `LIP_SMALL_TAPER` below the
-  //    bin's wall top, and a seated click rail hangs 3.15mm under that same
+  //    bin's wall top, and a seated click rail hangs 3.05mm under that same
   //    plane while reaching inboard of the inner wall face. A rail run straight
   //    through a divider's end is therefore 3.1mm of solid-on-solid overlap and
   //    the lid cannot close at all. `dividerRailBlocks` notches the run around
@@ -545,7 +545,7 @@ export function checkLidCompatibility(params: BinParams): readonly LidCompatibil
 
   // 10. Finger scoop reaching the click rail's band. A ramp
   //     against an outer wall of a lipped bin rises toward the lip, and where
-  //     it reaches the top ~3.15mm of the wall its arc fills the pocket the
+  //     it reaches the top ~3.05mm of the wall its arc fills the pocket the
   //     rail's bump drops into to hook the lip's underside — so that edge of
   //     the lid is propped off the rim.
   //

--- a/src/features/bin-designer/utils/lipCornerClassifier.test.ts
+++ b/src/features/bin-designer/utils/lipCornerClassifier.test.ts
@@ -15,9 +15,7 @@ const triAt = (x: number, y: number, z: number): number[] => [x, y, z, x, y, z, 
 
 /** The rule under test: one max layer above the wall the lip is fused onto. */
 const expectedFloorZ = (peakZ: number): number =>
-  peakZ -
-  (GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP) +
-  PRINT_SETTINGS_CONSTRAINTS.LAYER_HEIGHT_MAX;
+  peakZ - GRIDFINITY_SPEC.LIP_HEIGHT + PRINT_SETTINGS_CONSTRAINTS.LAYER_HEIGHT_MAX;
 
 describe('classifyLipCorner', () => {
   const cx = 50;

--- a/src/features/bin-designer/utils/lipCornerClassifier.ts
+++ b/src/features/bin-designer/utils/lipCornerClassifier.ts
@@ -16,7 +16,7 @@ import type { LipCorner, LipBand, LipAxisCount, LipCellZone } from '../types/fea
  * can be recovered from the lip's own peak without the caller passing the bin's
  * dimensions in.
  */
-const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP;
+const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT;
 
 /**
  * Gap between the wall top and the first colourable lip geometry.

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -642,7 +642,7 @@ function lipSupportArea(wallThickness: number): number {
   const top = Math.max(0, GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER - wallThickness);
   const foot = Math.max(0, LIP_EXTENSION - wallThickness);
   const rampHeight = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER - LIP_EXTENSION - FOOT;
-  return ((foot + top) / 2) * rampHeight + top * (LIP_EXTENSION + GRIDFINITY.LIP_OVERLAP);
+  return ((foot + top) / 2) * rampHeight + top * LIP_EXTENSION;
 }
 
 /**

--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -11,7 +11,7 @@
  */
 
 import { boundingBox, columnCrossings, verticalSolidSpans } from './meshAssertions';
-import { LIP_HEIGHT, LIP_OVERLAP } from '../generatorConstants';
+import { LIP_HEIGHT } from '../generatorConstants';
 import {
   lidAnchorZ,
   resolveLidCavityExtraMm,
@@ -46,7 +46,7 @@ export function lidZOffset(p: BinParams): number {
 /** Z of the bin's lip top in world coords. The plane a seated lid registers on. */
 export function binLipTopZ(p: BinParams): number {
   const wallTop = p.height * p.heightUnitMm + Math.max(0, p.extraWallHeightMm ?? 0);
-  return wallTop + LIP_HEIGHT - LIP_OVERLAP;
+  return wallTop + LIP_HEIGHT;
 }
 
 /** Total mm of bin and lid material sharing the same Z at this column. */

--- a/src/features/generation/worker/generators/__kernel-tests__/shellStageBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/shellStageBreakdown.test.ts
@@ -30,7 +30,6 @@ import { buildBaseSocket, DEFAULT_SOCKET_CELL_PLAN } from '../socketBuilder';
 import { clearAllCaches } from '../shapeCache';
 
 const OUT = process.env['PERF_OUT'] ?? '/tmp/perfbench/shell.txt';
-const LIP_OVERLAP = 0.1;
 
 beforeAll(async () => {
   await initBrepjs();
@@ -66,7 +65,7 @@ function buildShellOnce(gridW: number, gridD: number, wallHeight: number): Split
   const lipBase = buildTopShape(gridW, gridD, true, pitch);
   const t2 = performance.now();
 
-  const top = translate(lipBase, [0, 0, wallHeight - LIP_OVERLAP]);
+  const top = translate(lipBase, [0, 0, wallHeight]);
   const body = unwrap(fuse(box, top));
   const t3 = performance.now();
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3636`;
+exports[`bin styles > 2×2 slotted 1`] = `3564`;
 
 exports[`bin styles > 2×2 solid 1`] = `2604`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1668`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1596`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3616`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3608`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `3292`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `3272`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `3426`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `3378`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `30424`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2892`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3004`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2988`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3032`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3012`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3292`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3244`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
@@ -1,16 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2964`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2966`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5424`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5426`;
 
-exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4442`;
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4440`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `380`;
 
 exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5750`;
 
-exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5868`;
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5856`;
 
 exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8688`;
 
@@ -22,7 +22,7 @@ exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5680`;
 
 exports[`custom-shape > 3×3 T with lip 1`] = `4436`;
 
-exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5908`;
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5896`;
 
 exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5790`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -1,25 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`divider patterns > 2×2 honeycomb dividers 1`] = `10036`;
+exports[`divider patterns > 2×2 honeycomb dividers 1`] = `10020`;
 
 exports[`divider patterns > compound angled + leaned divider stays inside the bin 1`] = `2944`;
 
-exports[`divider patterns > dividers + interior cutouts 1`] = `9096`;
+exports[`divider patterns > dividers + interior cutouts 1`] = `9080`;
 
-exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `9616`;
+exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `9600`;
 
-exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13580`;
+exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13568`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `9802`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `9754`;
 
-exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10430`;
+exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10428`;
 
-exports[`divider patterns > mitsukude lattice on dividers 1`] = `16316`;
+exports[`divider patterns > mitsukude lattice on dividers 1`] = `16334`;
 
-exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10940`;
+exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10924`;
 
-exports[`divider patterns > round pattern on a single column divider 1`] = `20268`;
+exports[`divider patterns > round pattern on a single column divider 1`] = `20244`;
 
 exports[`divider patterns > shortened dividers re-fit the band 1`] = `8376`;
 
-exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10138`;
+exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10118`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`floor patterns > compartment divider footings stay solid 1`] = `6812`;
+exports[`floor patterns > compartment divider footings stay solid 1`] = `6796`;
 
 exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12314`;
 
@@ -14,4 +14,4 @@ exports[`floor patterns > half sockets get one window per quarter foot 1`] = `34
 
 exports[`floor patterns > magnet + screw pockets stay solid 1`] = `14892`;
 
-exports[`floor patterns > scoop ramp footings stay solid 1`] = `11742`;
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `11718`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5218`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5210`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4864`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4856`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4266`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4254`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4266`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4254`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4568`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4552`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `3908`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `3892`;
 
 exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `3900`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.knifeBlock.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.knifeBlock.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`knife block > 3x1x4 steak slot row (repeat array) with open ends 1`] = `2856`;
 
-exports[`knife block > 6x1x8 chef slot open end breaches the +X wall and lip 1`] = `3136`;
+exports[`knife block > 6x1x8 chef slot open end breaches the +X wall and lip 1`] = `3160`;
 
-exports[`knife block > 6x1x8 chef slot with integrated rear rest shelf 1`] = `3052`;
+exports[`knife block > 6x1x8 chef slot with integrated rear rest shelf 1`] = `3064`;
 
-exports[`knife block > 6x1x8 open chef slot ignores wall patterns (solid host) 1`] = `3136`;
+exports[`knife block > 6x1x8 open chef slot ignores wall patterns (solid host) 1`] = `3160`;
 
-exports[`knife block > 6x1x8 solid with enclosed chef knife slot 1`] = `3160`;
+exports[`knife block > 6x1x8 solid with enclosed chef knife slot 1`] = `3184`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
@@ -12,9 +12,9 @@ exports[`label tabs > 2×2 label disabled 1`] = `2892`;
 
 exports[`label tabs > 2×2 label front edge 1`] = `3044`;
 
-exports[`label tabs > 2×2 label lip bracket 1`] = `3048`;
+exports[`label tabs > 2×2 label lip bracket 1`] = `3064`;
 
-exports[`label tabs > 2×2 label lip solid 2mm 1`] = `2924`;
+exports[`label tabs > 2×2 label lip solid 2mm 1`] = `2964`;
 
 exports[`label tabs > 2×2 label solid left 1`] = `2870`;
 
@@ -22,6 +22,6 @@ exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `2972`;
 
 exports[`label tabs > 2×2×4 label both edges 1`] = `3196`;
 
-exports[`label tabs > 2×2×4 label lip both edges 1`] = `3204`;
+exports[`label tabs > 2×2×4 label lip both edges 1`] = `3236`;
 
 exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3068`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,49 +1,49 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3050`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3026`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `3404`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `3372`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `3050`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `3026`;
 
 exports[`scoop > 2×2 scoop disabled 1`] = `2892`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `3054`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `3030`;
 
-exports[`scoop flat base > 1×1 flat base scoop with lip 1`] = `1074`;
+exports[`scoop flat base > 1×1 flat base scoop with lip 1`] = `1050`;
 
 exports[`scoop flat base > 2×2 flat base scoop no lip 1`] = `436`;
 
-exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `1070`;
+exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `1046`;
 
-exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1`] = `1266`;
+exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1`] = `1242`;
 
-exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1662`;
+exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1638`;
 
-exports[`scoop multi-compartment > 2×2 grid front scoop (flat base) 1`] = `1442`;
+exports[`scoop multi-compartment > 2×2 grid front scoop (flat base) 1`] = `1394`;
 
-exports[`scoop multi-compartment > 2×2 grid front scoop (standard base + lip) 1`] = `3418`;
+exports[`scoop multi-compartment > 2×2 grid front scoop (standard base + lip) 1`] = `3370`;
 
-exports[`scoop multi-compartment > 2×2 grid left scoop (interior column span-ends) 1`] = `3426`;
+exports[`scoop multi-compartment > 2×2 grid left scoop (interior column span-ends) 1`] = `3378`;
 
-exports[`scoop multi-compartment > irregular grid (tall column + 2 stacked) front scoop 1`] = `3542`;
+exports[`scoop multi-compartment > irregular grid (tall column + 2 stacked) front scoop 1`] = `3498`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `3350`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `3326`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `3408`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `3376`;
 
-exports[`scoop side > scoop on the back wall 1`] = `3050`;
+exports[`scoop side > scoop on the back wall 1`] = `3026`;
 
-exports[`scoop side > scoop on the left wall 1`] = `3050`;
+exports[`scoop side > scoop on the left wall 1`] = `3026`;
 
-exports[`scoop side > scoop on the right wall 1`] = `3050`;
+exports[`scoop side > scoop on the right wall 1`] = `3026`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `3050`;
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `3026`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `3034`;
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `3010`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `3058`;
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `3048`;
 
-exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `2826`;
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `2812`;
 
-exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `2890`;
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `2864`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3636`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3564`;
 
-exports[`slotted variations > slotted with both axes 1`] = `4524`;
+exports[`slotted variations > slotted with both axes 1`] = `4380`;
 
 exports[`slotted variations > slotted without lip 1`] = `2164`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -8,7 +8,7 @@ exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `3116`;
 
 exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3116`;
 
-exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2694`;
+exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2692`;
 
 exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `2636`;
 

--- a/src/features/generation/worker/generators/binDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.test.ts
@@ -4,7 +4,7 @@ import type { BinParams } from '@/shared/types/bin';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import { generateBinDirect, canBinUseDirectMesh } from './binDirectMesh';
 import { CORNER_SEGMENTS } from './directMeshBuilder';
-import { LIP_HEIGHT, LIP_OVERLAP, CLEARANCE } from './generatorConstants';
+import { LIP_HEIGHT, CLEARANCE } from './generatorConstants';
 
 const bin = (overrides: Partial<BinParams> = {}): BinParams => ({
   ...DEFAULT_BIN_PARAMS,
@@ -156,8 +156,11 @@ describe('binDirectMesh — geometry sanity', () => {
     expect(bb.minY).toBeCloseTo(-outerD / 2, 1);
     expect(bb.maxY).toBeCloseTo(outerD / 2, 1);
     expect(bb.minZ).toBeCloseTo(0, 2);
-    // 3U body (21mm) + lip peak (4.4 − 0.1mm overlap).
-    expect(bb.maxZ).toBeCloseTo(3 * 7 + LIP_HEIGHT - LIP_OVERLAP, 2);
+    // The Gridfinity figure exactly: 3U body (21mm) + a 4.4mm lip = 25.4mm.
+    // The fuse overlap hangs BELOW the lip's base plane, so it never shows up
+    // here.
+    expect(bb.maxZ).toBeCloseTo(3 * 7 + LIP_HEIGHT, 2);
+    expect(bb.maxZ).toBeCloseTo(25.4, 2);
   });
 
   it('top sits at the body wall when the lip is disabled', () => {

--- a/src/features/generation/worker/generators/binDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.test.ts
@@ -156,9 +156,8 @@ describe('binDirectMesh — geometry sanity', () => {
     expect(bb.minY).toBeCloseTo(-outerD / 2, 1);
     expect(bb.maxY).toBeCloseTo(outerD / 2, 1);
     expect(bb.minZ).toBeCloseTo(0, 2);
-    // The Gridfinity figure exactly: 3U body (21mm) + a 4.4mm lip = 25.4mm.
-    // The fuse overlap hangs BELOW the lip's base plane, so it never shows up
-    // here.
+    // The fuse overlap hangs BELOW the lip's base plane, so it never reaches
+    // this figure.
     expect(bb.maxZ).toBeCloseTo(3 * 7 + LIP_HEIGHT, 2);
     expect(bb.maxZ).toBeCloseTo(25.4, 2);
   });

--- a/src/features/generation/worker/generators/binDirectMesh.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.ts
@@ -21,7 +21,7 @@
  * - Z=SOCKET_HEIGHT: foot top / socket interface (mates with the body).
  * - Z=SOCKET_HEIGHT + wallThickness: interior cavity floor.
  * - Z=totalHeight (= SOCKET_HEIGHT + wallHeight): body wall top.
- * - With a lip: the outer wall extends to totalHeight + LIP_HEIGHT − LIP_OVERLAP.
+ * - With a lip: the outer wall extends to totalHeight + LIP_HEIGHT.
  * - XY centered at the origin; per-cell feet are CLEARANCE smaller than the
  *   nominal cell so they seat in a baseplate pocket.
  */
@@ -47,7 +47,6 @@ import {
   SOCKET_TAPER_WIDTH,
   LIP_HEIGHT,
   LIP_TAPER_WIDTH,
-  LIP_OVERLAP,
 } from './generatorConstants';
 
 type Pt = readonly [number, number];
@@ -199,7 +198,7 @@ function addBinBody(mb: MeshBuilder, dims: BinBodyDims): void {
   const zBodyBot = SOCKET_HEIGHT;
   const zFloorTop = SOCKET_HEIGHT + wallThickness;
   const zWallTop = totalHeight; // = SOCKET_HEIGHT + wallHeight
-  const zOuterTop = hasLip ? totalHeight + LIP_HEIGHT - LIP_OVERLAP : zWallTop;
+  const zOuterTop = hasLip ? totalHeight + LIP_HEIGHT : zWallTop;
 
   // Outer wall: flush from the socket interface up to the wall top (or lip peak).
   addOuterWalls(mb, outerPts, 0, 0, zOuterTop, zBodyBot);

--- a/src/features/generation/worker/generators/binGenerator.scenario.split-matches-whole.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-matches-whole.test.ts
@@ -208,7 +208,7 @@ describe('rim-anchored features sit where the unsplit bin puts them', () => {
 
 describe('a wall pattern is not plugged by the lip fused on after it', () => {
   // Bold enough that the top row of stamps reaches above
-  // `wallHeight - LIP_OVERLAP - LIP_TAPER_WIDTH`, which is where the lip's
+  // `wallHeight - LIP_TAPER_WIDTH`, which is where the lip's
   // angled support reaches DOWN to. At the default scale the row stops short and
   // nothing is plugged, which is why this needs a scale of its own.
   const params: BinParams = {

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { Shape3D } from 'brepjs';
 import { initTestKernel } from '@/test/initTestKernel';
+import { LIP_TAPER_WIDTH, LIP_OVERLAP } from './generatorConstants';
 
 type BuildBinBoxFn = (
   gridW: number,
@@ -151,15 +152,15 @@ describe('buildTopShape', () => {
     const noStackBounds = shapeBounds(lipNoStack);
     const withStackBounds = shapeBounds(lipWithStack);
 
-    // The added depth of the stacking lip below Z = 0 is the lip
-    // extension PLUS the angled support, which spans LIP_TAPER_WIDTH
-    // (2.6mm). The pre-fix loft only built the extension flange and
-    // produced a delta of LIP_EXTENSION (1.2mm), which would fail the
-    // lower bound below. Comparing the delta cancels out the small
-    // BREP getBounds tolerance epsilon (~0.3mm) that's present in
-    // both the with-stack and no-stack cases.
+    // With the support the lip reaches LIP_TAPER_WIDTH below its base plane;
+    // without one it reaches LIP_OVERLAP, the skirt that gives the fuse a
+    // volume. So the delta is the difference of the two, not LIP_TAPER_WIDTH
+    // itself. The pre-fix loft built only the extension flange and produced a
+    // delta of LIP_EXTENSION (1.2mm), which the band still excludes. Comparing
+    // the delta cancels the BREP getBounds epsilon (~0.3mm) present in both.
+    const expectedDelta = LIP_TAPER_WIDTH - LIP_OVERLAP;
     const lipDepthDelta = noStackBounds.zMin - withStackBounds.zMin;
-    expect(lipDepthDelta).toBeGreaterThan(2.5); // ≈ LIP_TAPER_WIDTH (2.6)
-    expect(lipDepthDelta).toBeLessThan(2.7);
+    expect(lipDepthDelta).toBeGreaterThan(expectedDelta - 0.1);
+    expect(lipDepthDelta).toBeLessThan(expectedDelta + 0.1);
   }, 60000);
 });

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -152,12 +152,9 @@ describe('buildTopShape', () => {
     const noStackBounds = shapeBounds(lipNoStack);
     const withStackBounds = shapeBounds(lipWithStack);
 
-    // With the support the lip reaches LIP_TAPER_WIDTH below its base plane;
-    // without one it reaches LIP_OVERLAP, the skirt that gives the fuse a
-    // volume. So the delta is the difference of the two, not LIP_TAPER_WIDTH
-    // itself. The pre-fix loft built only the extension flange and produced a
-    // delta of LIP_EXTENSION (1.2mm), which the band still excludes. Comparing
-    // the delta cancels the BREP getBounds epsilon (~0.3mm) present in both.
+    // Both arms reach below the base plane, so the delta is the difference of
+    // their reaches rather than LIP_TAPER_WIDTH itself. Taking a delta also
+    // cancels the BREP getBounds epsilon (~0.3mm) present in both.
     const expectedDelta = LIP_TAPER_WIDTH - LIP_OVERLAP;
     const lipDepthDelta = noStackBounds.zMin - withStackBounds.zMin;
     expect(lipDepthDelta).toBeGreaterThan(expectedDelta - 0.1);

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -728,9 +728,9 @@ function buildTopShapeLoft(
       innerSections.push(sectionAt(Z_ANGLE_BOTTOM, INNER_ANGLE));
       innerSections.push(sectionAt(Z_EXT, INNER_BASE));
     } else {
-      // Matches the outer tube's bottom, so the skirt comes out as a ring. Let
-      // the inner loft start at the base plane instead and the cut leaves the
-      // skirt solid: a 0.1mm membrane sealing the bin's mouth.
+      // The inner loft has to reach the outer tube's bottom, or the cut
+      // leaves the skirt solid rather than a ring: a 0.1mm membrane sealing
+      // the bin's mouth.
       innerSections.push(sectionAt(Z_SKIRT, INNER_BASE));
     }
     innerSections.push(sectionAt(Z_BASE, INNER_BASE));

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -37,6 +37,7 @@ import {
   LIP_BIG_TAPER,
   LIP_HEIGHT,
   LIP_TAPER_WIDTH,
+  LIP_OVERLAP,
   TOP_FILLET,
   COPLANAR_MARGIN,
   sketch,
@@ -666,6 +667,12 @@ function buildTopShapeLoft(
   const Z_ANGLE_BOTTOM = includeLip ? -LIP_TAPER_WIDTH : 0;
   const Z_EXT = -LIP_EXTENSION;
   const Z_BASE = 0;
+  // Material below the base plane, so the caller can seat that plane ON the
+  // wall top and still hand the fuse a volume to work with rather than two
+  // touching faces. With a support there is already LIP_TAPER_WIDTH of it; the
+  // supportless profile bottoms out at the base plane and needs the skirt.
+  // Buried inside the wall either way, so it never reaches the silhouette.
+  const Z_SKIRT = includeLip ? Z_ANGLE_BOTTOM : -LIP_OVERLAP;
   const Z_TAPER1 = LIP_SMALL_TAPER; // 0.7
   const Z_VERT = LIP_SMALL_TAPER + LIP_VERTICAL_PART; // 2.5
   const Z_PEAK = LIP_HEIGHT; // 4.4
@@ -688,7 +695,7 @@ function buildTopShapeLoft(
   };
 
   // Outer: rectangular tube at bin outer edge (2 sections → no extra edges)
-  const zBottom = includeLip ? Z_ANGLE_BOTTOM : Z_BASE;
+  const zBottom = Z_SKIRT;
   const outerSections: Sketch[] = [sectionAt(zBottom, 0), sectionAt(Z_PEAK, 0)];
 
   // For O-shape footprints, pre-compute the hole drawings at every inset
@@ -720,6 +727,11 @@ function buildTopShapeLoft(
     if (includeLip) {
       innerSections.push(sectionAt(Z_ANGLE_BOTTOM, INNER_ANGLE));
       innerSections.push(sectionAt(Z_EXT, INNER_BASE));
+    } else {
+      // Matches the outer tube's bottom, so the skirt comes out as a ring. Let
+      // the inner loft start at the base plane instead and the cut leaves the
+      // skirt solid: a 0.1mm membrane sealing the bin's mouth.
+      innerSections.push(sectionAt(Z_SKIRT, INNER_BASE));
     }
     innerSections.push(sectionAt(Z_BASE, INNER_BASE));
     innerSections.push(sectionAt(Z_TAPER1, INNER_MID));
@@ -749,6 +761,8 @@ function buildTopShapeLoft(
       if (includeLip) {
         bigSections.push(atAngle.sketchOnPlane('XY', Z_ANGLE_BOTTOM) as Sketch);
         bigSections.push(atBase.sketchOnPlane('XY', Z_EXT) as Sketch);
+      } else {
+        bigSections.push(atBase.sketchOnPlane('XY', Z_SKIRT) as Sketch);
       }
       bigSections.push(atBase.sketchOnPlane('XY', Z_BASE) as Sketch);
       bigSections.push(atMid.sketchOnPlane('XY', Z_TAPER1) as Sketch);
@@ -817,13 +831,16 @@ function buildTopShapeSweep(
         .vLineTo(-(LIP_TAPER_WIDTH + LIP_EXTENSION))
         .lineTo([-LIP_TAPER_WIDTH, -LIP_EXTENSION]);
     } else {
-      sketcher = sketcher.vLineTo(0);
+      // Down past the base plane by LIP_OVERLAP and back, the skirt the loft
+      // path builds. Both paths have to hand the caller the same solid, or
+      // whether the loft threw would decide how tall the bin comes out.
+      sketcher = sketcher.vLineTo(-LIP_OVERLAP).hLineTo(-LIP_TAPER_WIDTH);
     }
 
     const basicShape = sketcher.close();
 
     let topProfileShape = basicShape.intersect(
-      drawRoundedRectangle(10, 10).translate(-5, includeLip ? 0 : 5)
+      drawRoundedRectangle(10, 10).translate(-5, includeLip ? 0 : 5 - LIP_OVERLAP)
     );
 
     if (includeLip) {
@@ -883,7 +900,10 @@ function buildTopShapeSweep(
  * fallback if loft throws.
  *
  * Profile per Gridfinity spec v5: 0.7mm + 1.8mm + 1.9mm = 4.4mm total height.
- * Built at Z=0 locally, caller translates to wallHeight.
+ * The base plane is Z=0 locally and the caller translates it to the wall top,
+ * so the peak lands exactly `LIP_HEIGHT` above it. Material hangs BELOW Z=0
+ * (the angled support, or `LIP_OVERLAP` of skirt without one) to give the fuse
+ * a volume; it is buried in the wall and never reaches the silhouette.
  */
 export function buildTopShape(
   gridW: number,
@@ -899,7 +919,7 @@ export function buildTopShape(
   const exp = ov && hasOverhang(ov) ? overhangExpansion(ov) : null;
   const pitch = resolvePitch(gridUnitMm);
   const lipKey = buildCacheKey(
-    'v4',
+    'v5',
     quantize(gridW),
     quantize(gridD),
     quantize(pitch.x),

--- a/src/features/generation/worker/generators/integratedLipBuilder.ts
+++ b/src/features/generation/worker/generators/integratedLipBuilder.ts
@@ -22,7 +22,6 @@ import {
   LIP_BIG_TAPER,
   LIP_HEIGHT,
   LIP_TAPER_WIDTH,
-  LIP_OVERLAP,
   sketch,
 } from './generatorTypes';
 import { isPartialMask, type CellMask } from '@/shared/utils/cellMask';
@@ -80,10 +79,10 @@ export function buildBinBoxWithLip(
   const INNER_BASE = LIP_TAPER_WIDTH; // 2.6
   const INNER_MID = LIP_BIG_TAPER; // 1.9
 
-  // Lip profile breakpoints in GLOBAL Z. The lip base sits LIP_OVERLAP below the
-  // wall top; the angled support runs LIP_TAPER_WIDTH below that, alongside the
-  // upper wall (this is the coincident region the fuse z-fights on).
-  const lipBaseZ = wallHeight - LIP_OVERLAP;
+  // Lip profile breakpoints in GLOBAL Z. The lip base sits ON the wall top; the
+  // angled support runs LIP_TAPER_WIDTH below it, alongside the upper wall
+  // (this is the coincident region the fuse z-fights on).
+  const lipBaseZ = wallHeight;
   const zAngleBottom = lipBaseZ - LIP_TAPER_WIDTH;
   const zExt = lipBaseZ - LIP_EXTENSION;
   const zTaper1 = lipBaseZ + LIP_SMALL_TAPER;

--- a/src/features/generation/worker/generators/lidDividerClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidDividerClearance.scenario.test.ts
@@ -2,7 +2,7 @@
  * Lid-vs-compartment-divider clearance.
  *
  * A divider is built from the cavity floor to the interior ceiling, whose top
- * sits 0.7mm below the bin's wall top, and a seated click rail hangs 3.15mm
+ * sits 0.7mm below the bin's wall top, and a seated click rail hangs 3.05mm
  * below that same plane while reaching 2.8mm inboard of the inner wall face.
  * Every point where a divider meets a perimeter wall was therefore 3.1mm of
  * solid-on-solid overlap: any bin with a compartment grid and the default

--- a/src/features/generation/worker/generators/lidGripDip.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGripDip.scenario.test.ts
@@ -261,7 +261,7 @@ describe('bin lip dip face provenance', () => {
 
 describe('bin lip dip across base styles', () => {
   /**
-   * The lip's Z is `baseOffsetZ + wallHeight + collarHeight - LIP_OVERLAP`,
+   * The lip's Z is `baseOffsetZ + wallHeight + collarHeight`,
    * and `baseOffsetZ + totalHeight` is a different number on every one of
    * these: 0.7mm high on a standard bin, 4.3mm low on a flat one, 8.3mm low
    * with a collar. Low enough and the cutter is inside the WALL, where

--- a/src/features/generation/worker/generators/lidInputs.ts
+++ b/src/features/generation/worker/generators/lidInputs.ts
@@ -214,7 +214,7 @@ export interface LidInputs {
    * which walls they take).
    *
    * Two unrelated reasons, applied identically. A compartment divider
-   * is built to the interior ceiling and a seated rail hangs 3.15mm below the
+   * is built to the interior ceiling and a seated rail hangs 3.05mm below the
    * wall top, so a run straight through one is 3.1mm of solid-on-solid overlap
    * and the lid cannot close. A wall cutout or a high handle hole is
    * the opposite — it has taken the lip away, so a rail there grips nothing.

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -77,8 +77,8 @@ describe('lid click rails clear the scoop', () => {
       expect(new Set(railPlacements(resolveLidInputs(params)).map((p) => p.rotationDeg))).toContain(
         ROTATION[side]
       );
-      // 0.15mm covers tessellation noise plus the 0.1mm ledge the chute leaves
-      // where it runs to the wall top while the lip fuses LIP_OVERLAP below it.
+      // 0.15mm covers tessellation noise on the chute where it runs to the
+      // wall top, which is the plane the lip's base now sits on.
       // The defect this guards against measured 1.1mm.
       expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.15);
     },
@@ -130,6 +130,10 @@ describe('lid click rails clear the scoop', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!blindLid) throw new Error('expected the lid to build');
 
-    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(1);
+    // The clash measures ~1.0mm. Asserted at 0.9 so the control still has room
+    // to move: it only has to stay far clear of the 0.15mm the seating cases
+    // above allow, and pinning it to its exact reading would make any change to
+    // where the lid seats look like a broken probe.
+    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(0.9);
   }, 300000);
 });

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -2,7 +2,7 @@
  * Lid-vs-finger-scoop clearance.
  *
  * A scoop against an outer wall of a lipped bin rises toward the lip. Where its
- * arc reaches the top ~3.15mm of the wall it fills the pocket the lid's click
+ * arc reaches the top ~3.05mm of the wall it fills the pocket the lid's click
  * rail bump drops into, so that edge never clicks and the lid is propped off
  * the rim. `autoScoopCeiling` holds an auto scoop clear of that band, and
  * `checkLidCompatibility` drops the rail only for a height the user typed that

--- a/src/features/generation/worker/generators/lipMultiColor.test.ts
+++ b/src/features/generation/worker/generators/lipMultiColor.test.ts
@@ -147,7 +147,7 @@ describe('lip multi-color splitter (generated bin)', () => {
     // 4. The color floor lands above the wall top, so no lip cell reaches the
     //    support skirt or the bin's top surface (#3705). The wall top is the
     //    lip apex less its protrusion; both come from the generated mesh.
-    const wallTopZ = origMaxZ - (GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP);
+    const wallTopZ = origMaxZ - GRIDFINITY_SPEC.LIP_HEIGHT;
     expect(geom!.floorZ).toBeGreaterThan(wallTopZ);
     expect(geom!.floorZ).toBeLessThan(origMaxZ);
     expect(coloredLipArea).toBeLessThan(outputLipArea);

--- a/src/features/generation/worker/generators/lipSupportSeating.kernel.test.ts
+++ b/src/features/generation/worker/generators/lipSupportSeating.kernel.test.ts
@@ -3,8 +3,8 @@
  * The stacking lip's angled support must not reach past the wall it sits on.
  *
  * `buildTopShapeLoft` builds that 45° wedge hanging `LIP_TAPER_WIDTH` (2.6mm)
- * BELOW the lip's own base plane, and the lip fuses at `wallTop - LIP_OVERLAP`.
- * So on a wall shorter than 2.7mm the wedge reaches below the wall bottom — which
+ * BELOW the lip's own base plane, and that plane is the wall top.
+ * So on a wall shorter than 2.6mm the wedge reaches below the wall bottom — which
  * IS the socket top — and back-fills the socket's upper 45° taper out to full
  * outer width. The bin then rests on the baseplate's pocket mouth instead of
  * dropping in.
@@ -46,8 +46,8 @@ beforeAll(async () => {
 /**
  * Tolerance on a seat-depth COMPARISON, in mm. Not a seated/proud threshold: the
  * whole point below is that a fixed threshold hides this defect. The overreach a
- * short wall produces equals `LIP_TAPER_WIDTH + LIP_OVERLAP - wall`, which is
- * 0.7mm for a 1u spacer — comfortably inside the 1mm of slack a
+ * short wall produces equals `LIP_TAPER_WIDTH - wall`, which is
+ * 0.6mm for a 1u spacer — comfortably inside the 1mm of slack a
  * "seated is within 4mm of a 5mm pocket" rule leaves, and invisible to it.
  */
 const SEAT_TOLERANCE_MM = 0.15;

--- a/src/features/generation/worker/generators/lipSupportSeating.kernel.test.ts
+++ b/src/features/generation/worker/generators/lipSupportSeating.kernel.test.ts
@@ -16,7 +16,7 @@
  *
  * Neither is visible to a bounding-box, triangle-count or watertight assertion:
  * both solids are fine, the bin is exactly as tall as it should be, and the extra
- * material is a 0.7mm wedge tucked under the wall. So this mates the bin to a
+ * material is a 0.6mm wedge tucked under the wall. So this mates the bin to a
  * generated plate and lets it fall, reusing the `binSeating` probe rather than
  * restating the profile arithmetic the defect lives in.
  *
@@ -99,7 +99,7 @@ function makeBin(overrides: BinOverrides, stackingLip: boolean): MeshData {
  * A DELTA, because the lip is the only variable: the same feet, the same plate,
  * the same placement. Anything positive is the lip's support pushing the foot out
  * of its pocket, and the sign of the answer does not depend on picking a
- * seated/proud threshold correctly — which is what let a 0.7mm defect ship.
+ * seated/proud threshold correctly — which is what let a 0.6mm defect ship.
  */
 function lipSeatCost(overrides: BinOverrides): number {
   const withLip = seatDepth(makeBin(overrides, true), plateMesh(), ON_GRID);
@@ -109,13 +109,13 @@ function lipSeatCost(overrides: BinOverrides): number {
 
 describe('stacking lip support vs. the socket taper', () => {
   it('costs a 1u spacer nothing', () => {
-    // Wall 2.0mm, so the support overreaches by 0.7mm: small enough that a fixed
+    // Wall 2.0mm, so the support overreaches by 0.6mm: small enough that a fixed
     // seated/proud threshold reads the result as seated.
     expect(lipSeatCost({ height: 1, base: { spacer: true } })).toBeLessThan(SEAT_TOLERANCE_MM);
   }, 240_000);
 
   it('costs a 2u bin at a 3mm height unit nothing', () => {
-    // Wall 1.0mm — the shortest an ordinary socketed bin can have, and a 1.7mm
+    // Wall 1.0mm — the shortest an ordinary socketed bin can have, and a 1.6mm
     // overreach. Nothing relaxed about this input: MIN_HEIGHT is 2u.
     expect(lipSeatCost({ height: 2, heightUnitMm: 3 })).toBeLessThan(SEAT_TOLERANCE_MM);
   }, 240_000);

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -22,7 +22,6 @@ import {
   CLEARANCE,
   SOCKET_HEIGHT,
   LIP_HEIGHT,
-  LIP_OVERLAP,
   LIP_SMALL_TAPER,
   LIP_TAPER_WIDTH,
   MIN_BODY_WALL_MM,
@@ -225,22 +224,22 @@ export function deriveDimensions(
   // slab, not on a wall; every other base carries it on the collar-extended wall
   // the box is extruded to. See `lipHasSupport` for what the number decides.
   const wallUnderLipMm = isTile ? tileFloorHeight : wallHeight + collarHeight;
-  const lipHasSupport = hasLip && wallUnderLipMm >= LIP_TAPER_WIDTH + LIP_OVERLAP;
-  // Safety: LIP_OVERLAP (0.1mm) < LIP_SMALL_TAPER (0.7mm) so interiorHeight
-  // already clears the actual lip base at wallHeight - LIP_OVERLAP.
+  const lipHasSupport = hasLip && wallUnderLipMm >= LIP_TAPER_WIDTH;
+  // The lip's base plane is the wall top, so subtracting any positive amount
+  // leaves the interior below it.
   // Floored at 0 for base-only, whose wallHeight is 0: the subtraction would
   // otherwise hand every downstream stage a -0.7mm interior, and a negative
   // extrude is a degenerate solid rather than an empty one.
   const interiorHeight = Math.max(0, hasLip ? wallHeight - LIP_SMALL_TAPER : wallHeight);
 
   // The rim, derived once. `shellStage` extrudes the outer box to `wallHeight +
-  // collarHeight` (or a base-only bin's slab to `tileFloorHeight`) and fuses
-  // the lip `LIP_OVERLAP` below its top; `translateStage` then lifts the whole
-  // body by `baseOffsetZ`. Every consumer that anchors to the rim reads these
+  // collarHeight` (or a base-only bin's slab to `tileFloorHeight`) and seats the
+  // lip's base plane on that top; `translateStage` then lifts the whole body by
+  // `baseOffsetZ`. Every consumer that anchors to the rim reads these
   // rather than restating that chain — the restatements landed a lid's magnet
   // posts 0.7mm proud on a socketed bin and 4.3mm short on a flat one.
   const wallTopZ = baseOffsetZ + wallHeight + tileFloorHeight + collarHeight;
-  const lipTopZ = wallTopZ + (hasLip ? LIP_HEIGHT - LIP_OVERLAP : 0);
+  const lipTopZ = wallTopZ + (hasLip ? LIP_HEIGHT : 0);
 
   // Bake compartment walls into the shell as a single multi-cavity cut when
   // the shape is amenable to that path: rectangular footprint (no polygon

--- a/src/features/generation/worker/generators/pipeline/stages/lidGripDipStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/lidGripDipStage.ts
@@ -46,7 +46,7 @@ import {
   LID_GRIP_MIN_WALL_MM,
 } from '@/shared/types/bin';
 import { checkCancelled } from '../../utils/abort';
-import { LIP_HEIGHT, LIP_OVERLAP, LIP_TAPER_WIDTH } from '../../generatorConstants';
+import { LIP_HEIGHT, LIP_TAPER_WIDTH } from '../../generatorConstants';
 import { LID_COPLANAR_MARGIN } from '../../lidConstants';
 import { resolveLidInputs } from '../../lidInputs';
 import { gripPlacements } from '../../lidGripRelief';
@@ -93,14 +93,14 @@ export const lidGripDipStage: PipelineStage = {
     );
     if (depthMm <= 0) return ctx;
 
-    // The lip's own base plane: `shellStage` fuses the lip `LIP_OVERLAP` below
-    // the body top, which `dimensions.wallTopZ` derives once. Do not restate it
-    // from `totalHeight` — that is `height * heightUnitMm`, which excludes the
-    // collar and does not track `wallHeight` across base styles, and a cutter
-    // `LIP_TAPER_WIDTH` deep landed a millimetre off opens a slot straight into
-    // the cavity through a 1.2mm wall. The result is still watertight, so only
-    // a probe finds it.
-    const lipBottomZ = dim.wallTopZ - LIP_OVERLAP;
+    // The lip's own base plane, which `shellStage` seats on the body top and
+    // `dimensions.wallTopZ` derives once. Do not restate it from `totalHeight`
+    // — that is `height * heightUnitMm`, which excludes the collar and does not
+    // track `wallHeight` across base styles, and a cutter `LIP_TAPER_WIDTH`
+    // deep landed a millimetre off opens a slot straight into the cavity
+    // through a 1.2mm wall. The result is still watertight, so only a probe
+    // finds it.
+    const lipBottomZ = dim.wallTopZ;
     // Outward overshoot: the coplanar margin PLUS however far the lid's
     // footprint is inboard of the bin's, so the cut reaches the bin face on a
     // magnetic lid as well as a flush one.

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.test.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.test.ts
@@ -6,10 +6,11 @@ describe('shellStage lip overlap', () => {
     expect(LIP_OVERLAP).toBeGreaterThan(0);
   });
 
-  it('LIP_OVERLAP is less than LIP_SMALL_TAPER so interiorHeight clears the lip', () => {
-    // interiorHeight = wallHeight - LIP_SMALL_TAPER, and the lip base is at
-    // wallHeight - LIP_OVERLAP. If LIP_OVERLAP >= LIP_SMALL_TAPER, interior
-    // features would collide with the lip.
+  it('LIP_OVERLAP is less than LIP_SMALL_TAPER so the skirt stays inside the wall', () => {
+    // The skirt hangs LIP_OVERLAP below the lip's base plane, which is the
+    // wall top; interiorHeight stops LIP_SMALL_TAPER below the same plane. A
+    // skirt at or past that depth would reach into the interior instead of
+    // staying buried in the wall it is there to fuse with.
     expect(LIP_OVERLAP).toBeLessThan(LIP_SMALL_TAPER);
   });
 

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -32,7 +32,6 @@ import {
 } from '../../compartmentBuilder';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { getShellCache, setShellCache } from '../../shapeCache';
-import { LIP_OVERLAP } from '../../generatorConstants';
 import { FeatureTag } from '../../featureTags';
 import { collectOrigins } from '../collectOrigins';
 import { applyPinHoles, buildDetachableFeet } from '../../detachableFeetBuilder';
@@ -231,10 +230,10 @@ export const shellStage: PipelineStage = {
               dim.overhang
             )
           );
-          // Same `-LIP_OVERLAP` drop the fuse path below uses: without it the
-          // ring merely TOUCHES the slab, and a coplanar contact fuses into a
-          // non-manifold solid instead of a single watertight one.
-          const top = scope.register(translate(lipBase, [0, 0, dim.tileFloorHeight - LIP_OVERLAP]));
+          // Seated ON the slab top: `buildTopShape` hangs its own material
+          // below the base plane, so the fuse still gets a volume rather than
+          // the coplanar contact that would come out non-manifold.
+          const top = scope.register(translate(lipBase, [0, 0, dim.tileFloorHeight]));
           collectOrigins(top, FeatureTag.LIP, originToTag);
           scope.register(floor); // consumed by fuse
           return unwrap(fuse(floor, top));
@@ -295,7 +294,7 @@ export const shellStage: PipelineStage = {
                 dim.overhang
               )
             );
-            const top = scope.register(translate(lipBase, [0, 0, boxWallHeight - LIP_OVERLAP]));
+            const top = scope.register(translate(lipBase, [0, 0, boxWallHeight]));
             collectOrigins(top, FeatureTag.LIP, originToTag);
             scope.register(binBody); // consumed by fuse
             return unwrap(

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -194,8 +194,8 @@ export interface BinDimensions {
    * the lip's inward jut down into the wall it sits on.
    *
    * `buildTopShapeLoft` builds that support hanging `LIP_TAPER_WIDTH` BELOW the
-   * lip's own base plane, and the lip fuses at `boxWallHeight - LIP_OVERLAP`, so
-   * on a wall shorter than `LIP_TAPER_WIDTH + LIP_OVERLAP` the support reaches
+   * lip's own base plane, and that plane is `boxWallHeight`, so
+   * on a wall shorter than `LIP_TAPER_WIDTH` the support reaches
    * past the wall bottom and lands inside the socket's upper taper, back-filling
    * it to full width. The foot then stops seating in a baseplate (CLAUDE.md
    * gotcha #10) — and the solid stays watertight and correctly sized, so no

--- a/src/features/generation/worker/generators/scenarios/heights.ts
+++ b/src/features/generation/worker/generators/scenarios/heights.ts
@@ -1,10 +1,38 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { LIP_HEIGHT } from '../generatorConstants';
 import {
   assertBoundingBoxMatchesParams,
   assertNoDegenerateTriangles,
+  boundingBox,
 } from '../__kernel-tests__/meshAssertions';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+import type { MeshData } from '@/features/generation/bridge/types';
+import type { BinParams } from '@/shared/types/bin';
+
+/**
+ * The Gridfinity figure for a lipped bin, to 0.05mm: the body is
+ * `height` units of `heightUnitMm` and the lip adds its whole profile on top.
+ *
+ * Tight on purpose. `assertBoundingBoxMatchesParams` ignores the lip and allows
+ * 5mm, so it reads as a height check while being blind to every error the lip
+ * can contribute — including the 0.1mm one where the fuse overlap that seats
+ * the lip was subtracted from the peak instead of buried in the wall.
+ */
+function assertLippedHeight(label: string) {
+  return (result: MeshData, params: BinParams): void => {
+    const bb = boundingBox(result.vertices);
+    const actual = bb.maxZ - bb.minZ;
+    const expected = params.height * params.heightUnitMm + LIP_HEIGHT;
+    if (Math.abs(actual - expected) > 0.05) {
+      throw new Error(
+        `${label}: expected ${expected.toFixed(2)}mm overall, got ${actual.toFixed(2)}mm. ` +
+          `A lipped bin is height*heightUnitMm + LIP_HEIGHT; anything the lip is ` +
+          `seated with belongs below its base plane, not off its peak.`
+      );
+    }
+  };
+}
 
 export const heightVariations: ScenarioCase[] = [
   defineScenario('height', '2×2 height minimum (2u)', { params: { height: 2 } }),
@@ -34,6 +62,14 @@ export const heightVariations: ScenarioCase[] = [
     params: { width: 4, depth: 4, height: 6 },
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '4x4x6');
+    },
+  }),
+
+  defineScenario('height', '2×2 3u lipped bin measures the spec 25.4mm', {
+    assert: 'structural',
+    params: { height: 3, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } },
+    customAssert: (result, params) => {
+      assertLippedHeight('2x2x3-lipped')(result, params);
     },
   }),
 

--- a/src/features/generation/worker/generators/scenarios/labelSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/labelSockets.ts
@@ -28,7 +28,7 @@ import type { BinParams } from '@/shared/types/bin';
 import type { MeshData } from '@/features/generation/bridge/types';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
-import { COPLANAR_OVERLAP, LIP_HEIGHT, LIP_OVERLAP, LIP_SMALL_TAPER } from '../generatorConstants';
+import { COPLANAR_OVERLAP, LIP_HEIGHT, LIP_SMALL_TAPER } from '../generatorConstants';
 
 const SOCKET_LABEL = {
   ...DEFAULT_BIN_PARAMS.label,
@@ -144,9 +144,9 @@ function assertRelievedPocketFloor(result: MeshData, label: string): void {
   for (let i = 2; i < vertices.length; i += 3) {
     if (vertices[i] > maxZ) maxZ = vertices[i];
   }
-  // maxZ is the lip peak: wallTop + LIP_HEIGHT − LIP_OVERLAP. Walk down to the
+  // maxZ is the lip peak: wallTop + LIP_HEIGHT. Walk down to the
   // interior ceiling, then apply relief + pocket depth.
-  const interiorTopZ = maxZ - (LIP_HEIGHT - LIP_OVERLAP) - LIP_SMALL_TAPER;
+  const interiorTopZ = maxZ - LIP_HEIGHT - LIP_SMALL_TAPER;
   const relievedFloorZ =
     interiorTopZ - LABEL_SOCKET_STACK_RELIEF_MM - LABEL_SOCKET_CLICK_POCKET_DEPTH_MM;
   const unrelievedFloorZ = interiorTopZ - LABEL_SOCKET_CLICK_POCKET_DEPTH_MM;

--- a/src/features/generation/worker/generators/scenarios/spacer.ts
+++ b/src/features/generation/worker/generators/scenarios/spacer.ts
@@ -8,7 +8,7 @@
  * of a 4u one).
  */
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
-import { SOCKET_HEIGHT, MIN_BODY_WALL_MM, LIP_HEIGHT, LIP_OVERLAP } from '../generatorConstants';
+import { SOCKET_HEIGHT, MIN_BODY_WALL_MM, LIP_HEIGHT } from '../generatorConstants';
 import {
   assertBoundingBoxMatchesParams,
   assertWatertight,
@@ -28,7 +28,7 @@ const liteBase = { ...DEFAULT_BIN_PARAMS.base, lightweight: true };
 function assertFlooredSpacer(result: MeshData, label: string): void {
   assertWatertight(result, label);
   const bbox = boundingBox(result.vertices);
-  const expected = SOCKET_HEIGHT + MIN_BODY_WALL_MM + LIP_HEIGHT - LIP_OVERLAP;
+  const expected = SOCKET_HEIGHT + MIN_BODY_WALL_MM + LIP_HEIGHT;
   const actual = bbox.maxZ - bbox.minZ;
   if (Math.abs(actual - expected) > 0.05) {
     throw new Error(

--- a/src/features/generation/worker/generators/scenarios/tile.ts
+++ b/src/features/generation/worker/generators/scenarios/tile.ts
@@ -18,7 +18,7 @@
  *    leaving a foot that will not seat in a baseplate.
  */
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
-import { SOCKET_HEIGHT, LIP_HEIGHT, LIP_OVERLAP } from '../generatorConstants';
+import { SOCKET_HEIGHT, LIP_HEIGHT } from '../generatorConstants';
 import {
   boundingBox,
   assertWatertight,
@@ -46,7 +46,7 @@ const RING_MASK: CellMask = {
 /** Feet plus the floor slab — the whole body, lip aside. */
 const BODY_MM = SOCKET_HEIGHT + DEFAULT_BIN_PARAMS.wallThickness;
 /** Body plus the lip's net rise above it. */
-const LIPPED_HEIGHT_MM = BODY_MM + LIP_HEIGHT - LIP_OVERLAP;
+const LIPPED_HEIGHT_MM = BODY_MM + LIP_HEIGHT;
 
 function assertTotalZ(expected: number, label: string) {
   return (result: MeshData): void => {

--- a/src/features/generation/worker/generators/scenarios/wallCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/wallCutouts.ts
@@ -148,7 +148,7 @@ export const wallCutouts: ScenarioCase[] = [
   }),
   defineScenario('wall cutouts', 'full-height u-shape through a stacking lip (#3173)', {
     // Same cut against a lipped wall: the true rim is the lip peak at
-    // wallHeight + LIP_HEIGHT - LIP_OVERLAP, which the overshoot clears by only
+    // wallHeight + LIP_HEIGHT, which the overshoot clears by only
     // ~2.1mm — the case where a 5mm corner radius left the most arc behind.
     assert: 'structural',
     params: {

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -24,7 +24,7 @@ import type { ExportFormat } from '../../bridge/types';
 
 import { CLEARANCE } from './generatorTypes';
 import { buildSTLBufferFromIndexed } from '@/features/generation/export/stlExporter';
-import { LIP_HEIGHT, LIP_OVERLAP, LIP_TAPER_WIDTH } from './generatorConstants';
+import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { pitchFromParams, type GridPitch } from './gridPitch';
 import { toIndexedMeshData } from './utils/mesh';
 import { creaseEdges } from './utils';
@@ -243,9 +243,9 @@ function splitSolidIntoPieces(
   // partial masks, matching the geometry pipeline.
   const overhang = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
 
-  // Build lip solid separately if needed. The lip is positioned at
+  // Build lip solid separately if needed. The lip's base plane is seated on
   // wallTopZ (= totalHeight for both flat and socket bases after the
-  // socket Z-offset applied in generateBin), shifted down by LIP_OVERLAP.
+  // socket Z-offset applied in generateBin).
   //
   // Pass cellMask + overhang so the lip footprint matches the body. A no-op for
   // a plain rectangular bin with no overhang; for a custom shape (L/U) or any
@@ -285,12 +285,11 @@ function splitSolidIntoPieces(
       params.cellMask,
       overhang
     );
-    // `-LIP_OVERLAP`, the same drop `shellStage` fuses an unsplit bin's lip at:
-    // it penetrates the wall so the fuse has a volumetric overlap rather than a
-    // shared edge (which comes out as degenerate faces at the junction), and
-    // taking the same value puts the piece's rim on the plane the whole bin's
-    // sits on rather than 0.05mm above it.
-    lipSolid = translate(lipBase, [0, 0, wallTopZ - LIP_OVERLAP]);
+    // The same plane `shellStage` seats an unsplit bin's lip on, so the
+    // piece's rim lands where the whole bin's does. `buildTopShape` carries its
+    // own material below that plane, so the fuse gets a volumetric overlap
+    // rather than a shared edge (which comes out as degenerate faces).
+    lipSolid = translate(lipBase, [0, 0, wallTopZ]);
     lipBase.delete();
 
     // For slotted bins, cut divider notches through the lip so removable
@@ -329,7 +328,7 @@ function splitSolidIntoPieces(
     // Wall patterns cut the lip for the same reason, and it is easy to miss
     // why: a hex sits well below the rim, so it looks like it could not reach
     // the lip at all. The lip's angled support hangs `LIP_TAPER_WIDTH` BELOW
-    // its own base plane, down to `wallHeight - LIP_OVERLAP - LIP_TAPER_WIDTH`,
+    // its own base plane, down to `wallHeight - LIP_TAPER_WIDTH`,
     // and the pattern band's top always clears that by ~0.5mm. Whether any
     // element actually lands in the overlap is down to how the stamp calculator
     // laid the rows out, so a bin at one scale is untouched and the same bin one
@@ -350,7 +349,7 @@ function splitSolidIntoPieces(
       // that converts to it) rather than restated from `wallHeight`, which is
       // one term short of the rim on a bin carrying an `extraWallHeightMm`
       // collar or a tray's floor.
-      const lipReach = wallTopZ - floorZ - LIP_OVERLAP - LIP_TAPER_WIDTH;
+      const lipReach = wallTopZ - floorZ - LIP_TAPER_WIDTH;
       // Asked of the built solids rather than recomputed from the layout, so it
       // cannot drift from where the stamps actually ended up. A bin whose top
       // row stops short of the wedge (the default scale does) skips the fuse and

--- a/src/shared/constants/lidKeepout.test.ts
+++ b/src/shared/constants/lidKeepout.test.ts
@@ -39,7 +39,7 @@ describe('lidKeepoutRing', () => {
   });
 
   it('is deep enough for the rail band plus a clearance', () => {
-    expect(ring.depthBelowWallTop).toBeCloseTo(3.15 + LID_KEEPOUT_CLEARANCE, 6);
+    expect(ring.depthBelowWallTop).toBeCloseTo(3.05 + LID_KEEPOUT_CLEARANCE, 6);
   });
 
   it('measures the label datum from the ceiling, a lip taper below the rim', () => {

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -42,6 +42,8 @@ const META_STORE = 'binMeshMeta';
  * one kernel's output, bump that kernel's {@link KERNEL_MESH_REVISION} entry
  * instead, so the other kernel's users keep their warm cache.
  *
+ * `v16`: the stacking lip's base plane seats on the wall top rather than
+ * `LIP_OVERLAP` under it, so every lipped bin is 0.1mm taller on both kernels.
  * `v14`: additive features union pairwise instead of through the kernel's
  * n-way fuse, and the scoop ramp stands on the floor top; both move every
  * kernel's output for any bin with a scoop, label tab, emboss or rail.
@@ -69,7 +71,7 @@ const META_STORE = 'binMeshMeta';
  * without regenerating, so without this bump a linked design in the layout
  * planner would render its pre-fix bin until the entry was evicted.
  */
-const MESH_CACHE_VERSION = 'v15';
+const MESH_CACHE_VERSION = 'v16';
 
 /**
  * Per-kernel revision, bumped when only THAT kernel's output moves for

--- a/src/shared/printSettings/assembledHeight.test.ts
+++ b/src/shared/printSettings/assembledHeight.test.ts
@@ -16,7 +16,7 @@ function bandOf(kind: AssembledSegmentKind, result: ReturnType<typeof assembledH
   return result.segments.find((s) => s.kind === kind)?.mm ?? 0;
 }
 
-const LIP_RISE = GRIDFINITY.LIP_HEIGHT - GRIDFINITY.LIP_OVERLAP;
+const LIP_RISE = GRIDFINITY.LIP_HEIGHT;
 
 describe('assembledHeight', () => {
   describe('band bookkeeping', () => {
@@ -163,7 +163,7 @@ describe('assembledHeight', () => {
   });
 
   describe('stacking lip', () => {
-    it('adds LIP_HEIGHT minus the fuse overlap', () => {
+    it('adds the full LIP_HEIGHT above the wall', () => {
       const result = assembledHeight(
         params({ height: 6, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } })
       );
@@ -171,13 +171,13 @@ describe('assembledHeight', () => {
       expect(result.totalMm).toBeCloseTo(42 + LIP_RISE, 6);
     });
 
-    it('reproduces the 67.3mm reading from issue #3037', () => {
-      // 9u at 7mm = 63mm body, plus the 4.3mm lip rise.
+    it('reports the 9u lipped stack at its Gridfinity height (#3037)', () => {
+      // 9u at 7mm = 63mm body, plus the spec's full 4.4mm lip.
       const result = assembledHeight(
         params({ height: 9, base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } }),
         PLAIN_PLATE
       );
-      expect(result.totalMm).toBeCloseTo(67.3, 6);
+      expect(result.totalMm).toBeCloseTo(67.4, 6);
     });
 
     it('omits the band when the lip is off', () => {
@@ -280,8 +280,8 @@ describe('assembledHeight', () => {
         'lid',
         'lidStackGrid',
       ]);
-      // 2.5 plate floor + 42 bin + 4.3 lip + ~2.093 lid + 5 grid
-      expect(result.totalMm).toBeCloseTo(55.893, 3);
+      // 2.5 plate floor + 42 bin + 4.4 lip + ~2.093 lid + 5 grid
+      expect(result.totalMm).toBeCloseTo(55.993, 3);
     });
   });
 });

--- a/src/shared/printSettings/assembledHeight.ts
+++ b/src/shared/printSettings/assembledHeight.ts
@@ -202,7 +202,7 @@ export function assembledHeight(
     : params.height * params.heightUnitMm +
       Math.max(0, params.extraWallHeightMm ?? 0) +
       (params.base.style === 'lid' ? skirtMm : 0);
-  const lipMm = params.base.stackingLip ? GRIDFINITY.LIP_HEIGHT - GRIDFINITY.LIP_OVERLAP : 0;
+  const lipMm = params.base.stackingLip ? GRIDFINITY.LIP_HEIGHT : 0;
   const lidMm = hasSeatedLid(params) ? lidRiseMm(params) : 0;
   // The stack grid is a SOCKET_HEIGHT slab above the lid's top face, whether it
   // is fused on or printed separately and glued. With nothing stacked on it, its

--- a/src/shared/utils/dividerRailPlan.test.ts
+++ b/src/shared/utils/dividerRailPlan.test.ts
@@ -125,9 +125,9 @@ describe('dividerRailBlocks', () => {
   });
 
   describe('a leaning divider sweeps across the rail band', () => {
-    // Divider top at the 15.3mm ceiling, band floor at 12.85mm: the rail sees
-    // 2.45mm of the wall, over which a lean travels 2.45 * tan(lean).
-    const BAND_DEPTH = 15.3 - 12.85;
+    // Divider top at the 15.3mm ceiling, band floor at 12.95mm: the rail sees
+    // 2.35mm of the wall, over which a lean travels 2.35 * tan(lean).
+    const BAND_DEPTH = 15.3 - 12.95;
     const leaning = (rakeDeg: number): readonly DividerRailBlock[] =>
       dividerRailBlocks(
         bin({

--- a/src/shared/utils/dividerRailPlan.test.ts
+++ b/src/shared/utils/dividerRailPlan.test.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * A default 2x2x3 bin: innerW = innerD = 2*42 - 0.5 - 2*1.2 = 81.1mm, interior
- * ceiling at 15.3mm, and the rail band's floor at 12.85mm above the cavity
+ * ceiling at 15.3mm, and the rail band's floor at 12.95mm above the cavity
  * floor. Every expectation below is stated against those, not re-derived.
  */
 function bin(compartments: CompartmentConfig, overrides: Partial<BinParams> = {}): BinParams {

--- a/src/shared/utils/dividerRailPlan.ts
+++ b/src/shared/utils/dividerRailPlan.ts
@@ -3,7 +3,7 @@
  *
  * A divider wall is built from the cavity floor to the interior ceiling, whose
  * top sits `LIP_SMALL_TAPER` below the bin's wall top. A seated rail hangs
- * `LID_CLICK_RAIL_BAND_BELOW_WALL_TOP` (3.15mm) under that same wall top and
+ * `LID_CLICK_RAIL_BAND_BELOW_WALL_TOP` (3.05mm) under that same wall top and
  * reaches inboard past the inner wall face, so every point where a divider
  * terminates on a perimeter wall is solid-on-solid overlap — measured at 3.1mm
  * on a stock 3x2 grid, which is a lid that cannot close at all.

--- a/src/shared/utils/drawerCeiling.test.ts
+++ b/src/shared/utils/drawerCeiling.test.ts
@@ -49,13 +49,13 @@ describe('drawerCeilingFit', () => {
   });
 
   // The reported case: a drawer measured at 55mm floors to 7.85u, the inspector
-  // offers 7.85u as the max, and the part prints 4.25mm proud of the drawer.
+  // offers 7.85u as the max, and the part prints 4.35mm proud of the drawer.
   it('flags the bin that exactly fills the unit budget as overflowing', () => {
     const result = fit([bin({ height: heightUnits(7.85), layerId: layerId('l1') })], 55);
     expect(result?.fits).toBe(false);
-    expect(result?.slackMm).toBeCloseTo(-4.25, 5);
+    expect(result?.slackMm).toBeCloseTo(-4.35, 5);
     expect(result?.overflowing).toHaveLength(1);
-    expect(result?.overflowing[0]?.overflowMm).toBeCloseTo(4.25, 5);
+    expect(result?.overflowing[0]?.overflowMm).toBeCloseTo(4.35, 5);
   });
 
   it('nests a stacked bin into the one below rather than summing printed heights', () => {

--- a/src/shared/utils/heightUnits.test.ts
+++ b/src/shared/utils/heightUnits.test.ts
@@ -78,7 +78,7 @@ describe('isStandardStackHeight', () => {
   });
 });
 
-/** What each junction costs against the body height: 4.75 − 4.3. */
+/** What each junction costs against the body height: 4.75 − 4.4. */
 const SHORTFALL_MM = STACK_JUNCTION_MM - LIP_PROTRUSION_MM;
 
 describe('stackPitchMm', () => {

--- a/src/shared/utils/heightUnits.test.ts
+++ b/src/shared/utils/heightUnits.test.ts
@@ -88,7 +88,7 @@ describe('stackPitchMm', () => {
   });
 
   it('the shortfall is the base profile standing proud of the lip', () => {
-    expect(SHORTFALL_MM).toBeCloseTo(0.45, 5);
+    expect(SHORTFALL_MM).toBeCloseTo(0.35, 5);
   });
 });
 

--- a/src/shared/utils/heightUnits.ts
+++ b/src/shared/utils/heightUnits.ts
@@ -10,7 +10,7 @@ import { GRIDFINITY_SPEC } from '@/shared/printSettings';
  * {@link STACK_JUNCTION_MM}, and conflating the two is what made every stack
  * readout 0.45mm per junction too tall (#3525).
  */
-export const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP;
+export const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT;
 
 /**
  * How far a stacked bin settles below the lip top of the bin under it, in mm.
@@ -23,9 +23,9 @@ export const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LI
  *
  * It is the base profile that sets this, never the lip: at 4.4mm of profile
  * against the base's 4.75mm the lip is the shorter of the two, so the bin above
- * settles 0.35mm past the lip's base plane (0.45mm here, `LIP_OVERLAP` sinking
- * the lip a further 0.1mm into the wall). Both figures come from the reference
- * profiles, so a canonical Gridfinity stack does not add body height either.
+ * settles 0.35mm past the lip's base plane. Both figures come from the
+ * reference profiles, so a canonical Gridfinity stack does not add body height
+ * either.
  *
  * Measured on the mated solids rather than trusted from this arithmetic —
  * `binStackSeating.kernel.test.ts`.

--- a/src/shared/utils/labelTabPlan.test.ts
+++ b/src/shared/utils/labelTabPlan.test.ts
@@ -54,11 +54,11 @@ describe('labelTabInteriorDims', () => {
 describe('clickRailZBandAboveFloor', () => {
   it('places the band where the mated lid actually puts its rails', () => {
     // Measured on the real assembly for a 2x3x6 bin (interiorHeight 36.3):
-    // the lid's rail solid spans [33.85, 37.60] above the cavity floor.
+    // the lid's rail solid spans [33.95, 37.70] above the cavity floor.
     const band = clickRailZBandAboveFloor(36.3);
-    expect(band.lo).toBeCloseTo(33.85, 2);
+    expect(band.lo).toBeCloseTo(33.95, 2);
     // `hi` carries the 0.8mm top chamfer above the rail's own top face.
-    expect(band.hi).toBeCloseTo(38.4, 2);
+    expect(band.hi).toBeCloseTo(38.5, 2);
   });
 });
 

--- a/src/shared/utils/labelTabPlan.ts
+++ b/src/shared/utils/labelTabPlan.ts
@@ -571,11 +571,7 @@ export function clickRailZBandAboveFloor(
   readonly hi: number;
 } {
   const lipTop =
-    interiorHeight +
-    collarHeight +
-    GRIDFINITY_SPEC.LIP_SMALL_TAPER +
-    GRIDFINITY_SPEC.LIP_HEIGHT -
-    GRIDFINITY_SPEC.LIP_OVERLAP;
+    interiorHeight + collarHeight + GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_HEIGHT;
   const wallBottom = lipTop - GRIDFINITY_SPEC.LIP_BIG_TAPER - GRIDFINITY_SPEC.LIP_VERTICAL_PART;
   return {
     lo: wallBottom - LID_CLICK_RAIL_DROP_BELOW_WALL,

--- a/src/shared/utils/slideLidPlan.test.ts
+++ b/src/shared/utils/slideLidPlan.test.ts
@@ -239,12 +239,12 @@ describe('resolveSlideLidPlan', () => {
 
     it('drops a recessed channel clear of the lip’s angled support', () => {
       // The support reaches LIP_TAPER_WIDTH (2.6mm) below the lip's own base
-      // plane, which sits LIP_OVERLAP (0.1mm) under the wall top. A retainer
+      // plane, which is the wall top. A retainer
       // fused inside that band would back-fill the taper a foot has to seat in,
       // and no mesh check would show it (CLAUDE.md gotcha #10).
       const recessed = slidePlateTopBelowWallTopMm('recessed', 0.25, true);
       const flush = slidePlateTopBelowWallTopMm('flush', 0.25, true);
-      expect(recessed - flush).toBeCloseTo(0.1 + 2.6, 9);
+      expect(recessed - flush).toBeCloseTo(2.6, 9);
     });
 
     it('collapses the two placements on a lipless bin', () => {
@@ -383,9 +383,9 @@ describe('resolveSlideLidPlan', () => {
       // worst overhang on the part.
       //
       // `zMax` is measured from the PLATE's top plane, so the lip's top face
-      // sits `plateTopBelowWallTopMm + LIP_HEIGHT - LIP_OVERLAP` above it.
+      // sits `plateTopBelowWallTopMm + LIP_HEIGHT` above it.
       const g = geometryOf();
-      const lipTopAbovePlate = g.plateTopBelowWallTopMm + 4.4 - 0.1;
+      const lipTopAbovePlate = g.plateTopBelowWallTopMm + 4.4;
       expect(g.entryNotch.zMax).toBeGreaterThan(lipTopAbovePlate);
     });
 

--- a/src/shared/utils/slideLidPlan.ts
+++ b/src/shared/utils/slideLidPlan.ts
@@ -463,7 +463,7 @@ export function slidePlateTopBelowWallTopMm(
 ): number {
   const roofTop = clearanceMm + SLIDE_ROOF_TIP_MM;
   if (placement === 'flush' || !hasLip) return roofTop;
-  return GRIDFINITY_SPEC.LIP_OVERLAP + LIP_TAPER_WIDTH + roofTop;
+  return LIP_TAPER_WIDTH + roofTop;
 }
 
 /**
@@ -642,9 +642,7 @@ export function resolveSlideLidPlan(input: SlideLidPlanInput): SlideLidPlan {
   // So the stacking lip really is interrupted on this one wall. That is the
   // trade `grip.binDip` already makes, `slideRimInterrupted` reports it, and
   // the bin still stacks on its other three walls and its corners.
-  const notchTopAboveWallTop = input.hasLip
-    ? GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP + 1
-    : 1;
+  const notchTopAboveWallTop = input.hasLip ? GRIDFINITY_SPEC.LIP_HEIGHT + 1 : 1;
   const entryNotch: SlideLidBox = {
     xMin: travelInner / 2 - 0.1,
     xMax: trailingX + 1,


### PR DESCRIPTION
Closes #4120.

A 3u bin with a stacking lip exported at 25.3mm where the spec says `3×7 + 4.4 = 25.4mm`. Every lipped bin was 0.1mm short the same way.

## Cause

`LIP_OVERLAP` is a fuse epsilon, not a dimension. The lip and the wall meet on a plane, and a coplanar contact fuses into a non-manifold solid, so the lip was sunk 0.1mm into the wall to hand the boolean a volume rather than two touching faces. It was never grown to match, so the epsilon came off the outside of the part. `gridfinityGeometry.ts` states the consequence outright: the top face lands at `wallTop + LIP_HEIGHT - LIP_OVERLAP`.

## Fix

The lip's base plane now seats ON the wall top, and the overlap moves into the lip solid as a skirt hanging below that plane, where it stays buried in the wall.

A supported lip already carried `LIP_TAPER_WIDTH` of material below its base plane, so its solid is unchanged apart from position; only the supportless profile (base-only bins, very short walls) needed a skirt built. Both the loft and its sweep fallback grew one, so which path ran cannot decide how tall the bin comes out.

Everything measured against the lip follows: lid seating, slide-lid placement, the click-rail band, drawer fit, and the assembled-height readout, which now agrees with the exported solid instead of being consistently 0.1mm under it.

## What this does not change

The bin-to-bin stack junction. `binStackSeating.kernel.test.ts` measures it on the mated solids and still reads 4.75mm, because the lip's profile is untouched and only its position moved. The shortfall a bin settles by is therefore 0.35mm rather than 0.45mm, which is the same number stated against a correct lip.

## Verification

A new scenario asserts the reported case to 0.05mm, on both the preview and export paths. It fails on the parent commit with exactly the reporter's reading:

```
2x2x3-lipped: expected 25.40mm overall, got 25.30mm
```

It is deliberately tight. `assertBoundingBoxMatchesParams` ignores the lip and allows 5mm, so it reads as a height check while being blind to every error the lip can contribute, which is why this one shipped.

Full local runs: 1625 unit/dom files (23026 tests), 339 generator files across `generators` and `generators-heavy` (3321 tests), typecheck clean. I ran the failing scenario files against a clean `main` worktree first to confirm the churn was mine.

## Baseline churn

63 triangle-count baselines move, by -24 to -32 on lipped scenarios. The scoop chute used to leave a 0.1mm ledge where it ran to the wall top while the lip sat below it; the two are flush now, and those triangles are gone. Structural, watertightness and export-integrity assertions pass unchanged.

The `.brepkit.snap` baselines are untouched, matching how they are maintained here: nothing sets `BREPJS_KERNEL` in CI or the package scripts, and they have been regenerated only four times in the repo's history.

The old height was pinned in several tests. Those stating it as a measurement are updated. The two that derived a threshold from it now read the constants instead of a magic number, since both only held because of the bug.

https://claude.ai/code/session_01Azrg5R8TiCRwwrc2jy4VPp

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

