### PR TITLE
fix(spacemouse): keep the model in frame when the puck pans away from it

### DIFF
--- a/src/shared/spacemouse/cameraCommands.test.ts
+++ b/src/shared/spacemouse/cameraCommands.test.ts
@@ -17,7 +17,7 @@ import {
   type OrbitLike,
   presetDirection,
 } from './cameraCommands';
-import { MIN_POLAR } from './constants';
+import { MIN_POLAR, PAN_LEASH_RADII, PAN_LEASH_VIEWPORT_FRACTION } from './constants';
 import type { FrameMotion } from './types';
 
 const noMotion: FrameMotion = { panX: 0, panY: 0, zoom: 0, orbitH: 0, orbitV: 0 };
@@ -280,6 +280,12 @@ describe('pan limits', () => {
 
   it('stops panning while the model is still in frame', () => {
     const { camera } = panHard(model);
+    // The model's CENTRE, not merely some corner of its box. `intersectsBox`
+    // alone passes on a sliver clipping the frustum edge, which is exactly the
+    // state a leash of a whole model radius left it in (#4041).
+    const centre = new Vector3();
+    model.getCenter(centre);
+    expect(frustumOf(camera).containsPoint(centre)).toBe(true);
     expect(frustumOf(camera).intersectsBox(model)).toBe(true);
   });
 
@@ -288,10 +294,64 @@ describe('pan limits', () => {
     expect(frustumOf(camera).intersectsBox(model)).toBe(false);
   });
 
-  it('leashes the target to one model radius outside the content box', () => {
+  it('leashes the target to half a model radius outside the content box', () => {
     const { target } = panHard(model);
     const nearest = model.clampPoint(target, new Vector3());
-    expect(target.distanceTo(nearest)).toBeCloseTo(boundingSphere(model).radius, 6);
+    expect(target.distanceTo(nearest)).toBeCloseTo(
+      boundingSphere(model).radius * PAN_LEASH_RADII,
+      6
+    );
+  });
+
+  it('bounds the leash in absolute terms however far out the view is', () => {
+    // Zooming out raises what the viewport shows without limit, so a leash
+    // resting on that alone buys a target thousands of millimetres away — and
+    // the dolly back in then drags it home in one lurch. The model-radius term
+    // is what caps it, and this is the case that needs it.
+    const camera = new PerspectiveCamera(50, 1, 0.1, 100000);
+    camera.up.set(0, 0, 1);
+    camera.position.set(0, -300, 200);
+    const controls = aimingOrbit(camera);
+    for (let i = 0; i < 30; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, zoom: -0.1 }, model);
+    }
+    for (let i = 0; i < 200; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, panX: 8, panY: 4 }, model);
+    }
+    const nearest = model.clampPoint(controls.target, new Vector3());
+    expect(controls.target.distanceTo(nearest)).toBeCloseTo(
+      boundingSphere(model).radius * PAN_LEASH_RADII,
+      6
+    );
+
+    // And the way home is walked, not jumped.
+    let prev = controls.target.clone();
+    let worstJump = 0;
+    for (let i = 0; i < 40; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, zoom: 0.1 }, model);
+      worstJump = Math.max(worstJump, controls.target.distanceTo(prev));
+      prev = controls.target.clone();
+    }
+    expect(worstJump).toBeLessThan(boundingSphere(model).radius * 0.1);
+  });
+
+  it('keeps the model in frame when the view orbits after panning out', () => {
+    // The leash only ever fires on a pan, but orbit swings the model around a
+    // target the pan already pushed away from it.
+    const camera = new PerspectiveCamera(50, 1, 0.1, 4000);
+    camera.up.set(0, 0, 1);
+    camera.position.set(0, -300, 200);
+    const controls = aimingOrbit(camera);
+    for (let i = 0; i < 200; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, panX: 8, panY: 4 }, model);
+    }
+    const centre = new Vector3();
+    model.getCenter(centre);
+    for (let i = 0; i < 40; i++) {
+      applyFrameMotion(camera, controls, { ...noMotion, orbitH: 0.15 }, model);
+      expect(frustumOf(camera).intersectsBox(model)).toBe(true);
+    }
+    expect(frustumOf(camera).containsPoint(centre)).toBe(true);
   });
 
   it('keeps the leash positive when the driver writes inverted view extents', () => {
@@ -302,7 +362,7 @@ describe('pan limits', () => {
     controls.target.set(900, 0, 0);
     applyFrameMotion(camera, controls, { ...noMotion, panX: 1 }, model);
     const nearest = model.clampPoint(controls.target, new Vector3());
-    expect(controls.target.distanceTo(nearest)).toBeCloseTo(1, 6);
+    expect(controls.target.distanceTo(nearest)).toBeCloseTo(PAN_LEASH_VIEWPORT_FRACTION, 6);
   });
 
   it('leaves the leash to a canvas that panned, not one that forbids it', () => {

--- a/src/shared/spacemouse/cameraCommands.ts
+++ b/src/shared/spacemouse/cameraCommands.ts
@@ -8,7 +8,12 @@ import {
   Spherical,
   Vector3,
 } from 'three';
-import { FOLD_SWEEP_TOLERANCE, MIN_POLAR, PAN_LEASH_RADII } from './constants';
+import {
+  FOLD_SWEEP_TOLERANCE,
+  MIN_POLAR,
+  PAN_LEASH_RADII,
+  PAN_LEASH_VIEWPORT_FRACTION,
+} from './constants';
 import type { CameraViewPreset, FrameMotion } from './types';
 
 /**
@@ -256,7 +261,7 @@ export function constrainPose(
   if (controls.enablePan !== false && contentBox && !contentBox.isEmpty()) {
     const leash = Math.min(
       boundingSphere(contentBox).radius * PAN_LEASH_RADII,
-      visibleRadius(camera, distance)
+      visibleRadius(camera, distance) * PAN_LEASH_VIEWPORT_FRACTION
     );
     const away = controls.target.clone().sub(contentBox.clampPoint(controls.target, new Vector3()));
     const overshoot = away.length() - leash;

--- a/src/shared/spacemouse/constants.ts
+++ b/src/shared/spacemouse/constants.ts
@@ -36,11 +36,24 @@ export const FOLD_SWEEP_TOLERANCE = 0.01;
 
 /**
  * How far the orbit target may drift outside the model's bounding box before
- * panning stops, in model radii. One radius lets the model be pushed to the
- * edge of the viewport without letting it leave. Also capped by what the
- * viewport actually shows, so the leash tightens as you zoom in.
+ * panning stops. The smaller of two bounds, and each one answers a case the
+ * other cannot:
+ *
+ * - {@link PAN_LEASH_RADII}, in model radii, is the absolute bound. Without it
+ *   the leash grows with viewing distance, so zooming out first buys a target
+ *   thousands of millimetres away and the dolly back in drags it home in one
+ *   long lurch.
+ * - {@link PAN_LEASH_VIEWPORT_FRACTION}, of what the viewport shows, tightens
+ *   as you zoom in, and is what keeps a large layout pannable: a target inside
+ *   the box overshoots by nothing, so this only governs leaving the model.
+ *
+ * Both are halves rather than wholes. At a whole radius the nearest face of a
+ * small model sat right on the edge of the screen and everything past it was
+ * off, which is the "still possible to move the model out of view" in #4041 —
+ * a bound that let the model leave while reporting that it had not.
  */
-export const PAN_LEASH_RADII = 1;
+export const PAN_LEASH_RADII = 0.5;
+export const PAN_LEASH_VIEWPORT_FRACTION = 0.5;
 
 export const DEFAULT_SETTINGS: SpaceMouseSettings = {
   sensitivity: 1,


### PR DESCRIPTION
The pan leash let the model leave the view while reporting that it had not. The second half of #4041, after #4155 fixed the pole behaviour.

## Cause

`constrainPose` bounded the orbit target to `min(modelRadius × 1, visibleRadius)` outside the content box, measured from the box **surface**. At the stock view that picks the model term, so the nearest face of the model sits exactly at the edge of the screen and everything beyond it is off.

The test meant to catch this asked only `frustum.intersectsBox(model)`, which a single corner clipping the frustum edge satisfies. So a view with the model's centre off screen passed.

Measured on a 168 mm model viewed from 360 mm, after panning to the limit:

| | before | after |
|---|---|---|
| model centre in frustum | **false** | true |
| centre in frustum after a following orbit | **false** | true |
| target outside the box | 120.6 mm | 60.3 mm |

## Fix

Both bounds become halves. Keeping both matters, and I confirmed that the hard way by first trying to drop the model-radius term as redundant:

- **`PAN_LEASH_RADII`** caps the leash in absolute terms. Without it the leash grows with viewing distance, so zooming out first bought a target **1678 mm** from the model and the dolly back in dragged it home in one lurch — the worst single-frame pull went from 10.7 mm to 150.5 mm. That is a snap, not a fix.
- **`PAN_LEASH_VIEWPORT_FRACTION`** tightens as you zoom in, and is what keeps a large layout pannable: a target inside the box overshoots by nothing, so this only ever governs leaving the model behind.

With both at a half, the worst single-frame pull during a dolly home **halves**, 10.7 mm → 5.4 mm.

## Verification

- The in-frame assertion now names the model's **centre**, not merely its box.
- Orbit-after-pan is covered for the first time. The leash only ever fires on a pan, while orbit swings the model around a target the pan already pushed away — nothing checked that.
- A case pinning the absolute bound, including that the way home is walked rather than jumped, so the term cannot be dropped again.

Reverting fails the two behavioural cases. Green: `src/shared/spacemouse`, `SpaceMouseController` — 14 files, 118 tests.

## On #4041

This and #4155 cover both halves of what tg73 reported. Neither is confirmed on hardware — there is no puck or driver on any machine here — so the issue should stay open until he re-tests.

Refs #4041

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

