### PR TITLE
fix(designer): keep a shape draggable on the axis that overruns the board

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -47,6 +47,8 @@ vi.mock('@/design-system', async () => ({
 }));
 
 vi.mock('../panel/CutoutsSection/geometry', () => ({
+  clampToBoardAxis: (value: number, min: number, max: number) =>
+    max < min ? value : Math.min(Math.max(value, min), max),
   clampRotationToBounds: (_c: Cutout, rotation: number) => rotation,
   getRotatedBounds: (c: Cutout) => ({
     minX: c.x,
@@ -452,7 +454,10 @@ describe('InspectorContent multi-select editing', () => {
     expect(updates.get('a')?.width).toBe(2);
   });
 
-  it('pins a batch X to 0 for a cutout wider than the board', () => {
+  // A cutout wider than the board leaves no valid offset, so the clamp has no
+  // range to hold it in. Pinning it to 0 there took away the only way to line it
+  // up before growing the bin (#4122).
+  it('still moves a batch X for a cutout wider than the board', () => {
     const onUpdateBatch = renderMulti([
       createCutout({ id: 'oversize', width: 156 }),
       createCutout({ id: 'normal' }),
@@ -461,7 +466,9 @@ describe('InspectorContent multi-select editing', () => {
     fireEvent.change(screen.getByTestId('compact-input-X'), { target: { value: '20' } });
 
     const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
-    expect(updates.get('oversize')?.x).toBe(0);
+    expect(updates.get('oversize')?.x).toBe(20);
+    // The one that does fit is still held inside the board.
+    expect(updates.get('normal')?.x).toBe(20);
   });
 
   it('skips meshes when batch-resizing, since their geometry is baked', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -14,6 +14,7 @@ import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { alignSelection, distributeSelection } from '../panel/CutoutsSection/geometryAlign';
 import { expandSelectionToGroups } from '../panel/CutoutsSection/cutoutGroups';
 import { resizeAroundCenter } from '../panel/CutoutsSection/cutoutHelpers';
+import { clampToBoardAxis } from '../panel/CutoutsSection/geometry';
 import { CutoutArrayControls } from '../panel/CutoutsSection/CutoutArrayControls';
 import {
   arrayInstanceCount,
@@ -341,9 +342,8 @@ export function InspectorContent({
         );
         continue;
       }
-      // An oversize cutout leaves no valid offset on this axis; pin it to 0.
-      const limit = Math.max(0, key === 'x' ? binWidth - c.width : binDepth - c.depth);
-      updates.set(c.id, { [key]: Math.max(0, Math.min(value, limit)) });
+      const limit = key === 'x' ? binWidth - c.width : binDepth - c.depth;
+      updates.set(c.id, { [key]: clampToBoardAxis(value, 0, limit) });
     }
     if (updates.size > 0) onUpdateBatch(updates);
   };

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
@@ -92,6 +92,31 @@ describe('SingleCutoutInspector', () => {
     expect(onUpdate).toHaveBeenCalledWith('c1', { width: 156, depth: 10, x: -68, y: 5 });
   });
 
+  // #4122: a shape bigger than the board has no valid offset, so X/Y's ceiling
+  // collapses to 0. Truncating there pins the shape in the corner, and the axis
+  // the user is trying to line up is the one that stops responding.
+  it('commits a typed Y for a cutout deeper than the board', () => {
+    const onUpdate = vi.fn();
+    render(
+      <SingleCutoutInspector
+        cutout={makeCutout({ shape: 'rectangle', x: 5, y: 0, width: 10, depth: 156 })}
+        preview={new Map()}
+        binWidth={123.1}
+        binDepth={123.1}
+        maxCutDepth={20}
+        onUpdate={onUpdate}
+        disabled={false}
+      />
+    );
+
+    const input = screen.getByRole('spinbutton', { name: 'Y' });
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '12' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onUpdate).toHaveBeenCalledWith('c1', { y: 12 });
+  });
+
   // The router-bit case from the issue: only the size was meant to change, so
   // the hole must not walk out from under the part it was drilled for.
   it('holds a cutout center when a typed size changes', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -101,15 +101,18 @@ export function SingleCutoutInspector({
       <div className="-mx-4 border-b border-stroke-subtle px-4 pt-2 pb-3">
         <Collapsible title={t('binDesigner.cutouts.section.transform')} size="sm">
           <div className="grid grid-cols-2 gap-1">
-            {/* A cutout wider than the board leaves no valid offset, and a
-                negative ceiling would report a nonsense aria-valuemax — pin the
-                axis to 0 until the board grows or the cutout shrinks. */}
+            {/* softMax for the same reason W/H carry it: a shape bigger than
+                the board leaves no valid offset, and a hard ceiling then pins
+                the axis at 0 — so the shape that most needs positioning is the
+                one that cannot be moved (#4122). The off-board banner is what
+                resolves the state, by growing the bin. */}
             <NumberField
               label="X"
               value={getEffective(cutout, preview, 'x')}
               onChange={(x) => onUpdate(cutout.id, { x })}
               min={0}
               max={Math.max(0, binWidth - cutout.width)}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled}
@@ -120,6 +123,7 @@ export function SingleCutoutInspector({
               onChange={(y) => onUpdate(cutout.id, { y })}
               min={0}
               max={Math.max(0, binDepth - cutout.depth)}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled}

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -21,6 +21,7 @@ import { expandCutoutArray, expandCutoutGroup } from '@/shared/utils/cutoutArray
 import { DEFAULT_KNIFE_PRESET } from './knifeSlotPresets';
 import { KNIFE_SLOT_DEFAULT_CHAMFER, knifeSlotDimensions } from '@/features/bin-designer/types';
 import { translatePathPoints } from './pathGeometry';
+import { clampToBoardAxis } from './geometryCore';
 // Re-exported: the implementation moved to `shared/` so the variant resolver can
 // reach it, and every existing caller keeps importing it from here.
 export { resizeAroundCenter } from '@/shared/utils/cutoutResize';
@@ -97,8 +98,8 @@ export function clampedDelta(
   binDepth: number
 ): { x: number; y: number } {
   return {
-    x: Math.max(0, Math.min(original.x + dx, binWidth - original.width)),
-    y: Math.max(0, Math.min(original.y + dy, binDepth - original.depth)),
+    x: clampToBoardAxis(original.x + dx, 0, binWidth - original.width),
+    y: clampToBoardAxis(original.y + dy, 0, binDepth - original.depth),
   };
 }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.ts
@@ -21,6 +21,7 @@ export {
   clampRotationToBounds,
   getEffectiveBounds,
   computeBounds,
+  clampToBoardAxis,
   clampPosition,
   getEffectiveWidth,
   getEffectiveDepth,

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryCore.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryCore.ts
@@ -173,6 +173,21 @@ export function computeBounds(cutouts: readonly Cutout[]): Bounds {
 }
 
 /**
+ * Clamp one axis to `[min, max]`, or pass the value through when that range is
+ * empty.
+ *
+ * An empty range means the shape is bigger than the board on this axis, which
+ * the editor treats as a state to work in rather than an error: `W`/`H` are
+ * `softMax` so a measured size past the board is kept (#3061), and the off-board
+ * banner offers to grow the bin to fit. Clamping an empty range collapses to
+ * `min`, so the shape that most needs positioning is the one that cannot be
+ * moved — the axis is simply dead under the cursor (#4122).
+ */
+export function clampToBoardAxis(value: number, min: number, max: number): number {
+  return max < min ? value : Math.min(Math.max(value, min), max);
+}
+
+/**
  * Clamp a cutout position to keep it within the bin interior.
  */
 export function clampPosition(
@@ -181,8 +196,8 @@ export function clampPosition(
   binDepth: number
 ): { x: number; y: number } {
   return {
-    x: Math.max(0, Math.min(cutout.x, binWidth - cutout.width)),
-    y: Math.max(0, Math.min(cutout.y, binDepth - cutout.depth)),
+    x: clampToBoardAxis(cutout.x, 0, binWidth - cutout.width),
+    y: clampToBoardAxis(cutout.y, 0, binDepth - cutout.depth),
   };
 }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryResize.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryResize.ts
@@ -12,7 +12,7 @@
 
 import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
 import type { ResizeHandle } from './useCutoutInteraction';
-import { computeBounds, getRotatedBounds, rotatePoint } from './geometryCore';
+import { clampToBoardAxis, computeBounds, getRotatedBounds, rotatePoint } from './geometryCore';
 
 /** Minimum cutout dimension in mm */
 export const MIN_CUTOUT_SIZE = 2;
@@ -169,9 +169,10 @@ export function constrainGroupDrag(
   binDepth: number
 ): { dx: number; dy: number } {
   const bounds = computeBounds(cutouts);
-  const clampedDx = Math.max(-bounds.minX, Math.min(dx, binWidth - bounds.maxX));
-  const clampedDy = Math.max(-bounds.minY, Math.min(dy, binDepth - bounds.maxY));
-  return { dx: clampedDx, dy: clampedDy };
+  return {
+    dx: clampToBoardAxis(dx, -bounds.minX, binWidth - bounds.maxX),
+    dy: clampToBoardAxis(dy, -bounds.minY, binDepth - bounds.maxY),
+  };
 }
 
 /**

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
@@ -186,3 +186,42 @@ describe('handleDragMove polygon-mask rejection', () => {
     expect(setters.preview?.get('c-1')?.x).toBe(25);
   });
 });
+
+describe('handleDragMove on an axis with no room', () => {
+  // #4122: an imported outline is routinely deeper than the bin it lands in.
+  // The board's own controls keep that state — W/H are `softMax` and the
+  // off-board banner offers to grow the bin — so the shape has to stay
+  // draggable while it waits to be dealt with.
+  const OVERSIZED = { x: 0, y: 0, width: 20, depth: 60 };
+
+  function dragOversized(dx: number, dy: number) {
+    const cutout = makeCutout(OVERSIZED);
+    const bounds: BinBounds = {
+      binWidth: 100,
+      binDepth: 40,
+      cellMask: undefined,
+      maskCellSize: undefined,
+      meshAssets: undefined,
+    };
+    const setters = makeSetters();
+    handleDragMove(
+      makeMode(cutout.x, cutout.y, [[cutout.id, 0, 0]]),
+      { mmX: cutout.x + dx, mmY: cutout.y + dy, shiftKey: false },
+      [cutout],
+      bounds,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+    return setters.preview?.get(cutout.id);
+  }
+
+  it('still moves a cutout deeper than the board', () => {
+    expect(dragOversized(0, 12)?.y).toBeCloseTo(12, 6);
+    expect(dragOversized(0, -8)?.y).toBeCloseTo(-8, 6);
+  });
+
+  it('keeps clamping the axis that does have room', () => {
+    expect(dragOversized(500, 5)?.x).toBeCloseTo(80, 6);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -7,6 +7,7 @@
 
 import type { Cutout } from '@/features/bin-designer/types';
 import {
+  clampToBoardAxis,
   constrainGroupDrag,
   computeBounds,
   findAlignmentGuides,
@@ -80,8 +81,8 @@ export function handleDragMove(
     const maxX = bounds.binWidth - cutout.width - overhangX;
     const maxY = bounds.binDepth - cutout.depth - overhangY;
     nextPreview.set(id, {
-      x: Math.max(overhangX, Math.min(snap(mode.startX + dx + offset.dx), maxX)),
-      y: Math.max(overhangY, Math.min(snap(mode.startY + dy + offset.dy), maxY)),
+      x: clampToBoardAxis(snap(mode.startX + dx + offset.dx), overhangX, maxX),
+      y: clampToBoardAxis(snap(mode.startY + dy + offset.dy), overhangY, maxY),
     });
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.test.ts
@@ -212,6 +212,22 @@ describe('useCutoutInteraction', () => {
       expect(onUpdate).toHaveBeenCalledWith('a', expect.objectContaining({ x: 10.5 }));
     });
 
+    // #4122: the arrow keys clamp against the same empty range the drag does,
+    // so a shape deeper than the board lost its only fine-positioning control.
+    it('nudges a cutout deeper than the board', () => {
+      const tall = createCutout('tall', { y: 4, depth: 160 });
+      const { result } = renderHook(() =>
+        useCutoutInteraction({ ...defaultOpts, cutouts: [tall] })
+      );
+      act(() => result.current.selectCutout('tall', false));
+
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      });
+
+      expect(onUpdate).toHaveBeenCalledWith('tall', expect.objectContaining({ y: 4.5 }));
+    });
+
     it('nudges selected up on ArrowUp (increases model Y)', () => {
       const { result } = renderHook(() => useCutoutInteraction(defaultOpts));
       act(() => result.current.selectCutout('a', false));

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -18,7 +18,7 @@ import {
   isWithin,
   unitSelectionIds,
 } from '@/features/bin-designer/utils/cutoutHierarchy';
-import { snapToGrid, getRotatedBounds, type AlignmentGuide } from './geometry';
+import { clampToBoardAxis, snapToGrid, getRotatedBounds, type AlignmentGuide } from './geometry';
 import { cutoutFitsInMask } from './maskFit';
 import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
 import { buildSnapModel } from './handlers/rulerHandler';
@@ -243,8 +243,8 @@ export function useCutoutInteraction({
         const maxX = binWidth - cutout.width - overhangX;
         const maxY = binDepth - cutout.depth - overhangY;
         updates.set(id, {
-          x: Math.max(minX, Math.min(cutout.x + dx, maxX)),
-          y: Math.max(minY, Math.min(cutout.y + dy, maxY)),
+          x: clampToBoardAxis(cutout.x + dx, minX, maxX),
+          y: clampToBoardAxis(cutout.y + dy, minY, maxY),
         });
       }
 


### PR DESCRIPTION
A shape deeper than the bin's interior could not be moved in Y at all. The drag, the arrow keys and the Y number field were all dead, while X kept working normally. An imported outline arrives at its measured size, so this is the ordinary state right after a scan or an SVG import.

## Cause

Every clamp on the position path is written the same way:

```ts
Math.max(min, Math.min(value, max))
```

When the shape is bigger than the board on that axis, `max` falls below `min` and the expression collapses to `min` for every input. The axis stops responding, and it is precisely the axis the user is trying to line up. Five call sites shared it: the group drag constraint, the per-cutout drag clamp, the arrow-key nudge, the paste offset, and `clampPosition`.

## Fix

The editor already treats an oversized shape as a state to work in rather than an error: `W`/`H` carry `softMax` so a measured size past the board is kept (#3061), and the off-board banner offers to grow the bin to fit. Positioning now holds to the same contract.

`clampToBoardAxis` passes the value through when the range is empty and clamps normally otherwise, and the inspector's X/Y fields take `softMax` alongside W/H. `NumberField` already publishes `aria-valuemax` as `max(max, value)`, so the announced range stays valid.

"Bring back in" is unaffected: `clampOffBoardCutouts` goes through `clampCutoutToBoard` and already declines a shape it cannot seat, leaving the grow action to handle it.

## Verified

Reproduced first, at the handler: a 20x60 cutout on a 100x40 board had `y` pinned at 0 for every delta while `x` clamped correctly. Covered now at each layer that was broken — drag, arrow-key nudge, single-cutout Y field, multi-select batch X — plus the whole bin-designer suite (5978 tests), typecheck and lint.

The multi-select test that asserted the pin (`pins a batch X to 0 for a cutout wider than the board`) is inverted, since that was the bug.

Closes #4122

https://claude.ai/code/session_016wkfVEaumcLvXdbqTg1wrx


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

