### PR TITLE
fix(spacemouse): stop reading a fast horizontal spin as a pole crossing

### DIFF
--- a/src/shared/spacemouse/cameraCommands.test.ts
+++ b/src/shared/spacemouse/cameraCommands.test.ts
@@ -214,6 +214,44 @@ describe('vertical orbit limits', () => {
     expect(Math.min(...polars)).toBeCloseTo(Math.PI * 0.05, 6);
   });
 
+  it.each([1.6, 2.0, 2.5, 3.0, 5.0])(
+    'keeps the polar angle when the puck spins %s rad horizontally in one frame',
+    (orbitH) => {
+      // Pure azimuth: `applyFrameMotion` turns the offset about the up axis,
+      // which cannot change the polar angle by construction. Reading the fold
+      // off the azimuth jump alone said otherwise past a quarter turn and threw
+      // the view flat onto the pole, which is where it then stuck (#4041).
+      const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
+      camera.up.set(0, 0, 1);
+      camera.position.set(60, 0, 20);
+      const controls = aimingOrbit(camera);
+      const before = polarOf(camera, controls);
+
+      for (let i = 0; i < 8; i++) {
+        applyFrameMotion(camera, controls, { ...noMotion, orbitH });
+        expect(polarOf(camera, controls)).toBeCloseTo(before, 6);
+      }
+      expect(camera.position.length()).toBeCloseTo(Math.sqrt(60 * 60 + 20 * 20), 6);
+    }
+  );
+
+  it('still stalls at the pole when the spin is fast and the push is vertical', () => {
+    // The pair to the case above: the fold detection has to keep working while
+    // the azimuth moves fast, or the fix for one is the other's regression.
+    const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
+    camera.up.set(0, 0, 1);
+    camera.position.set(60, 0, 20);
+    const controls = aimingOrbit(camera);
+
+    const polars: number[] = [];
+    for (let i = 0; i < 40; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, orbitV: -0.15, orbitH: 1.6 });
+      polars.push(polarOf(camera, controls));
+    }
+    expect(Math.min(...polars)).toBeGreaterThanOrEqual(MIN_POLAR - 1e-9);
+    expect(polars[polars.length - 1]).toBeCloseTo(MIN_POLAR, 6);
+  });
+
   it('leaves an orbit that stays inside the limits untouched', () => {
     const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
     camera.up.set(0, 0, 1);

--- a/src/shared/spacemouse/cameraCommands.ts
+++ b/src/shared/spacemouse/cameraCommands.ts
@@ -8,7 +8,7 @@ import {
   Spherical,
   Vector3,
 } from 'three';
-import { MIN_POLAR, PAN_LEASH_RADII } from './constants';
+import { FOLD_SWEEP_TOLERANCE, MIN_POLAR, PAN_LEASH_RADII } from './constants';
 import type { CameraViewPreset, FrameMotion } from './types';
 
 /**
@@ -152,6 +152,43 @@ function visibleRadius(camera: Camera, distance: number): number {
   return Infinity;
 }
 
+type PoleCrossing = 'zenith' | 'nadir' | null;
+
+/** Which pole a known vertical step carried the view over, if either. */
+function foldFromStep(prevPhi: number, polarStep: number): PoleCrossing {
+  const intended = prevPhi + polarStep;
+  if (intended < 0) return 'zenith';
+  if (intended > Math.PI) return 'nadir';
+  return null;
+}
+
+/**
+ * Which pole a finished pose appears to have crossed, from how far the view
+ * swept getting there.
+ *
+ * Over a pole the two directions are separated by exactly the two polar angles
+ * added together, because the path runs up one meridian and down the opposite
+ * one, and every other route between the same pair is shorter. The azimuth jump
+ * on its own proves nothing: a horizontal spin past a quarter turn in a frame
+ * jumps just as far, and reading it that way threw the view flat onto the pole
+ * on motions with no vertical component in them at all.
+ *
+ * Only sound while the frame's own azimuth motion is small, which is what a
+ * pose arriving from the driver's pitch is. A caller integrating its own orbit
+ * passes the step instead and this is not consulted.
+ */
+function foldFromSweep(prevPhi: number, phi: number, swept: number): PoleCrossing {
+  const overZenith = prevPhi + phi;
+  if (overZenith <= Math.PI && Math.abs(swept - overZenith) < FOLD_SWEEP_TOLERANCE) {
+    return 'zenith';
+  }
+  const overNadir = 2 * Math.PI - overZenith;
+  if (overNadir <= Math.PI && Math.abs(swept - overNadir) < FOLD_SWEEP_TOLERANCE) {
+    return 'nadir';
+  }
+  return null;
+}
+
 /**
  * Pull a camera that has already moved back inside its canvas's navigation
  * limits, `prevOffset` being the target-to-camera vector from before the move.
@@ -160,12 +197,20 @@ function visibleRadius(camera: Camera, distance: number): number {
  * only limits the moves it makes itself: a WebHID frame integrates its own
  * orbit, and the driver hands over a finished pose. Without it the puck reaches
  * poses the mouse refuses on the same canvas.
+ *
+ * `polarStep` is the vertical orbit the caller just applied, when it applied
+ * one itself. Whether the pose went over a pole is NOT recoverable from the two
+ * poses: the folded and unfolded readings describe the same final vector, so
+ * both hypotheses predict every measurable thing about it. A caller that
+ * integrated the step knows the answer outright and should say so; one handed a
+ * finished pose has {@link foldFromSweep} to fall back on.
  */
 export function constrainPose(
   camera: Camera,
   controls: OrbitLike,
   prevOffset: Vector3,
-  contentBox?: Box3 | null
+  contentBox?: Box3 | null,
+  polarStep?: number
 ): void {
   const offset = camera.position.clone().sub(controls.target);
   const distance = offset.length();
@@ -175,20 +220,21 @@ export function constrainPose(
       camera.up.clone().normalize(),
       new Vector3(0, 1, 0)
     );
-    const spherical = new Spherical().setFromVector3(offset.applyQuaternion(toSpherical));
+    const spherical = new Spherical().setFromVector3(offset.clone().applyQuaternion(toSpherical));
     // A pose that went over a pole comes back mirrored: the polar angle folds
     // back into [0, PI] and the azimuth jumps half a turn. Unfolding it is what
     // makes the clamp below stall the orbit rather than pin it facing backwards.
-    // Half a turn of azimuth within one frame is not reachable at any puck
-    // speed, so it can only be the fold; which pole it went over is whichever
-    // unfolding continues from where the view already was.
     if (prevOffset.lengthSq() > 1e-18) {
       const prev = new Spherical().setFromVector3(prevOffset.clone().applyQuaternion(toSpherical));
-      if (Math.abs(wrapPi(spherical.theta - prev.theta)) > Math.PI / 2) {
-        const overZenith = -spherical.phi;
-        const overNadir = 2 * Math.PI - spherical.phi;
-        spherical.phi =
-          Math.abs(overZenith - prev.phi) < Math.abs(overNadir - prev.phi) ? overZenith : overNadir;
+      const crossed =
+        polarStep === undefined
+          ? foldFromSweep(prev.phi, spherical.phi, prevOffset.angleTo(offset))
+          : foldFromStep(prev.phi, polarStep);
+      if (crossed === 'zenith') {
+        spherical.phi = -spherical.phi;
+        spherical.theta = wrapPi(spherical.theta + Math.PI);
+      } else if (crossed === 'nadir') {
+        spherical.phi = 2 * Math.PI - spherical.phi;
         spherical.theta = wrapPi(spherical.theta + Math.PI);
       }
     }
@@ -286,6 +332,11 @@ export function applyFrameMotion(
     }
   }
 
-  constrainPose(camera, controls, prevOffset, contentBox);
+  // The vertical orbit is applied as a rotation about an axis perpendicular to
+  // both up and the offset, so it moves the polar angle by exactly its own
+  // value and the horizontal one cannot move it at all. That makes the pole
+  // crossing a fact here rather than something to infer from the result.
+  const polarStep = controls.enableRotate !== false ? motion.orbitV : 0;
+  constrainPose(camera, controls, prevOffset, contentBox, polarStep);
   controls.update();
 }

--- a/src/shared/spacemouse/constants.ts
+++ b/src/shared/spacemouse/constants.ts
@@ -23,6 +23,18 @@ export const ORBIT_RATE = 3.6; // radians / s
 export const MIN_POLAR = 0.01;
 
 /**
+ * How far the swept angle may sit from the over-a-pole distance and still be
+ * read as a pole crossing (radians).
+ *
+ * A crossing sweeps the two polar angles added together and every other route
+ * between the same pair is shorter, so the only competing motion is a spin of
+ * very nearly half a turn IN ONE FRAME, which closes the gap to nothing. This
+ * sits below where that becomes a risk: a 143 deg/frame spin still reads a
+ * quarter radian short, while a real crossing matches to float precision.
+ */
+export const FOLD_SWEEP_TOLERANCE = 0.01;
+
+/**
  * How far the orbit target may drift outside the model's bounding box before
  * panning stops, in model radii. One radius lets the model be pushed to the
  * edge of the viewport without letting it leave. Also capped by what the


### PR DESCRIPTION
A horizontal spin faster than a quarter turn per frame threw the view flat onto the pole, on a motion carrying no vertical component at all. Part of #4041, and the mechanism behind the "treacle then whip" tg73 reported after #4105.

## Cause

`constrainPose` decided a pose had folded over a pole from the azimuth jump alone:

```ts
if (Math.abs(wrapPi(spherical.theta - prev.theta)) > Math.PI / 2) { ... }
```

Its own justification reads "half a turn of azimuth within one frame is not reachable at any puck speed" — half a turn is π, but the test is π/2. A legitimate fast spin crosses that, and the code then mirrors the polar angle and rotates the azimuth half a turn; the clamp pins the result at `MIN_POLAR`.

Near the pole a small puck input already produces a large azimuth delta, so the threshold is crossed exactly where the reporter says it goes wrong, and since #4072 the 3Dconnexion driver owns the puck's speed, making large per-frame deltas reachable in a way they were not before.

That is both symptoms in one mechanism: pinned at `MIN_POLAR`, further vertical input does nothing (the treacle), and the next fast flick throws the view across (the whip).

Measured at the stock view, pure horizontal input, no vertical component:

| orbitH per frame | resulting polar |
|---|---|
| 1.5 rad (just under π/2) | 1.249, unchanged ✓ |
| 1.6 rad (just over) | **0.010 — slammed to the pole** |
| 1.7 rad | **0.010** |

## Fix

Which side of a pole a pose came from is **not recoverable from the two poses**: the folded and unfolded readings describe the same final vector, so both hypotheses predict every measurable thing about it. Any endpoint-only rule is a guess.

So the caller states it. `applyFrameMotion` applies the vertical orbit as a rotation about an axis perpendicular to both the up vector and the offset, which moves the polar angle by exactly its own value, while the horizontal orbit turns about the up axis and cannot move it at all. The crossing is therefore a fact at the call site, and `constrainPose` takes it as `polarStep`.

A pose arriving finished from the driver has no such step and falls back to `foldFromSweep`: over a pole the two directions are separated by exactly the two polar angles added together, because the path runs up one meridian and down the opposite one, and every other route between the same pair is shorter. That holds while the frame's own azimuth motion is small, which is what a driver pitch is — and it is the case the driver-pose test already exercises.

## Verification

- Horizontal spins of 1.6 / 2.0 / 2.5 / 3.0 / 5.0 rad per frame leave the polar angle and the orbit radius untouched over eight frames.
- A fast spin combined with a vertical push still stalls at `MIN_POLAR`, so the fix for one is not the other's regression.
- Reverting fails five of them.

Green: `src/shared/spacemouse`, `SpaceMouseController` — 14 files, 116 tests, including the existing zenith/nadir stall and driver-pose tests from #4105.

## Still open on #4041

This is the pole half. The pan leash (the model still being pushed out of frame, and the tether's snap) I have not changed, and tg73 should re-test on hardware before that half is called.

Refs #4041

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

