### PR TITLE
fix(ui): fill the panel width with the bin dimension steppers

### DIFF
--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -23,9 +23,9 @@ export function DimensionsSection() {
   return (
     <div className="space-y-3">
       {/* Width and Depth on same row with swap button */}
-      <div className="flex items-end justify-center gap-2">
+      <div className="flex items-end gap-2">
         {/* Width */}
-        <div className="flex flex-col">
+        <div className="flex min-w-0 flex-1 flex-col">
           <span className="mb-1 block text-xs text-content-tertiary">{t('common.width')}</span>
           <Stepper
             value={state.width}
@@ -35,6 +35,7 @@ export function DimensionsSection() {
             max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
             step={state.dimensionStep}
             size={stepperSize}
+            fullWidth
             aria-label={t('common.width')}
           />
         </div>
@@ -53,7 +54,7 @@ export function DimensionsSection() {
         </IconButton>
 
         {/* Depth */}
-        <div className="flex flex-col">
+        <div className="flex min-w-0 flex-1 flex-col">
           <span className="mb-1 block text-xs text-content-tertiary">{t('common.depth')}</span>
           <Stepper
             value={state.depth}
@@ -63,6 +64,7 @@ export function DimensionsSection() {
             max={DESIGNER_CONSTRAINTS.MAX_DIMENSION}
             step={state.dimensionStep}
             size={stepperSize}
+            fullWidth
             aria-label={t('common.depth')}
           />
         </div>

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -138,9 +138,9 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
 
       <div className="space-y-4">
         {/* Size inputs with flip button between */}
-        <div className="flex items-end justify-center gap-2">
+        <div className="flex items-end gap-2">
           {/* Width control */}
-          <div className="flex flex-col">
+          <div className="flex min-w-0 flex-1 flex-col">
             <label className={`block ${labelSize} text-content-tertiary`}>
               {t('common.width')}
             </label>
@@ -153,6 +153,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
               step={stepSize}
               disabled={locked}
               size={isMobile ? 'lg' : 'md'}
+              fullWidth
               aria-label={t('common.width')}
             />
           </div>
@@ -177,7 +178,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
           </IconButton>
 
           {/* Depth control */}
-          <div className="flex flex-col">
+          <div className="flex min-w-0 flex-1 flex-col">
             <label className={`block ${labelSize} text-content-tertiary`}>
               {t('common.depth')}
             </label>
@@ -190,6 +191,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
               step={stepSize}
               disabled={locked}
               size={isMobile ? 'lg' : 'md'}
+              fullWidth
               aria-label={t('common.depth')}
             />
           </div>
@@ -250,6 +252,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
                 inputDecimals={2}
                 disabled={locked}
                 size={isMobile ? 'lg' : 'md'}
+                fullWidth
                 aria-label={t('inspector.single.heightAria')}
               />
               <div className="mt-1 text-micro text-content-disabled">{heightEquiv}</div>
@@ -283,6 +286,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
                   step={layout.heightUnitMm}
                   inputDecimals={2}
                   size={isMobile ? 'lg' : 'md'}
+                  fullWidth
                   aria-label={t('inspector.single.clearanceAria')}
                 />
                 <div className="mt-1 text-micro text-content-disabled">


### PR DESCRIPTION
The width and depth steppers sat at 96px inside a 255px panel while every control below them ran edge to edge.

`Stepper` defaults to `inline-flex`, so it hugs its content unless its parent happens to stretch it. Inside a `flex flex-col` the default `align-items: stretch` widens it back out (which is why the baseplate panel looks right despite also omitting `fullWidth`), but inside a plain block `div` or a `justify-center` row it stays at its intrinsic width.

Two rows were affected: the inspector's Width / swap / Depth row and the designer's shape section, which mirrors it. Both now use `flex-1` columns and `fullWidth` steppers, with the swap button staying fixed. The inspector's height and clearance pair gets the same treatment, so the whole dimensions block shares one column instead of leaving a full-width row above two short ones.

Measured in the inspector, panel content spans 1329 to 1584:

| control | before | after |
| --- | --- | --- |
| Width | 1337 to 1433 (96px) | 1329 to 1433 (104px) |
| Depth | 1481 to 1577 (96px) | 1481 to 1584 (104px) |
| Height | 96px | 122px |
| Clearance | 96px | 122px |

Verified at 1600px and at 390px mobile (no horizontal overflow); 274 tests across bin-inspector, bin-designer dimensions and the Stepper design-system suite pass, along with typecheck and lint.

https://claude.ai/code/session_016wkfVEaumcLvXdbqTg1wrx

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

