### PR TITLE
fix(bins): carry a slotted bin's divider pocket through the stacking lip

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3564`;
+exports[`bin styles > 2×2 slotted 1`] = `3540`;
 
 exports[`bin styles > 2×2 solid 1`] = `2604`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1596`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1572`;
 
 exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3608`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3564`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3540`;
 
-exports[`slotted variations > slotted with both axes 1`] = `4380`;
+exports[`slotted variations > slotted with both axes 1`] = `4332`;
 
 exports[`slotted variations > slotted without lip 1`] = `2164`;

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -177,12 +177,13 @@ function createGrooveCutter(
 /**
  * Create a mirrored pair of lip overhang cutters along one axis.
  *
- * These remove the interior lip overhang so dividers can slide in from the
- * top. Extended by SLOT_EXTENSION into the wall for volumetric fuse overlap
- * with the wall slot cutter.
+ * These carry the divider's channel through the lip zone so a piece can slide
+ * in from the top: the lip's inward jut on one side of the wall face, and the
+ * wall pocket's own depth on the other.
  */
 function createMirroredLipCutters(
   lipOverhang: number,
+  slotDepth: number,
   slotWidth: number,
   lipCutHeight: number,
   halfSpan: number,
@@ -190,16 +191,21 @@ function createMirroredLipCutters(
   lipCutStartZ: number,
   axis: 'x' | 'y'
 ): [Shape3D, Shape3D] {
-  const extOverhang = lipOverhang + SLOT_EXTENSION;
+  // Reaches `slotDepth` PAST the inner wall face, not merely up to it. The tab
+  // that engages the wall slot rides at that depth the whole way down, so a
+  // lip cut that stops at the face leaves the pocket roofed over: the wall's
+  // own top stub (the slot ends at the interior ceiling, a small taper below
+  // the wall top) and then the lip body above it. Both sit outboard of the
+  // face, and neither is visible to a check on the slot's own width.
+  const reach = lipOverhang + slotDepth;
 
-  const rectW = axis === 'x' ? extOverhang : slotWidth;
-  const rectD = axis === 'x' ? slotWidth : extOverhang;
+  const rectW = axis === 'x' ? reach : slotWidth;
+  const rectD = axis === 'x' ? slotWidth : reach;
 
-  // Lip cutter sits inside the interior: centered at halfSpan - lipOverhang/2,
-  // shifted outward by SLOT_EXTENSION/2 so the outer face extends past the
-  // inner wall surface (halfSpan) for overlap with the wall slot cutter.
-  const negCenter = -(halfSpan - lipOverhang / 2 + SLOT_EXTENSION / 2);
-  const posCenter = halfSpan - lipOverhang / 2 + SLOT_EXTENSION / 2;
+  // Centred so the cutter spans [halfSpan - lipOverhang, halfSpan + slotDepth]:
+  // the lip's inward jut on one side, the wall pocket's floor on the other.
+  const negCenter = -(halfSpan - lipOverhang / 2 + slotDepth / 2);
+  const posCenter = halfSpan - lipOverhang / 2 + slotDepth / 2;
 
   const zCenter = lipCutStartZ + lipCutHeight / 2;
   const pos = (primary: number): [number, number, number] =>
@@ -285,7 +291,7 @@ export function buildLipSlotCuts(
 
   return withScope((scope: DisposalScope): Shape3D | null => {
     const { slotConfig } = params;
-    const { slotWidth } = getEffectiveSlotDimensions(params);
+    const { slotWidth, slotDepth } = getEffectiveSlotDimensions(params);
     const lipCutStartZ = lipInfo.wallHeight - lipInfo.lipTaperWidth;
     const lipCutHeight = lipInfo.lipTaperWidth + lipInfo.lipHeight + 1;
 
@@ -296,6 +302,7 @@ export function buildLipSlotCuts(
       for (const crossPos of positions) {
         const lipCutters = createMirroredLipCutters(
           lipOverhang,
+          slotDepth,
           slotWidth,
           lipCutHeight,
           halfSpan,
@@ -404,6 +411,7 @@ function buildSlotCutsInScope(
       if (lipInfo && lipOverhang > 0) {
         const lipCutters = createMirroredLipCutters(
           lipOverhang,
+          slotDepth,
           slotWidth,
           lipCutHeight,
           halfSpan,
@@ -474,6 +482,7 @@ function buildSlotCutsInScope(
       if (lipInfo && lipOverhang > 0) {
         const [negLip, posLip] = createMirroredLipCutters(
           lipOverhang,
+          slotDepth,
           slotWidth,
           lipCutHeight,
           halfSpan,

--- a/src/features/generation/worker/generators/slottedLipPocket.kernel.test.ts
+++ b/src/features/generation/worker/generators/slottedLipPocket.kernel.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+/**
+ * A divider must be able to reach its slot past the stacking lip.
+ *
+ * The wall pocket stops at the interior ceiling and the lip-zone cutter only
+ * took the lip's inward jut, so everything OUTBOARD of the inner wall face
+ * stayed: the wall's own top stub and then the lip body above it, roofing the
+ * pocket over for the whole lip band. The slot's width and depth are correct
+ * everywhere they are measured, which is why nothing caught it (#4148).
+ *
+ * Measured as a boolean volume, never by column crossings: a slotted bin is
+ * built from box cutters, and the coincident faces those leave break the
+ * parity that `verticalSolidSpans` pairs on — it reads this bin's walls as
+ * hollow. `sharedVolume` in `__kernel-tests__/hingeSwing.ts` documents the
+ * same trap for the hinge.
+ *
+ * Stated against the same bin with no lip, so the lip is the only variable.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/slottedLipPocket.kernel
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+import type { Shape3D, ValidSolid } from 'brepjs';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { initTestKernel } from '@/test/initTestKernel';
+import { boundingBox, meshVolume } from './__kernel-tests__/meshAssertions';
+import { getEffectiveSlotDimensions } from './slotBuilder';
+
+let generateBin: (params: BinParams) => MeshData;
+let getLastSolid: () => Shape3D | null;
+
+beforeAll(async () => {
+  await initTestKernel();
+  generateBin = (await import('./binOrchestrator')).generateBin;
+  getLastSolid = (await import('./shapeCache')).getLastSolid;
+}, 120000);
+
+/**
+ * A boolean over coincident faces can legitimately produce nothing, which is
+ * the answer this probe wants: no shared volume.
+ */
+async function sharedVolume(a: Shape3D, b: Shape3D): Promise<number> {
+  const { intersect, mesh } = await import('brepjs');
+  const result = intersect(a as ValidSolid, b as ValidSolid);
+  if (!result.ok) return 0;
+  const overlap = result.value;
+  try {
+    const m = mesh(overlap, { tolerance: 0.05, angularTolerance: 10 });
+    return Math.abs(
+      meshVolume({ vertices: m.vertices, indices: m.triangles } as unknown as MeshData)
+    );
+  } finally {
+    overlap.delete();
+  }
+}
+
+function slottedBin(stackingLip: boolean): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 2,
+    depth: 2,
+    height: 3,
+    style: 'slotted',
+    base: { ...DEFAULT_BIN_PARAMS.base, stackingLip },
+    slotConfig: {
+      ...DEFAULT_BIN_PARAMS.slotConfig,
+      x: { enabled: true, pitch: 42 },
+      y: { enabled: false, pitch: 42 },
+    },
+  };
+}
+
+/**
+ * Material (mm³) standing in a divider tab's way as it is lowered into its
+ * slot, over the stretch above the divider's own resting top.
+ *
+ * The tab is modelled inset off both pocket faces, so a tangent face is not
+ * counted, and the window starts above the throat so the retention detent —
+ * which is deliberately tighter than the tab and paired with a relieved neck —
+ * is not measured as obstruction.
+ */
+async function tabObstructionMm3(params: BinParams): Promise<{ mm3: number; envelopeMm3: number }> {
+  const { box } = await import('brepjs');
+  const mesh = generateBin(params);
+  const bin = getLastSolid();
+  if (!bin) throw new Error('expected a cached bin solid');
+
+  const { slotDepth } = getEffectiveSlotDimensions(params);
+  const outerW = params.width * params.gridUnitMm - GRIDFINITY_SPEC.TOLERANCE;
+  const innerHalfW = outerW / 2 - params.wallThickness;
+  const thickness = params.dividerPieces.thickness;
+
+  const inset = 0.05;
+  const xLo = innerHalfW + inset;
+  const xHi = innerHalfW + slotDepth - inset;
+  // `getLastSolid` is the translated solid, so these are world Z.
+  const bb = boundingBox(mesh.vertices);
+  const hasLip = params.base.stackingLip;
+  const wallTopZ = bb.maxZ - (hasLip ? GRIDFINITY_SPEC.LIP_HEIGHT : 0);
+  const zLo = wallTopZ - GRIDFINITY_SPEC.LIP_SMALL_TAPER + inset;
+  const zHi = bb.maxZ + 0.1;
+
+  const tab = box(xHi - xLo, thickness, zHi - zLo, {
+    at: [(xLo + xHi) / 2, 0, (zLo + zHi) / 2],
+  });
+  try {
+    return {
+      mm3: await sharedVolume(bin, tab),
+      envelopeMm3: (xHi - xLo) * thickness * (zHi - zLo),
+    };
+  } finally {
+    tab.delete();
+  }
+}
+
+describe('slotted bin with a stacking lip', () => {
+  it('carries the divider pocket through the lip zone', async () => {
+    const lipless = await tabObstructionMm3(slottedBin(false));
+    const lipped = await tabObstructionMm3(slottedBin(true));
+
+    // The lip adds ~4x the window, so a pass here is a real measurement of the
+    // lip band and not a window that stops below it.
+    expect(lipped.envelopeMm3).toBeGreaterThan(lipless.envelopeMm3 * 3);
+
+    expect(lipless.mm3).toBeCloseTo(0, 3);
+    expect(lipped.mm3).toBeCloseTo(lipless.mm3, 3);
+  }, 300000);
+});


### PR DESCRIPTION
On a slotted bin the stacking lip roofed over the divider slots, so a piece could not be lowered into them from the top. Reported in #4148.

## Cause

The wall pocket is cut `slotDepth` past the inner wall face and stops at the interior ceiling. The lip-zone cutter took only the lip's inward jut, spanning `[halfSpan - lipOverhang, halfSpan]` — up to the wall face and no further.

Everything outboard of that face therefore survived, right where the tab rides:

- the wall's own top stub, `LIP_SMALL_TAPER` tall, between the interior ceiling and the wall top
- the lip body above it

The slot's width and depth are correct everywhere anything measures them, which is why this held for so long: the defect is in a band nothing was looking at.

## Fix

The lip cutter reaches the pocket's own floor instead of the wall face, so the channel is continuous from the divider's seat to above the lip peak. One change covers the stub and the lip body, since a single cutter spans both.

## Verification

Measured as a **boolean volume**, not by column crossings. A slotted bin is built from box cutters, and the coincident faces those leave break the parity `verticalSolidSpans` pairs on — it reads this bin's walls as hollow. `sharedVolume` in `__kernel-tests__/hingeSwing.ts` documents the same trap for the hinge.

Material in the path of a tab descending the slot, above the divider's resting top:

| | obstruction |
|---|---|
| lip on, before | **3.320 mm³** of a 4.12 mm³ envelope |
| lip on, after | 0.000 mm³ |
| no lip (control) | 0.000 mm³ |

Section through a slot: the inboard bulge from z≈20.3 to z≈24.2 is gone, leaving a straight channel.

`slottedLipPocket.kernel.test.ts` states it against the lipless bin, so the lip is the only variable, and asserts the lipped window is genuinely larger so a pass cannot come from a window that stops below the lip. Reverting the fix fails it at 3.32 mm³.

Four `triangleCount` snapshots moved, each by exactly 24 per slot axis: the stub's faces going away.

Green: `binGenerator.scenario` (102 files, 804 tests), `binGenerator.export`, `slotBuilder`, `split-slotted-lip`, `dividerRetention`, `dividerSeat` (53 files, 569 tests).

## Not changed

The reporter also asked about the narrowing at the bottom of each slot. That is the retention detent and is deliberate: `getDividerLockPlan` builds a `pocketWidth` head pocket, a narrower `throatWidth` band (1.3 mm at the 1.6 mm default divider, hence "lower than the separator thickness"), then the plain `slotWidth`. The generated divider piece is relieved to `neckWidth` (1.2 mm) across that band so the head snaps past and the throat re-closes over the neck. It only pairs with the pieces the app generates — a hand-cut separator has no neck relief.

Closes #4148

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

