### PR TITLE
refactor(shared): share the anchored overflow menu behaviour

### DIFF
--- a/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
+++ b/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
@@ -16,7 +16,7 @@ import { useToastStore } from '@/core/store/toast';
 import { useMutations } from '@/shared/contexts';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
-import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
+import { useAnchoredMenu } from '@/shared/hooks/useAnchoredMenu';
 import { useResponsive } from '@/shared/hooks';
 import { Button, IconButton, Input, XIcon, useInlineEdit } from '@/design-system';
 import type { BaseplateDesignId } from '@/core/types';
@@ -353,53 +353,15 @@ function BaseplateCardActions({
 }: BaseplateCardActionsProps) {
   const t = useTranslation();
   const { isMobile } = useResponsive();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
-  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
-
-  useEffect(() => {
-    if (!isMenuOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(e.target as Node) &&
-        menuButtonRef.current &&
-        !menuButtonRef.current.contains(e.target as Node)
-      ) {
-        setIsMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isMenuOpen]);
-
-  const handleMenuToggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isMenuOpen) {
-      setIsMenuOpen(false);
-      return;
-    }
-    const button = menuButtonRef.current;
-    if (button) {
-      const rect = button.getBoundingClientRect();
-      const openAbove = window.innerHeight - rect.bottom < 200;
-      setMenuStyle({
-        position: 'fixed',
-        right: window.innerWidth - rect.right,
-        ...(openAbove ? { bottom: window.innerHeight - rect.top + 4 } : { top: rect.bottom + 4 }),
-      });
-    }
-    setIsMenuOpen(true);
-  };
-
-  const handleAction = (action: () => void) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    action();
-    setIsMenuOpen(false);
-  };
+  const {
+    isOpen: isMenuOpen,
+    menuStyle,
+    menuButtonRef,
+    menuRef,
+    toggle: handleMenuToggle,
+    withClose: handleAction,
+    onMenuKeyDown,
+  } = useAnchoredMenu();
 
   return (
     <div className="relative" role="presentation" onClick={(e) => e.stopPropagation()}>

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from '@/i18n';
-import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
+import { useAnchoredMenu } from '@/shared/hooks/useAnchoredMenu';
 import { Button, IconButton } from '@/design-system';
 import { useTwoClickDelete } from '@/shared/components';
 import type { SavedDesign } from '../../types';
@@ -38,72 +37,25 @@ export function DesignActions({
   onDelete,
 }: DesignActionsProps) {
   const t = useTranslation();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
-  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
+  const {
+    isOpen: isMenuOpen,
+    menuStyle,
+    menuButtonRef,
+    menuRef,
+    toggle: handleMenuToggle,
+    close: closeMenu,
+    withClose: handleAction,
+    onMenuKeyDown,
+  } = useAnchoredMenu({ onClose: () => resetDelete() });
 
-  // Two-click delete state
   const {
     isConfirming: isConfirmingDelete,
     handleClick: handleDeleteClick,
     reset: resetDelete,
   } = useTwoClickDelete(() => {
     onDelete();
-    setIsMenuOpen(false);
+    closeMenu();
   });
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(e.target as Node) &&
-        menuButtonRef.current &&
-        !menuButtonRef.current.contains(e.target as Node)
-      ) {
-        setIsMenuOpen(false);
-        resetDelete();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isMenuOpen, resetDelete]);
-
-  const handleMenuToggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    if (isMenuOpen) {
-      setIsMenuOpen(false);
-      resetDelete();
-    } else {
-      const button = menuButtonRef.current;
-      if (button) {
-        const rect = button.getBoundingClientRect();
-        const spaceBelow = window.innerHeight - rect.bottom;
-        const openAbove = spaceBelow < 200;
-
-        setMenuStyle({
-          position: 'fixed',
-          right: window.innerWidth - rect.right,
-          ...(openAbove ? { bottom: window.innerHeight - rect.top + 4 } : { top: rect.bottom + 4 }),
-        });
-      }
-      setIsMenuOpen(true);
-    }
-  };
-
-  const handleAction = (action: () => void) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    action();
-    setIsMenuOpen(false);
-    resetDelete();
-  };
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -204,7 +156,7 @@ export function DesignActions({
                 variant="ghost"
                 fullWidth
                 role="menuitem"
-                onClick={handleAction(onDownloadJSON ?? (() => {}))}
+                onClick={handleAction(onDownloadJSON)}
                 className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
               >
                 <svg

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { LayoutEntry } from '@/core/types';
 import { useTranslation } from '@/i18n';
-import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
+import { useAnchoredMenu } from '@/shared/hooks/useAnchoredMenu';
 import { useTwoClickDelete } from '@/shared/components';
 import { Button, IconButton } from '@/design-system';
 
@@ -33,76 +32,29 @@ export function LayoutActions({
   onMoveToFolder,
 }: LayoutActionsProps) {
   const t = useTranslation();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
-  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
+  const {
+    isOpen: isMenuOpen,
+    menuStyle,
+    menuButtonRef,
+    menuRef,
+    toggle: handleMenuToggle,
+    close: closeMenu,
+    withClose: handleAction,
+    onMenuKeyDown,
+  } = useAnchoredMenu({ onClose: () => resetDelete() });
 
-  // Two-click delete state
   const {
     isConfirming: isConfirmingDelete,
     handleClick: handleDeleteClick,
     reset: resetDelete,
   } = useTwoClickDelete(() => {
     onDelete();
-    setIsMenuOpen(false);
+    closeMenu();
   });
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(e.target as Node) &&
-        menuButtonRef.current &&
-        !menuButtonRef.current.contains(e.target as Node)
-      ) {
-        setIsMenuOpen(false);
-        resetDelete();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isMenuOpen, resetDelete]);
-
-  const handleMenuToggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    if (isMenuOpen) {
-      setIsMenuOpen(false);
-      resetDelete();
-    } else {
-      // Calculate fixed position based on button location
-      const button = menuButtonRef.current;
-      if (button) {
-        const rect = button.getBoundingClientRect();
-        const spaceBelow = window.innerHeight - rect.bottom;
-        const openAbove = spaceBelow < 200;
-
-        setMenuStyle({
-          position: 'fixed',
-          right: window.innerWidth - rect.right,
-          ...(openAbove ? { bottom: window.innerHeight - rect.top + 4 } : { top: rect.bottom + 4 }),
-        });
-      }
-      setIsMenuOpen(true);
-    }
-  };
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
     handleDeleteClick();
-  };
-
-  const handleAction = (action: () => void) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    action();
-    setIsMenuOpen(false);
   };
 
   return (

--- a/src/shared/hooks/useAnchoredMenu.test.tsx
+++ b/src/shared/hooks/useAnchoredMenu.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useAnchoredMenu } from './useAnchoredMenu';
+
+function Harness({ onClose, onPick }: { onClose?: () => void; onPick?: () => void }) {
+  const { isOpen, menuStyle, menuButtonRef, menuRef, toggle, withClose, onMenuKeyDown } =
+    useAnchoredMenu({ onClose });
+  return (
+    <div>
+      <button ref={menuButtonRef} onClick={toggle} aria-expanded={isOpen}>
+        more
+      </button>
+      {isOpen && (
+        <div ref={menuRef} role="menu" tabIndex={-1} style={menuStyle} onKeyDown={onMenuKeyDown}>
+          <button role="menuitem" onClick={withClose(() => onPick?.())}>
+            pick
+          </button>
+        </div>
+      )}
+      <span data-testid="outside">outside</span>
+    </div>
+  );
+}
+
+function rectAt(top: number): DOMRect {
+  return { top, bottom: top + 20, right: 300, left: 260, width: 40, height: 20 } as DOMRect;
+}
+
+describe('useAnchoredMenu', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+    Object.defineProperty(window, 'innerWidth', { value: 1000, configurable: true });
+  });
+
+  it('opens below the button, right-aligned, with a fixed position', () => {
+    render(<Harness />);
+    const button = screen.getByRole('button', { name: 'more' });
+    vi.spyOn(button, 'getBoundingClientRect').mockReturnValue(rectAt(100));
+
+    fireEvent.click(button);
+
+    const menu = screen.getByRole('menu');
+    expect(menu.style.position).toBe('fixed');
+    expect(menu.style.right).toBe('700px');
+    expect(menu.style.top).toBe('124px');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('opens above the button when there is little room below', () => {
+    render(<Harness />);
+    const button = screen.getByRole('button', { name: 'more' });
+    vi.spyOn(button, 'getBoundingClientRect').mockReturnValue(rectAt(700));
+
+    fireEvent.click(button);
+
+    const menu = screen.getByRole('menu');
+    expect(menu.style.bottom).toBe('104px');
+    expect(menu.style.top).toBe('');
+  });
+
+  it('closes on a click outside and reports it', () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'more' }));
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('stays open on a mousedown inside the menu', () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: 'more' }));
+
+    fireEvent.mouseDown(screen.getByRole('menuitem'));
+
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('runs an item action, then closes and reports it', () => {
+    const onClose = vi.fn();
+    const onPick = vi.fn();
+    render(<Harness onClose={onClose} onPick={onPick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'more' }));
+
+    fireEvent.click(screen.getByRole('menuitem'));
+
+    expect(onPick).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('toggles closed from the button and reports it', () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    const button = screen.getByRole('button', { name: 'more' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/hooks/useAnchoredMenu.ts
+++ b/src/shared/hooks/useAnchoredMenu.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
+import { useMenuKeyboardNav } from './useMenuKeyboardNav';
+
+interface UseAnchoredMenuOptions {
+  /** Runs on every close, whichever way it happens: toggle, click outside, Escape or an item. */
+  onClose?: () => void;
+}
+
+/** Below this much room under the button the menu opens upward instead. */
+const MIN_SPACE_BELOW_PX = 200;
+const GAP_PX = 4;
+
+/**
+ * An overflow menu portaled next to its button. The position is fixed so the
+ * menu escapes a modal's transform, and it is measured on open rather than
+ * tracked, so a scroll while open leaves it where it was.
+ */
+export function useAnchoredMenu({ onClose }: UseAnchoredMenuOptions = {}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>({});
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    onCloseRef.current?.();
+  }, []);
+
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen, menuRef, onClose: close });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        menuButtonRef.current &&
+        !menuButtonRef.current.contains(e.target as Node)
+      ) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen, close]);
+
+  const toggle = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      if (isOpen) {
+        close();
+        return;
+      }
+      const button = menuButtonRef.current;
+      if (button) {
+        const rect = button.getBoundingClientRect();
+        const openAbove = window.innerHeight - rect.bottom < MIN_SPACE_BELOW_PX;
+        setMenuStyle({
+          position: 'fixed',
+          right: window.innerWidth - rect.right,
+          ...(openAbove
+            ? { bottom: window.innerHeight - rect.top + GAP_PX }
+            : { top: rect.bottom + GAP_PX }),
+        });
+      }
+      setIsOpen(true);
+    },
+    [isOpen, close]
+  );
+
+  const withClose = useCallback(
+    (action: () => void) => (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      action();
+      close();
+    },
+    [close]
+  );
+
+  return { isOpen, menuStyle, menuButtonRef, menuRef, toggle, close, withClose, onMenuKeyDown };
+}


### PR DESCRIPTION
Three overflow menus (design actions, layout actions, baseplate card actions) each carried the same 60-line state machine: open state, a fixed position measured from the button that flips upward when fewer than 200px remain below, a `mousedown` listener that closes on a click outside either the button or the menu, keyboard navigation via `useMenuKeyboardNav`, and a "run the action, then close" wrapper for menu items. jscpd flagged the design/layout pair as the third-largest clone in `src/`.

**`useAnchoredMenu` in `shared/hooks`**

Returns `isOpen`, `menuStyle`, the two refs, `toggle`, `close`, `withClose(action)` and `onMenuKeyDown`. The optional `onClose` runs on every close path. The two menus with a two-click delete pass their `resetDelete` there, which closes a small inconsistency in the originals: closing with Escape, or picking another item in the layout menu, used to leave the delete button armed.

The rendering of each menu (buttons, icons, labels, class names) is untouched; only the plumbing moved. The hook keeps the original click-outside condition, which requires both elements to be mounted before it closes.

**Verification**

- Typecheck, lint, module boundaries and design-system gates pass. The `react-hooks/refs` rule requires consumers to destructure the hook result, which all three do.
- Vitest across the hook, the three consumers and the design list dialog and layout manager modal that host them: 32 files, 369 tests. The hook has its own tests for placement below and above, click outside, mousedown inside, item pick, and toggle close, each asserting the `onClose` count.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

