### PR TITLE
fix(lid): keep the stacking lip's angled support on a relieved bin

### DIFF
--- a/src/features/generation/worker/generators/lipSupportUnderLid.kernel.test.ts
+++ b/src/features/generation/worker/generators/lipSupportUnderLid.kernel.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+/**
+ * Enabling a lid must not reshape the bin's stacking lip.
+ *
+ * `lid.relieveInterior` cuts the lid's seating envelope out of the cavity as a
+ * ring whose top is the wall top. The lip reaches its deepest exactly there —
+ * `LIP_TAPER_WIDTH` in from the outer face, a small taper further than the
+ * `LIP_BIG_TAPER` line it holds higher up — so a ring started on the shallower
+ * plane cuts through the lip's angled support and leaves its underside a flat
+ * annulus at the wall top: a 90° overhang no printer can bridge (#4146).
+ *
+ * Nothing else sees it. Both bins are watertight, identically sized, and their
+ * triangle counts differ by the handful the ring's own faces contribute. So
+ * this states the lip as a DELTA against the same bin with the lid off, where
+ * the lid is the only variable and no threshold has to be chosen.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/lipSupportUnderLid.kernel
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { lidKeepoutRing } from '@/shared/constants/lidKeepout';
+import { initTestKernel } from '@/test/initTestKernel';
+import { boundingBox, verticalSolidSpans } from './__kernel-tests__/meshAssertions';
+
+let generateBin: (params: BinParams) => MeshData;
+
+beforeAll(async () => {
+  await initTestKernel();
+  generateBin = (await import('./binOrchestrator')).generateBin;
+}, 120000);
+
+const BIN: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  width: 2,
+  depth: 2,
+  height: 3,
+  base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+};
+
+const withLid = (params: BinParams, lid: Partial<BinParams['lid']>): BinParams => ({
+  ...params,
+  lid: { ...params.lid, ...lid },
+});
+
+/** Interior half-depth and wall-top Z, both read off the mesh where possible. */
+function frame(mesh: MeshData, params: BinParams): { innerHalfD: number; wallTopZ: number } {
+  return {
+    innerHalfD:
+      (params.depth * params.gridUnitMm - GRIDFINITY_SPEC.TOLERANCE) / 2 - params.wallThickness,
+    wallTopZ: boundingBox(mesh.vertices).maxZ - GRIDFINITY_SPEC.LIP_HEIGHT,
+  };
+}
+
+/**
+ * Underside of the rim material at each sampled radius, relative to the wall
+ * top. The lip's support is a 45° ramp, so a supported lip returns a
+ * descending series and a sheared one returns zeros.
+ */
+function rimUnderside(mesh: MeshData, params: BinParams, radii: readonly number[]): number[] {
+  const { innerHalfD, wallTopZ } = frame(mesh, params);
+  return radii.map((inward) => {
+    // Under the jut the column is the base socket low down and the rim up top,
+    // and the rim's own top rides the lip's sloped inner face rather than
+    // reaching the peak — so it is the highest span, not the tallest one.
+    const spans = verticalSolidSpans(mesh, 0, innerHalfD - inward);
+    const rim = spans.at(-1);
+    return rim && rim[1] > wallTopZ ? rim[0] - wallTopZ : NaN;
+  });
+}
+
+describe('stacking lip under a lid', () => {
+  // Spans the band between the two candidate lip planes (0.7mm and 1.4mm in),
+  // which is the material a ring on the shallower plane removes.
+  const RADII = [1.2, 1.0, 0.8] as const;
+
+  it('leaves the angled support identical to a bin with no lid', () => {
+    const plain = rimUnderside(generateBin(BIN), BIN, RADII);
+    // Every attachment cuts the same ring — the stage is deliberately blind to
+    // which lid you picked — so one capping lid stands for all of them.
+    const lidded = withLid(BIN, { enabled: true });
+    const relieved = rimUnderside(generateBin(lidded), lidded, RADII);
+
+    // A real ramp, not a flat underside that happens to match.
+    expect(plain[0]).toBeLessThan(-1);
+    expect(plain[0]).toBeGreaterThan(plain[2]);
+
+    for (let i = 0; i < RADII.length; i++) {
+      expect(relieved[i]).toBeCloseTo(plain[i], 3);
+    }
+  }, 300000);
+
+  it('still relieves the cavity the rail seats in', () => {
+    // The guard against "fixing" the lip by not cutting at all: a divider
+    // rising to the interior ceiling must still be taken down to the ring's
+    // floor wherever the ring passes over it.
+    const params: BinParams = {
+      ...BIN,
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+    };
+    const lidded = withLid(params, { enabled: true });
+
+    const mesh = generateBin(lidded);
+    const { innerHalfD, wallTopZ } = frame(mesh, lidded);
+    const ring = lidKeepoutRing(0, 0, params.wallThickness);
+
+    // On the divider line, one ring width inboard of the wall: inside the band.
+    const y = innerHalfD - (1.4 + ring.width / 2);
+    const top = Math.max(...verticalSolidSpans(mesh, 0, y).map(([, hi]) => hi));
+    expect(top).toBeLessThanOrEqual(wallTopZ - ring.depthBelowWallTop + 0.05);
+
+    const plainTop = Math.max(...verticalSolidSpans(generateBin(params), 0, y).map(([, hi]) => hi));
+    expect(plainTop).toBeGreaterThan(wallTopZ - GRIDFINITY_SPEC.LIP_SMALL_TAPER - 0.05);
+  }, 300000);
+});

--- a/src/shared/constants/lidKeepout.test.ts
+++ b/src/shared/constants/lidKeepout.test.ts
@@ -25,16 +25,24 @@ describe('railInboardReachMm', () => {
 describe('lidKeepoutRing', () => {
   const ring = lidKeepoutRing(INNER, INNER, 1.2);
 
-  it('starts at the stacking lip’s inner face, not the wall’s', () => {
-    // The lip juts 0.7mm into the cavity at the default wall, and the void
-    // under that jut is the undercut the rail hooks. Starting the ring here
-    // means every radius it spans has open air above it.
-    expect(ring.outerHalfX).toBeCloseTo(INNER / 2 - 0.7, 6);
-    expect(ring.outerHalfX).toBeCloseTo(INNER / 2 + 1.2 - GRIDFINITY_SPEC.LIP_BIG_TAPER, 6);
+  it('starts at the lip’s inner face on the ring’s own top plane', () => {
+    // The lip reaches deepest at the wall top, which is where the ring's top
+    // sits: 1.4mm into the cavity at the default wall, not the 0.7mm it holds
+    // a small taper higher up. Taking the shallower plane puts the cutter over
+    // the lip's angled support and shears it into a 90° overhang (#4146).
+    expect(ring.outerHalfX).toBeCloseTo(INNER / 2 - 1.4, 6);
+    expect(ring.outerHalfX).toBeCloseTo(
+      INNER / 2 + 1.2 - (GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_BIG_TAPER),
+      6
+    );
   });
 
   it('reaches past the rail’s deepest point by one clearance', () => {
-    const innerEdgeFromWall = 0.7 + ring.width;
+    // Stated from the ring's own outer boundary rather than a repeated
+    // constant: the width absorbs the lip inset, so the INNER edge lands on
+    // the rail's reach whatever plane the outer boundary is taken on. That
+    // invariant is why correcting the outer boundary cannot give up clearance.
+    const innerEdgeFromWall = INNER / 2 - (ring.outerHalfX - ring.width);
     expect(innerEdgeFromWall).toBeCloseTo(railInboardReachMm(1.2) + LID_KEEPOUT_CLEARANCE, 6);
   });
 

--- a/src/shared/constants/lidKeepout.ts
+++ b/src/shared/constants/lidKeepout.ts
@@ -99,6 +99,22 @@ export function railInboardReachMm(wallThickness: number): number {
 }
 
 /**
+ * Signed offset from the inner wall face out to the lip's inner face, at the
+ * plane the ring's top sits on (mm). Negative: the lip juts into the cavity.
+ *
+ * Measured at the WALL TOP, which is where the lip reaches deepest. Its inner
+ * face runs vertically at `LIP_TAPER_WIDTH` from the outer face for the 1.2mm
+ * under the base plane, and only above that does the small taper open it back
+ * out to `LIP_BIG_TAPER`. Taking the jut from the big taper describes the lip
+ * 0.7mm higher than anything this ring touches, and the 0.7mm of difference is
+ * the angled support — which a cutter reaching to the wall top then shears
+ * into a 90° overhang.
+ */
+function lipInsetAtWallTopMm(wallThickness: number): number {
+  return wallThickness - (GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_BIG_TAPER);
+}
+
+/**
  * Radial width of the ring, inward from the lip's inner face.
  *
  * Depends on nothing but the wall, so a polygon footprint takes the same band
@@ -107,10 +123,12 @@ export function railInboardReachMm(wallThickness: number): number {
  * {@link lidKeepoutRing}.
  */
 export function lidKeepoutWidthMm(wallThickness: number): number {
-  const lipInset = wallThickness - GRIDFINITY_SPEC.LIP_BIG_TAPER;
+  const lipInset = lipInsetAtWallTopMm(wallThickness);
   // Both terms are measured from the INNER WALL FACE while the ring starts at
   // the lip line, so the jut is already spent: `lipInset` is negative and
-  // adding it shortens the width by the head start.
+  // adding it shortens the width by the head start. That keeps the ring's INNER
+  // edge invariant under the choice of lip plane above — only its outer
+  // boundary moves — so nothing the rail needs cleared can be given up here.
   return railInboardReachMm(wallThickness) + LID_KEEPOUT_CLEARANCE + lipInset;
 }
 
@@ -119,29 +137,31 @@ export function lidKeepoutWidthMm(wallThickness: number): number {
  * sits, for a polygon edge.
  *
  * A mask outline spans the full grid-unit extent, so the bin's real outer face
- * is already `TOLERANCE / 2` inside it; the lip's inner face is a further
- * `LIP_BIG_TAPER` in. The rectangle path reaches the same line by a different
- * route (`innerW / 2 + lipInset` = `outerW / 2 - LIP_BIG_TAPER`), which is the
+ * is already `TOLERANCE / 2` inside it; the lip's inner face on the ring's top
+ * plane is a further `LIP_TAPER_WIDTH` in ({@link lipInsetAtWallTopMm}). The
+ * rectangle path reaches the same line by a different route
+ * (`innerW / 2 + lipInset` = `outerW / 2 - LIP_TAPER_WIDTH`), which is the
  * arithmetic `lidKeepoutSlabs` must agree with and the reason this is stated
  * once here.
  */
 export const LID_KEEPOUT_OUTLINE_INSET_MM =
-  GRIDFINITY_SPEC.TOLERANCE / 2 + GRIDFINITY_SPEC.LIP_BIG_TAPER;
+  GRIDFINITY_SPEC.TOLERANCE / 2 + (GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_BIG_TAPER);
 
 /**
  * Resolve the keep-out ring for a bin's interior.
  *
  * Two bounds, both chosen so the cut can never touch what makes the joint work:
  *
- * - OUTER, at the stacking lip's inner face rather than the wall's. The lip
- *   juts into the cavity by `LIP_BIG_TAPER - wallThickness` (0.7mm at the
- *   default), and the void beneath that jut IS the undercut the rail's bump
- *   hooks. Starting the ring at the wall face would put the cutter over that
- *   material, and extending it upward to cut cleanly would then shave the
- *   undercut away and quietly disable the snap. Starting at the lip line
- *   leaves open air above the ring at every radius it spans, so the top can
- *   overshoot freely. The rail's own outer face sits 0.25mm inboard of this
- *   line, so nothing is given up.
+ * - OUTER, at the stacking lip's inner face rather than the wall's, taken on
+ *   the ring's own top plane ({@link lipInsetAtWallTopMm}): 1.4mm into the
+ *   cavity at the default wall. The void beneath that jut IS the undercut the
+ *   rail's bump hooks. Starting the ring at the wall face would put the cutter
+ *   over that material, and extending it upward to cut cleanly would then
+ *   shave the undercut away and quietly disable the snap. Starting at the lip
+ *   line leaves open air above the ring at every radius it spans, so the top
+ *   can overshoot freely. The rail's own outer face sits inboard of this line,
+ *   so nothing is given up — and the band between the two planes is filled by
+ *   the lip's angled support on every bin, which a seated lid already clears.
  * - DEPTH, the rail band plus one clearance. Measured from the WALL TOP, which
  *   is what {@link LID_CLICK_RAIL_BAND_BELOW_WALL_TOP} is stated against, so a
  *   collar carries the whole envelope up with it for free.
@@ -154,19 +174,26 @@ export function lidKeepoutRing(
   wallThickness: number
 ): LidKeepoutRing {
   // Distance from the interior centre out to the lip's inner face.
-  const lipInset = wallThickness - GRIDFINITY_SPEC.LIP_BIG_TAPER;
+  const lipInset = lipInsetAtWallTopMm(wallThickness);
   const outerHalfX = innerW / 2 + lipInset;
   const outerHalfY = innerD / 2 + lipInset;
   // Inward to the rail's deepest reach, plus clearance. Subtracting `lipInset`
-  // instead of adding it makes the ring 2x0.7mm too wide, which cuts more
-  // divider than the lid needs and passes every geometry check.
+  // instead of adding it makes the ring too wide, which cuts more divider than
+  // the lid needs and passes every geometry check.
   const width = lidKeepoutWidthMm(wallThickness);
   return {
     outerHalfX,
     outerHalfY,
     width,
     depthBelowWallTop: LID_CLICK_RAIL_BAND_BELOW_WALL_TOP + LID_KEEPOUT_CLEARANCE,
-    cornerRadius: Math.max(GRIDFINITY_SPEC.BOX_CORNER_RADIUS - GRIDFINITY_SPEC.LIP_BIG_TAPER, 0),
+    // Concentric with the boundary above: a rounded rect inset by d loses d of
+    // radius, and this boundary is inset from the outer face by the same lip
+    // reach, so the ring turns the corner along the lip rather than across it.
+    cornerRadius: Math.max(
+      GRIDFINITY_SPEC.BOX_CORNER_RADIUS -
+        (GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_BIG_TAPER),
+      0
+    ),
   };
 }
 


### PR DESCRIPTION
Enabling a lid sheared the stacking lip's 45° angled support off flat at the wall top, leaving a 90° overhang around the whole rim. Reported in #4146.

## Cause

`lid.relieveInterior` (on by default for new designs) cuts the lid's seating envelope out of the cavity as a ring whose top plane is the wall top. `lidKeepoutRing` takes the ring's outer boundary at the lip's inner face, derived as `wallThickness - LIP_BIG_TAPER`, 0.7 mm into the cavity at the default wall.

That is the lip's inner face in its **vertical band**, a small taper above the plane the ring actually tops out at. On the wall top the lip reaches `LIP_TAPER_WIDTH`, 1.4 mm in. The 0.7 mm between the two planes is the angled support, so the ring's deliberate overshoot to the wall top cut straight through it.

The docstring's safety argument, that starting at the lip line "leaves open air above the ring at every radius it spans", holds only for radii inboard of 1.4 mm. Between 0.7 and 1.4 there is lip.

## Fix

Take the lip inset on the ring's own top plane. `lidKeepoutWidthMm` adds the same inset that `lidKeepoutRing` subtracts, so the ring's **inner** edge is algebraically independent of the choice: correcting the plane moves only the outer boundary and gives up no rail clearance. The band it now stops short of is filled by the lip's angled support on every bin, which a seated lid already clears.

The polygon path's `LID_KEEPOUT_OUTLINE_INSET_MM` and the ring's corner radius follow the same line, so a custom shape's bands and a corner arc stay concentric with the lip.

## Verification

Rim section on the X=0 plane, lid enabled:

| | before | after |
|---|---|---|
| z = 21.0 (wall top) | horizontal shelf jutting inboard | lip's inner face |
| below it | vertical drop to z = 19.0 | continuous 45° ramp to z = 18.2 |

Underside of the jut, relative to the wall top, sampled inboard of the wall face:

| inward | no lid | lid, before | lid, after |
|---|---|---|---|
| 1.2 mm | −1.40 | **0.00** | −1.40 |
| 1.0 mm | −1.60 | **0.00** | −1.60 |
| 0.8 mm | −1.80 | **0.00** | −1.80 |

`lipSupportUnderLid.kernel.test.ts` states this as a delta against the same bin with the lid off, so no threshold has to be chosen, and pairs it with a guard that the ring still takes a divider down to its floor. Reverting the constant fails it at 1.4 mm.

Green: `binGenerator.scenario`, `binGenerator.export`, `lidGenerator.scenario`, `lidInteriorRelief.scenario`, `lidDividerClearance.scenario`, `lidSeatInterference.matrix`, `lipSupportSeating.kernel`, `lidKeepout*` — 154 files, 1452 tests.

Closes #4146

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

