### PR TITLE
refactor(preview): share the ghost overlay material lifecycle

### DIFF
--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -10,15 +10,11 @@
  * Uses Line2 for proper line width support across WebGL implementations.
  */
 
-import { useMemo, useEffect, useRef } from 'react';
+import { useMemo } from 'react';
 import { baseFloorZ, baseWallHeight } from '@/features/bin-designer/utils/binDimensions';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { useDesignerStore, useCutoutSelection } from '@/features/bin-designer/store';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import { expandInteriorForOverhang } from '@/features/bin-designer/utils/binDimensions';
 import type { Cutout } from '@/features/bin-designer/types';
@@ -29,9 +25,6 @@ const GHOST_COLOR = '#fbbf24';
 const GHOST_OPACITY = 0.6;
 const LINE_WIDTH = 2;
 export function GhostCutouts() {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const {
     width,
     depth,
@@ -129,41 +122,15 @@ export function GhostCutouts() {
     return buildCutoutGeometry(cutoutsToRender, originX, originY, floorZ + fillSurface);
   }, [shouldShow, cutoutsToRender, floorZ, fillSurface, originX, originY]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      // Disable depth test so ghost lines render on top of bin walls,
-      // making cutout depth clearly visible from any angle.
-      depthTest: false,
-      depthWrite: false,
-      resolution: new THREE.Vector2(),
-    });
-  }, [shouldShow]);
-
-  useLineMaterialResolution(material);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  // Drawn through the walls so the cutout depth reads from any angle.
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+    throughSolid: true,
+  });
 
   if (!lineSegments) return null;
 
-  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
+  return <primitive object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
 }

--- a/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividers/GhostDividers.tsx
@@ -8,15 +8,11 @@
  * Uses Line2 for proper line width support across WebGL implementations.
  */
 
-import { useMemo, useEffect, useRef } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
 /** Ghost line color (matches selection ring yellow used in 2D grid editor) */
@@ -26,9 +22,6 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostDividers() {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const {
     width,
     depth,
@@ -97,41 +90,13 @@ export function GhostDividers() {
     return geo;
   }, [shouldShow, cols, rows, innerW, innerD, topZ]);
 
-  // Create material (resolution set via effect — avoids recreating on resize)
-  const material = useMemo(() => {
-    if (!shouldShow || (cols <= 1 && rows <= 1)) return null;
-
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      depthTest: true,
-      resolution: new THREE.Vector2(),
-    });
-  }, [shouldShow, cols, rows]);
-
-  useLineMaterialResolution(material);
-
-  // Dispose resources on unmount or change
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  // Invalidate frame when geometry changes
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+  });
 
   if (!lineSegments) return null;
 
-  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
+  return <primitive object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
+++ b/src/features/bin-designer/components/preview/GhostHandles/GhostHandles.tsx
@@ -5,10 +5,10 @@
  * Position math mirrors handleBuilder.ts buildHandleHoles.
  */
 
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { baseFloorZ, baseWallHeight } from '@/features/bin-designer/utils/binDimensions';
 import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useGhostMeshMaterial } from '../useGhostMeshMaterial';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
@@ -24,7 +24,6 @@ const GHOST_COLOR = '#22d3ee';
 const GHOST_OPACITY = 0.4;
 
 export function GhostHandles() {
-  const { invalidate } = useThree();
   const {
     width,
     depth,
@@ -180,27 +179,7 @@ export function GhostHandles() {
     interiorHeight,
   ]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-    return new THREE.MeshBasicMaterial({
-      color: GHOST_COLOR,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      side: THREE.DoubleSide,
-      depthTest: true,
-    });
-  }, [shouldShow]);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
+  const material = useGhostMeshMaterial(geometry, { color: GHOST_COLOR, opacity: GHOST_OPACITY });
 
   if (!geometry || !material) return null;
 

--- a/src/features/bin-designer/components/preview/GhostKnives/GhostKnives.tsx
+++ b/src/features/bin-designer/components/preview/GhostKnives/GhostKnives.tsx
@@ -14,15 +14,11 @@
  * ghost would be baked into every published knife block (CLAUDE.md #16).
  */
 
-import { useMemo, useEffect } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
+import { useMemo } from 'react';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { planKnifeRest } from '@/shared/utils/knifeRestPlan';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { PREVIEW_Z_OFFSET } from '../LidMesh/lidAnchorZ';
 import { buildKnifeGhostPositions } from './knifeGhostGeometry';
 
@@ -32,8 +28,6 @@ const GHOST_OPACITY = 0.55;
 const LINE_WIDTH = 2;
 
 export function GhostKnives() {
-  const { invalidate } = useThree();
-
   const params = useDesignerStore((s) => s.params);
 
   // No rest to plan means no open-ended slot on a solid host, so there is no
@@ -49,38 +43,14 @@ export function GhostKnives() {
     return geo;
   }, [hasRest, params]);
 
-  const material = useMemo(() => {
-    if (!geometry) return null;
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      // The blade is inside the block by design, so the profile has to draw
-      // through the solid or the only visible part is the handle.
-      depthTest: false,
-      depthWrite: false,
-      resolution: new THREE.Vector2(),
-    });
-  }, [geometry]);
-
-  useLineMaterialResolution(material);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  // The blade is inside the block by design, so the profile has to draw
+  // through the solid or the only visible part is the handle.
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+    throughSolid: true,
+  });
 
   if (!lineSegments) return null;
 

--- a/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
+++ b/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
@@ -8,10 +8,10 @@
  * Position math mirrors binGenerator.ts buildLabelTabs.
  */
 
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { baseFloorZ, baseWallHeight } from '@/features/bin-designer/utils/binDimensions';
 import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useGhostMeshMaterial } from '../useGhostMeshMaterial';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
@@ -31,8 +31,6 @@ const GHOST_COLOR = '#fbbf24';
 const GHOST_OPACITY = 0.45;
 
 export function GhostLabelTabs() {
-  const { invalidate } = useThree();
-
   const {
     width,
     depth,
@@ -322,30 +320,7 @@ export function GhostLabelTabs() {
     label.lipHeight,
   ]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-
-    return new THREE.MeshBasicMaterial({
-      color: GHOST_COLOR,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      side: THREE.DoubleSide,
-      depthTest: true,
-    });
-  }, [shouldShow]);
-
-  // Dispose resources on unmount or change
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  // Invalidate frame when geometry changes
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
+  const material = useGhostMeshMaterial(geometry, { color: GHOST_COLOR, opacity: GHOST_OPACITY });
 
   if (!geometry || !material) return null;
 

--- a/src/features/bin-designer/components/preview/GhostLidCutouts/GhostLidCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostLidCutouts/GhostLidCutouts.tsx
@@ -19,14 +19,10 @@
  *   arithmetic that CLAUDE.md gotcha #14 is about.
  */
 
-import { useMemo, useEffect, useRef } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { useDesignerStore, useCutoutSelection } from '@/features/bin-designer/store';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { lidGroupPosition } from '../LidMesh/lidAnchorZ';
 import { lidCutoutHostFace, lidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import type { Cutout } from '@/features/bin-designer/types';
@@ -43,9 +39,6 @@ interface GhostLidCutoutsProps {
 }
 
 export function GhostLidCutouts({ lidOffsetMm }: GhostLidCutoutsProps) {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const { params, generationStatus } = useDesignerStore(
     useShallow((s) => ({ params: s.params, generationStatus: s.generation.status }))
   );
@@ -101,46 +94,18 @@ export function GhostLidCutouts({ lidOffsetMm }: GhostLidCutoutsProps) {
     return buildCutoutGeometry(cutoutsToRender, originX, originY, lidCutoutHostFace(params).topZ);
   }, [window, cutoutsToRender, params]);
 
-  const material = useMemo(() => {
-    if (!geometry) return null;
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      // Through the lid's own plate, so the far outline stays readable when the
-      // lid is closed over the bin.
-      depthTest: false,
-      depthWrite: false,
-      resolution: new THREE.Vector2(),
-    });
-  }, [geometry]);
-
-  useLineMaterialResolution(material);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  // Through the lid's own plate, so the far outline stays readable when the
+  // lid is closed over the bin.
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+    throughSolid: true,
+  });
 
   if (!lineSegments) return null;
 
   return (
-    <primitive
-      ref={lineRef}
-      object={lineSegments}
-      position={[lidPosition[0], lidPosition[1], lidPosition[2]]}
-    />
+    <primitive object={lineSegments} position={[lidPosition[0], lidPosition[1], lidPosition[2]]} />
   );
 }

--- a/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
+++ b/src/features/bin-designer/components/preview/GhostScoops/GhostScoops.tsx
@@ -8,10 +8,10 @@
  * Position math mirrors binGenerator.ts buildScoopRamps.
  */
 
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { baseFloorZ, baseWallHeight } from '@/features/bin-designer/utils/binDimensions';
 import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useGhostMeshMaterial } from '../useGhostMeshMaterial';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
@@ -31,8 +31,6 @@ const GHOST_OPACITY = 0.35;
 const ARC_SEGMENTS = 16;
 
 export function GhostScoops() {
-  const { invalidate } = useThree();
-
   const {
     width,
     depth,
@@ -203,27 +201,7 @@ export function GhostScoops() {
     scoop,
   ]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-    return new THREE.MeshBasicMaterial({
-      color: GHOST_COLOR,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      side: THREE.DoubleSide,
-      depthTest: true,
-    });
-  }, [shouldShow]);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
+  const material = useGhostMeshMaterial(geometry, { color: GHOST_COLOR, opacity: GHOST_OPACITY });
 
   if (!geometry || !material) return null;
 

--- a/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
+++ b/src/features/bin-designer/components/preview/GhostSlotLines/GhostSlotLines.tsx
@@ -7,15 +7,11 @@
  * Pattern matches GhostDividers.tsx (LineSegments2 with LineMaterial).
  */
 
-import { useMemo, useEffect, useRef } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import {
   calculateSlotPositions,
@@ -29,9 +25,6 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostSlotLines() {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const {
     width,
     depth,
@@ -159,38 +152,13 @@ export function GhostSlotLines() {
     dividerPieces.clearance,
   ]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      depthTest: true,
-      resolution: new THREE.Vector2(),
-    });
-  }, [shouldShow]);
-
-  useLineMaterialResolution(material);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+  });
 
   if (!lineSegments) return null;
 
-  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
+  return <primitive object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostWallCutouts/GhostWallCutouts.tsx
@@ -7,16 +7,12 @@
  * Pattern matches GhostSlotLines.tsx (LineSegments2 with LineMaterial).
  */
 
-import { useMemo, useEffect, useRef } from 'react';
+import { useMemo } from 'react';
 import { baseWallHeight } from '@/features/bin-designer/utils/binDimensions';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import {
@@ -32,9 +28,6 @@ const GHOST_OPACITY = 0.75;
 const LINE_WIDTH = 2;
 
 export function GhostWallCutouts() {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const {
     width,
     depth,
@@ -348,38 +341,13 @@ export function GhostWallCutouts() {
     // the previous clamp.
   }, [shouldShow, walls, innerW, innerD, wallHeight, wallThickness, totalH, base.stackingLip]);
 
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      depthTest: true,
-      resolution: new THREE.Vector2(),
-    });
-  }, [shouldShow]);
-
-  useLineMaterialResolution(material);
-
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+  });
 
   if (!lineSegments) return null;
 
-  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
+  return <primitive object={lineSegments} position={[0, 0, 0.1]} renderOrder={2} />;
 }

--- a/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
+++ b/src/features/bin-designer/components/preview/GhostWireframe/GhostWireframe.tsx
@@ -8,16 +8,12 @@
  * Uses Line2 for proper line width support across WebGL implementations.
  */
 
-import { useMemo, useEffect, useRef } from 'react';
-import * as THREE from 'three';
-import { useThree } from '@react-three/fiber';
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
-import { useLineMaterialResolution } from '../useLineMaterialResolution';
+import { useGhostLineSegments } from '../useGhostLineSegments';
 
 /** Ghost line color (matches selection ring yellow used in 2D grid editor) */
 const GHOST_COLOR = '#fbbf24';
@@ -26,9 +22,6 @@ const GHOST_OPACITY = 0.85;
 const LINE_WIDTH = 2;
 
 export function GhostWireframe() {
-  const { invalidate } = useThree();
-  const lineRef = useRef<LineSegments2 | null>(null);
-
   const { width, depth, height, gridUnitMm, gridUnitMmY, heightUnitMm, generationStatus } =
     useDesignerStore(
       useShallow((s) => ({
@@ -147,41 +140,13 @@ export function GhostWireframe() {
     return geo;
   }, [shouldShow, outerW, outerD, totalH]);
 
-  // Create material (resolution set via effect — avoids recreating on resize)
-  const material = useMemo(() => {
-    if (!shouldShow) return null;
-
-    return new LineMaterial({
-      color: new THREE.Color(GHOST_COLOR).getHex(),
-      linewidth: LINE_WIDTH,
-      transparent: true,
-      opacity: GHOST_OPACITY,
-      depthTest: true,
-      resolution: new THREE.Vector2(),
-    });
-  }, [shouldShow]);
-
-  useLineMaterialResolution(material);
-
-  // Dispose resources on unmount or change
-  useEffect(() => {
-    return () => {
-      geometry?.dispose();
-      material?.dispose();
-    };
-  }, [geometry, material]);
-
-  // Invalidate frame when geometry changes
-  useEffect(() => {
-    if (geometry && material) invalidate();
-  }, [geometry, material, invalidate]);
-
-  const lineSegments = useMemo(
-    () => (geometry && material ? new LineSegments2(geometry, material) : null),
-    [geometry, material]
-  );
+  const lineSegments = useGhostLineSegments(geometry, {
+    color: GHOST_COLOR,
+    opacity: GHOST_OPACITY,
+    lineWidth: LINE_WIDTH,
+  });
 
   if (!lineSegments) return null;
 
-  return <primitive ref={lineRef} object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
+  return <primitive object={lineSegments} position={[0, 0, 0.1]} renderOrder={3} />;
 }

--- a/src/features/bin-designer/components/preview/useGhostLineSegments.test.ts
+++ b/src/features/bin-designer/components/preview/useGhostLineSegments.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
+import { useGhostLineSegments } from './useGhostLineSegments';
+
+const invalidateMock = vi.fn();
+vi.mock('@react-three/fiber', () => ({
+  useThree: () => ({ size: { width: 800, height: 600 }, invalidate: invalidateMock }),
+}));
+
+const STYLE = { color: '#fbbf24', opacity: 0.75, lineWidth: 2 };
+
+function makeGeometry() {
+  const geo = new LineSegmentsGeometry();
+  geo.setPositions([0, 0, 0, 1, 0, 0]);
+  return geo;
+}
+
+describe('useGhostLineSegments', () => {
+  beforeEach(() => invalidateMock.mockClear());
+
+  it('returns nothing without geometry and requests no frame', () => {
+    const { result } = renderHook(() => useGhostLineSegments(null, STYLE));
+    expect(result.current).toBeNull();
+    expect(invalidateMock).not.toHaveBeenCalled();
+  });
+
+  it('builds fat lines styled from the options and requests a frame', () => {
+    const geometry = makeGeometry();
+    const { result } = renderHook(() => useGhostLineSegments(geometry, STYLE));
+
+    const lines = result.current;
+    expect(lines).not.toBeNull();
+    expect(lines?.geometry).toBe(geometry);
+    expect(lines?.material.opacity).toBe(0.75);
+    expect(lines?.material.linewidth).toBe(2);
+    expect(lines?.material.depthTest).toBe(true);
+    expect(lines?.material.resolution.x).toBe(800);
+    expect(invalidateMock).toHaveBeenCalled();
+  });
+
+  it('draws through the solid when asked', () => {
+    const { result } = renderHook(() =>
+      useGhostLineSegments(makeGeometry(), { ...STYLE, throughSolid: true })
+    );
+    expect(result.current?.material.depthTest).toBe(false);
+    expect(result.current?.material.depthWrite).toBe(false);
+  });
+
+  it('disposes the geometry and material together when the geometry changes or unmounts', () => {
+    const first = makeGeometry();
+    const second = makeGeometry();
+    const firstDispose = vi.spyOn(first, 'dispose');
+    const secondDispose = vi.spyOn(second, 'dispose');
+    const { result, rerender, unmount } = renderHook(
+      ({ geometry }: { geometry: LineSegmentsGeometry }) => useGhostLineSegments(geometry, STYLE),
+      { initialProps: { geometry: first } }
+    );
+    const firstMaterial = result.current?.material;
+    const firstMaterialDispose = vi.spyOn(
+      firstMaterial as NonNullable<typeof firstMaterial>,
+      'dispose'
+    );
+
+    rerender({ geometry: second });
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(firstMaterialDispose).toHaveBeenCalledOnce();
+    expect(result.current?.material).not.toBe(firstMaterial);
+    expect(secondDispose).not.toHaveBeenCalled();
+
+    unmount();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/bin-designer/components/preview/useGhostLineSegments.ts
+++ b/src/features/bin-designer/components/preview/useGhostLineSegments.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
+import type { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
+import { useLineMaterialResolution } from './useLineMaterialResolution';
+
+export interface GhostLineStyle {
+  readonly color: string;
+  readonly opacity: number;
+  readonly lineWidth: number;
+  /** Draw through the solid (no depth test) for a feature that sits inside the body. */
+  readonly throughSolid?: boolean;
+}
+
+/**
+ * Owns the fat-line material and `LineSegments2` for a ghost outline: built
+ * alongside the geometry, kept at the canvas resolution, a frame requested when
+ * they appear, and both disposed when the geometry changes or the overlay
+ * unmounts.
+ */
+export function useGhostLineSegments(
+  geometry: LineSegmentsGeometry | null,
+  style: GhostLineStyle
+): LineSegments2 | null {
+  const { invalidate } = useThree();
+  const { color, opacity, lineWidth, throughSolid = false } = style;
+
+  const material = useMemo(() => {
+    if (!geometry) return null;
+    return new LineMaterial({
+      color: new THREE.Color(color).getHex(),
+      linewidth: lineWidth,
+      transparent: true,
+      opacity,
+      depthTest: !throughSolid,
+      depthWrite: !throughSolid,
+      resolution: new THREE.Vector2(),
+    });
+  }, [geometry, color, opacity, lineWidth, throughSolid]);
+
+  useLineMaterialResolution(material);
+
+  useEffect(() => {
+    return () => {
+      geometry?.dispose();
+      material?.dispose();
+    };
+  }, [geometry, material]);
+
+  useEffect(() => {
+    if (geometry && material) invalidate();
+  }, [geometry, material, invalidate]);
+
+  return useMemo(
+    () => (geometry && material ? new LineSegments2(geometry, material) : null),
+    [geometry, material]
+  );
+}

--- a/src/features/bin-designer/components/preview/useGhostMeshMaterial.test.ts
+++ b/src/features/bin-designer/components/preview/useGhostMeshMaterial.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import * as THREE from 'three';
+import { useGhostMeshMaterial } from './useGhostMeshMaterial';
+
+const invalidateMock = vi.fn();
+vi.mock('@react-three/fiber', () => ({
+  useThree: () => ({ size: { width: 800, height: 600 }, invalidate: invalidateMock }),
+}));
+
+const STYLE = { color: '#22d3ee', opacity: 0.4 };
+
+describe('useGhostMeshMaterial', () => {
+  beforeEach(() => invalidateMock.mockClear());
+
+  it('returns nothing without geometry and requests no frame', () => {
+    const { result } = renderHook(() => useGhostMeshMaterial(null, STYLE));
+    expect(result.current).toBeNull();
+    expect(invalidateMock).not.toHaveBeenCalled();
+  });
+
+  it('builds a translucent double-sided material and requests a frame', () => {
+    const { result } = renderHook(() => useGhostMeshMaterial(new THREE.BufferGeometry(), STYLE));
+    const material = result.current;
+    expect(material).toBeInstanceOf(THREE.MeshBasicMaterial);
+    expect(material?.opacity).toBe(0.4);
+    expect(material?.transparent).toBe(true);
+    expect(material?.side).toBe(THREE.DoubleSide);
+    expect(material?.color.getHexString()).toBe('22d3ee');
+    expect(invalidateMock).toHaveBeenCalled();
+  });
+
+  it('disposes the geometry and material together when the geometry changes or unmounts', () => {
+    const first = new THREE.BufferGeometry();
+    const second = new THREE.BufferGeometry();
+    const firstDispose = vi.spyOn(first, 'dispose');
+    const secondDispose = vi.spyOn(second, 'dispose');
+    const { result, rerender, unmount } = renderHook(
+      ({ geometry }: { geometry: THREE.BufferGeometry }) => useGhostMeshMaterial(geometry, STYLE),
+      { initialProps: { geometry: first } }
+    );
+    const firstMaterial = result.current;
+    const firstMaterialDispose = vi.spyOn(firstMaterial as THREE.MeshBasicMaterial, 'dispose');
+
+    rerender({ geometry: second });
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(firstMaterialDispose).toHaveBeenCalledOnce();
+    expect(result.current).not.toBe(firstMaterial);
+
+    unmount();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/bin-designer/components/preview/useGhostMeshMaterial.ts
+++ b/src/features/bin-designer/components/preview/useGhostMeshMaterial.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+
+export interface GhostMeshStyle {
+  readonly color: string;
+  readonly opacity: number;
+}
+
+/**
+ * Owns the translucent material for a ghost mesh: built alongside the
+ * geometry, a frame requested when they appear, and both disposed when the
+ * geometry changes or the overlay unmounts.
+ */
+export function useGhostMeshMaterial(
+  geometry: THREE.BufferGeometry | null,
+  style: GhostMeshStyle
+): THREE.MeshBasicMaterial | null {
+  const { invalidate } = useThree();
+  const { color, opacity } = style;
+
+  const material = useMemo(() => {
+    if (!geometry) return null;
+    return new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      side: THREE.DoubleSide,
+      depthTest: true,
+    });
+  }, [geometry, color, opacity]);
+
+  useEffect(() => {
+    return () => {
+      geometry?.dispose();
+      material?.dispose();
+    };
+  }, [geometry, material]);
+
+  useEffect(() => {
+    if (geometry && material) invalidate();
+  }, [geometry, material, invalidate]);
+
+  return material;
+}


### PR DESCRIPTION
Ten ghost overlays in the bin designer preview each carried the same 30-line block: build a material when the geometry exists, keep the fat-line resolution current, dispose geometry and material together, and request a frame when they appear. jscpd flagged this family as the densest clone cluster in `src/` after the preview chrome.

**Two hooks next to `useLineMaterialResolution`**

- `useGhostLineSegments(geometry, style)` owns the `LineMaterial` and the `LineSegments2` for a fat-line ghost. `style.throughSolid` covers the three overlays that disable the depth test to draw inside the body (knives, cutouts, lid cutouts); the reasons for that stay as comments at the call sites.
- `useGhostMeshMaterial(geometry, style)` owns the translucent double-sided `MeshBasicMaterial` for the mesh ghosts (handles, label tabs, scoops).

Both hooks key the material on the geometry rather than on `shouldShow`. The old dispose effect ran on every geometry change and disposed the still-live material along with the old geometry, then kept rendering with it; three.js tolerates that by recompiling, but the pair now changes and disposes together. Per-overlay colours, opacities and line widths are unchanged and stay in their files.

Also drops the `lineRef` that six overlays attached to their `<primitive>` and never read.

**Verification**

- Typecheck, lint, module boundaries, design-system and component-structure gates pass.
- Vitest across the whole preview folder: 51 files, 324 tests. The hooks have their own tests against real three.js objects (material options, through-solid flags, paired disposal on geometry change and on unmount, frame invalidation).

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

