### PR TITLE
refactor(cutouts): share the shape renderers' pointer and colour plumbing

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
@@ -6,10 +6,9 @@
  * coordinates (mm, Y-up).
  */
 
-import { memo, useMemo, useRef, useEffect, useState } from 'react';
+import { memo, useMemo, useRef, useEffect } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
-import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import {
   sdfVertexShader,
@@ -19,20 +18,18 @@ import {
 } from './shapeGeometry';
 import {
   RENDER_ORDER,
-  ACCENT_COLOR_HEX,
   STROKE_WIDTH_SELECTED_PX,
   STROKE_WIDTH_DEFAULT_PX,
   STROKE_WIDTH_HOVER_PX,
   STROKE_WIDTH_GROUPED_PX,
 } from './constants';
+import { useShapePointerHandlers, useShapeColors, STROKE_SELECTED } from './shapeInteraction';
 import { shapePosZ, shapeRenderOrder } from './zLayer';
 import { PathShapeMesh } from './PathShapeMesh';
 import { PolygonShapeMesh } from './PolygonShapeMesh';
 import { MeshFootprintMesh } from './MeshFootprintMesh';
 import { TextElementMesh } from './TextElementMesh';
 import { slotCornerRadius } from '@/shared/utils/cutoutPolygon';
-
-const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
 /** Render mode for grouped cutout visual merge via stencil buffer */
 export type ShapeRenderMode = 'normal' | 'fill' | 'stroke';
@@ -144,7 +141,20 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
 }: CutoutShapeMeshProps) {
   const meshRef = useRef<THREE.Mesh>(null);
   const materialRef = useRef<THREE.ShaderMaterial>(null);
-  const [isHovered, setIsHovered] = useState(false);
+  const {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  } = useShapePointerHandlers({
+    cutoutId: cutout.id,
+    isSelected,
+    disablePointerEvents,
+    onSelect,
+    onDragStart,
+    onDoubleClick,
+  });
   const { camera } = useThree();
   const zoom = camera.zoom;
 
@@ -155,14 +165,7 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
   );
 
   // Cutout colors derived from the bin surface color
-  const { cutFillColor, strokeDefault, strokeHover } = useMemo(() => {
-    const base = new THREE.Color(binColor);
-    return {
-      cutFillColor: base.clone().multiplyScalar(0.7), // darkened — bottom of cut
-      strokeDefault: base.clone().multiplyScalar(0.5), // outline for contrast
-      strokeHover: base.clone().multiplyScalar(0.4), // darker on hover
-    };
-  }, [binColor]);
+  const { cutFillColor, strokeDefault, strokeHover } = useShapeColors(binColor);
 
   // Visual styling — screen-space stroke width converted to world mm
   const fillOpacity = isDragging ? 0.85 : 0.95; // Opaque — these are physical cuts
@@ -278,34 +281,6 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
   // Rotation in radians around Z axis
   // SVG used clockwise degrees; Three.js uses counter-clockwise radians
   const rotationZ = -(effective.rotation * Math.PI) / 180;
-
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    if (e.nativeEvent.button !== 0) return; // Only left-click
-    if (disablePointerEvents) return; // Let click fall through to background
-    e.stopPropagation();
-    const additive = e.nativeEvent.shiftKey;
-    onSelect(cutout.id, additive);
-
-    if (onDragStart && !additive) {
-      onDragStart(cutout.id, e.point.x, e.point.y, e.nativeEvent.altKey);
-    }
-  };
-
-  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    onDoubleClick?.(cutout.id);
-  };
-
-  const handlePointerEnter = () => {
-    if (!isSelected) {
-      setIsHovered(true);
-    }
-  };
-
-  const handlePointerLeave = () => {
-    setIsHovered(false);
-  };
 
   const renderBand =
     renderMode === 'fill'

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
@@ -7,15 +7,13 @@
  * itself is derived from the mesh and never point-edited or resized.
  */
 
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { RENDER_ORDER } from './constants';
+import { useShapePointerHandlers, useShapeColors, pickStrokeColor } from './shapeInteraction';
 import { shapePosZ, shapeRenderOrder } from './zLayer';
-
-const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
 interface MeshFootprintMeshProps {
   readonly cutout: Cutout;
@@ -42,20 +40,26 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
   onDragStart,
   disablePointerEvents,
 }: MeshFootprintMeshProps) {
-  const [isHovered, setIsHovered] = useState(false);
+  const {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  } = useShapePointerHandlers({
+    cutoutId: cutout.id,
+    isSelected,
+    disablePointerEvents,
+    onSelect,
+    onDragStart,
+    onDoubleClick,
+  });
   const asset = useDesignerStore((s) =>
     cutout.meshId !== undefined ? s.params.meshAssets?.[cutout.meshId] : undefined
   );
 
-  const { cutFillColor, strokeDefault, strokeGrouped, strokeHover } = useMemo(() => {
-    const base = new THREE.Color(binColor);
-    return {
-      cutFillColor: base.clone().multiplyScalar(0.7),
-      strokeDefault: base.clone().multiplyScalar(0.5),
-      strokeGrouped: base.clone().multiplyScalar(0.35),
-      strokeHover: base.clone().multiplyScalar(0.4),
-    };
-  }, [binColor]);
+  const shapeColors = useShapeColors(binColor);
+  const { cutFillColor } = shapeColors;
 
   // Fill: one triangulated ShapeGeometry per outline ring, in a local frame
   // centered on the footprint (rings live in asset space [0..w]×[0..d]).
@@ -113,30 +117,7 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
   // smaller-shape-wins tiebreaker instead of pinning to its layer floor.
   const area = effective.width * effective.depth;
 
-  const strokeColor = isSelected
-    ? STROKE_SELECTED
-    : isHovered
-      ? strokeHover
-      : isGrouped
-        ? strokeGrouped
-        : strokeDefault;
-
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    if (e.nativeEvent.button !== 0) return;
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    const additive = e.nativeEvent.shiftKey;
-    onSelect(cutout.id, additive);
-    if (onDragStart && !additive) {
-      onDragStart(cutout.id, e.point.x, e.point.y, e.nativeEvent.altKey);
-    }
-  };
-
-  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    onDoubleClick?.(cutout.id);
-  };
+  const strokeColor = pickStrokeColor({ isSelected, isHovered, isGrouped }, shapeColors);
 
   return (
     <group
@@ -149,10 +130,8 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
         renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
         onPointerDown={handlePointerDown}
         onDoubleClick={handleDoubleClick}
-        onPointerEnter={() => {
-          if (!isSelected) setIsHovered(true);
-        }}
-        onPointerLeave={() => setIsHovered(false)}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
       >
         <meshBasicMaterial
           color={cutFillColor}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
@@ -6,12 +6,12 @@
  * coordinates (mm, Y-up).
  */
 
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { flattenPath, triangulatePath, getPathBounds, MIN_PATH_POINTS } from '../pathGeometry';
-import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { RENDER_ORDER } from './constants';
+import { useShapePointerHandlers, useShapeColors, pickStrokeColor } from './shapeInteraction';
 import { shapePosZ, shapeRenderOrder } from './zLayer';
 import {
   outlineVertexShader as pathVertexShader,
@@ -19,8 +19,6 @@ import {
   bakeDistanceField,
   MIN_POLYLINE_POINTS,
 } from './outlineShapeGeometry';
-
-const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
 interface PathShapeMeshProps {
   readonly cutout: Cutout;
@@ -48,7 +46,20 @@ export const PathShapeMesh = memo(function PathShapeMesh({
   onDragStart,
   disablePointerEvents,
 }: PathShapeMeshProps) {
-  const [isHovered, setIsHovered] = useState(false);
+  const {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  } = useShapePointerHandlers({
+    cutoutId: cutout.id,
+    isSelected,
+    disablePointerEvents,
+    onSelect,
+    onDragStart,
+    onDoubleClick,
+  });
 
   const path = cutout.path;
 
@@ -59,15 +70,8 @@ export const PathShapeMesh = memo(function PathShapeMesh({
   );
 
   // Cutout colors derived from the bin surface color
-  const { cutFillColor, strokeDefault, strokeGrouped, strokeHover } = useMemo(() => {
-    const base = new THREE.Color(binColor);
-    return {
-      cutFillColor: base.clone().multiplyScalar(0.7), // darkened — bottom of cut
-      strokeDefault: base.clone().multiplyScalar(0.5), // outline for contrast
-      strokeGrouped: base.clone().multiplyScalar(0.35), // darker for grouped emphasis
-      strokeHover: base.clone().multiplyScalar(0.4), // darker on hover
-    };
-  }, [binColor]);
+  const shapeColors = useShapeColors(binColor);
+  const { cutFillColor } = shapeColors;
 
   // Geometry center from committed path — stable reference for local coords
   const { geoCenterX, geoCenterY, area } = useMemo(() => {
@@ -199,43 +203,9 @@ export const PathShapeMesh = memo(function PathShapeMesh({
     return null;
 
   const effective = previewOverrides ? { ...cutout, ...previewOverrides } : cutout;
-  const strokeColor = isSelected
-    ? STROKE_SELECTED
-    : isHovered
-      ? strokeHover
-      : isGrouped
-        ? strokeGrouped
-        : strokeDefault;
+  const strokeColor = pickStrokeColor({ isSelected, isHovered, isGrouped }, shapeColors);
   const rotationZ = -(effective.rotation * Math.PI) / 180;
   const posZ = shapePosZ(cutout.zIndex, area);
-
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    if (e.nativeEvent.button !== 0) return;
-    if (disablePointerEvents) return; // Let click fall through to background
-    e.stopPropagation();
-    const additive = e.nativeEvent.shiftKey;
-    onSelect(cutout.id, additive);
-
-    if (onDragStart && !additive) {
-      onDragStart(cutout.id, e.point.x, e.point.y, e.nativeEvent.altKey);
-    }
-  };
-
-  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    onDoubleClick?.(cutout.id);
-  };
-
-  const handlePointerEnter = () => {
-    if (!isSelected) {
-      setIsHovered(true);
-    }
-  };
-
-  const handlePointerLeave = () => {
-    setIsHovered(false);
-  };
 
   return (
     <group

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
@@ -6,14 +6,14 @@
  * paths via the shared `outlineShapeGeometry` helpers.
  */
 
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { DEFAULT_POLYGON_SIDES } from '@/features/bin-designer/types';
 import { regularPolygonPoints, clampPolygonSides } from '@/shared/utils/cutoutPolygon';
 import { triangulatePath } from '../pathGeometry';
-import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { RENDER_ORDER } from './constants';
+import { useShapePointerHandlers, useShapeColors, pickStrokeColor } from './shapeInteraction';
 import { shapePosZ, shapeRenderOrder } from './zLayer';
 import {
   outlineVertexShader,
@@ -21,8 +21,6 @@ import {
   bakeDistanceField,
   MIN_POLYLINE_POINTS,
 } from './outlineShapeGeometry';
-
-const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
 interface PolygonShapeMeshProps {
   readonly cutout: Cutout;
@@ -49,7 +47,20 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
   onDragStart,
   disablePointerEvents,
 }: PolygonShapeMeshProps) {
-  const [isHovered, setIsHovered] = useState(false);
+  const {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  } = useShapePointerHandlers({
+    cutoutId: cutout.id,
+    isSelected,
+    disablePointerEvents,
+    onSelect,
+    onDragStart,
+    onDoubleClick,
+  });
 
   const effective = useMemo(
     () => (previewOverrides ? { ...cutout, ...previewOverrides } : cutout),
@@ -72,15 +83,8 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
   const centerY = effective.y + effective.depth / 2;
   const area = effective.width * effective.depth;
 
-  const { cutFillColor, strokeDefault, strokeGrouped, strokeHover } = useMemo(() => {
-    const base = new THREE.Color(binColor);
-    return {
-      cutFillColor: base.clone().multiplyScalar(0.7),
-      strokeDefault: base.clone().multiplyScalar(0.5),
-      strokeGrouped: base.clone().multiplyScalar(0.35),
-      strokeHover: base.clone().multiplyScalar(0.4),
-    };
-  }, [binColor]);
+  const shapeColors = useShapeColors(binColor);
+  const { cutFillColor } = shapeColors;
 
   const fillGeometry = useMemo(() => {
     if (points.length < MIN_POLYLINE_POINTS) return null;
@@ -149,32 +153,9 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
 
   if (points.length < MIN_POLYLINE_POINTS) return null;
 
-  const strokeColor = isSelected
-    ? STROKE_SELECTED
-    : isHovered
-      ? strokeHover
-      : isGrouped
-        ? strokeGrouped
-        : strokeDefault;
+  const strokeColor = pickStrokeColor({ isSelected, isHovered, isGrouped }, shapeColors);
   const rotationZ = -(effective.rotation * Math.PI) / 180;
   const posZ = shapePosZ(cutout.zIndex, area);
-
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    if (e.nativeEvent.button !== 0) return;
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    const additive = e.nativeEvent.shiftKey;
-    onSelect(cutout.id, additive);
-    if (onDragStart && !additive) {
-      onDragStart(cutout.id, e.point.x, e.point.y, e.nativeEvent.altKey);
-    }
-  };
-
-  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    onDoubleClick?.(cutout.id);
-  };
 
   return (
     <group
@@ -189,8 +170,8 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
           renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
           onPointerDown={handlePointerDown}
           onDoubleClick={handleDoubleClick}
-          onPointerEnter={() => !isSelected && setIsHovered(true)}
-          onPointerLeave={() => setIsHovered(false)}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={handlePointerLeave}
         />
       )}
       {strokeGeometry && (

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/TextElementMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/TextElementMesh.tsx
@@ -9,14 +9,12 @@
  * impossible to find again.
  */
 
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import * as THREE from 'three';
-import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
-import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { RENDER_ORDER } from './constants';
+import { useShapePointerHandlers, useShapeColors, pickStrokeColor } from './shapeInteraction';
 import { shapePosZ, shapeRenderOrder } from './zLayer';
-
-const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
 interface TextElementMeshProps {
   readonly cutout: Cutout;
@@ -43,16 +41,22 @@ export const TextElementMesh = memo(function TextElementMesh({
   onDragStart,
   disablePointerEvents,
 }: TextElementMeshProps) {
-  const [isHovered, setIsHovered] = useState(false);
+  const {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  } = useShapePointerHandlers({
+    cutoutId: cutout.id,
+    isSelected,
+    disablePointerEvents,
+    onSelect,
+    onDragStart,
+    onDoubleClick,
+  });
 
-  const { strokeDefault, strokeGrouped, strokeHover } = useMemo(() => {
-    const base = new THREE.Color(binColor);
-    return {
-      strokeDefault: base.clone().multiplyScalar(0.5),
-      strokeGrouped: base.clone().multiplyScalar(0.35),
-      strokeHover: base.clone().multiplyScalar(0.4),
-    };
-  }, [binColor]);
+  const shapeColors = useShapeColors(binColor);
 
   const effective = previewOverrides ? { ...cutout, ...previewOverrides } : cutout;
   const groupX = effective.x + effective.width / 2;
@@ -73,30 +77,7 @@ export const TextElementMesh = memo(function TextElementMesh({
 
   const isEmpty = effective.label.trim() === '';
   const showFrame = isSelected || isHovered || isGrouped || isEmpty;
-  const strokeColor = isSelected
-    ? STROKE_SELECTED
-    : isHovered
-      ? strokeHover
-      : isGrouped
-        ? strokeGrouped
-        : strokeDefault;
-
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    if (e.nativeEvent.button !== 0) return;
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    const additive = e.nativeEvent.shiftKey;
-    onSelect(cutout.id, additive);
-    if (onDragStart && !additive) {
-      onDragStart(cutout.id, e.point.x, e.point.y, e.nativeEvent.altKey);
-    }
-  };
-
-  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
-    if (disablePointerEvents) return;
-    e.stopPropagation();
-    onDoubleClick?.(cutout.id);
-  };
+  const strokeColor = pickStrokeColor({ isSelected, isHovered, isGrouped }, shapeColors);
 
   return (
     <group
@@ -108,10 +89,8 @@ export const TextElementMesh = memo(function TextElementMesh({
         renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
         onPointerDown={handlePointerDown}
         onDoubleClick={handleDoubleClick}
-        onPointerEnter={() => {
-          if (!isSelected) setIsHovered(true);
-        }}
-        onPointerLeave={() => setIsHovered(false)}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
       >
         <planeGeometry args={[effective.width, effective.depth]} />
         <meshBasicMaterial transparent opacity={0} depthTest={false} depthWrite={false} />

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.test.ts
@@ -32,8 +32,8 @@ describe('useShapeColors', () => {
 });
 
 describe('pickStrokeColor', () => {
-  const colors = renderHook(() => useShapeColors('#808080')).result.current;
   it('prefers selected, then hover, then grouped, then default', () => {
+    const colors = renderHook(() => useShapeColors('#808080')).result.current;
     expect(pickStrokeColor({ isSelected: true, isHovered: true, isGrouped: true }, colors)).toBe(
       STROKE_SELECTED
     );

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ThreeEvent } from '@react-three/fiber';
+import {
+  STROKE_SELECTED,
+  pickStrokeColor,
+  useShapeColors,
+  useShapePointerHandlers,
+} from './shapeInteraction';
+
+function pointerEvent(init: { button?: number; shiftKey?: boolean; altKey?: boolean } = {}) {
+  return {
+    nativeEvent: { button: 0, shiftKey: false, altKey: false, ...init },
+    point: { x: 12, y: 34 },
+    stopPropagation: vi.fn(),
+  } as unknown as ThreeEvent<PointerEvent>;
+}
+
+describe('useShapeColors', () => {
+  it('darkens the bin colour by a fixed factor per role and memoises per colour', () => {
+    const { result, rerender } = renderHook(({ c }: { c: string }) => useShapeColors(c), {
+      initialProps: { c: '#ffffff' },
+    });
+    expect(result.current.cutFillColor.r).toBeCloseTo(0.7);
+    expect(result.current.strokeDefault.r).toBeCloseTo(0.5);
+    expect(result.current.strokeHover.r).toBeCloseTo(0.4);
+    expect(result.current.strokeGrouped.r).toBeCloseTo(0.35);
+    const first = result.current;
+    rerender({ c: '#ffffff' });
+    expect(result.current).toBe(first);
+  });
+});
+
+describe('pickStrokeColor', () => {
+  const colors = renderHook(() => useShapeColors('#808080')).result.current;
+  it('prefers selected, then hover, then grouped, then default', () => {
+    expect(pickStrokeColor({ isSelected: true, isHovered: true, isGrouped: true }, colors)).toBe(
+      STROKE_SELECTED
+    );
+    expect(pickStrokeColor({ isSelected: false, isHovered: true, isGrouped: true }, colors)).toBe(
+      colors.strokeHover
+    );
+    expect(pickStrokeColor({ isSelected: false, isHovered: false, isGrouped: true }, colors)).toBe(
+      colors.strokeGrouped
+    );
+    expect(pickStrokeColor({ isSelected: false, isHovered: false, isGrouped: false }, colors)).toBe(
+      colors.strokeDefault
+    );
+  });
+});
+
+describe('useShapePointerHandlers', () => {
+  function setup(overrides: Partial<Parameters<typeof useShapePointerHandlers>[0]> = {}) {
+    const onSelect = vi.fn();
+    const onDragStart = vi.fn();
+    const onDoubleClick = vi.fn();
+    const hook = renderHook(() =>
+      useShapePointerHandlers({
+        cutoutId: 'c1',
+        isSelected: false,
+        onSelect,
+        onDragStart,
+        onDoubleClick,
+        ...overrides,
+      })
+    );
+    return { hook, onSelect, onDragStart, onDoubleClick };
+  }
+
+  it('selects and starts a drag on a plain left press', () => {
+    const { hook, onSelect, onDragStart } = setup();
+    const e = pointerEvent({ altKey: true });
+    hook.result.current.handlePointerDown(e);
+    expect(e.stopPropagation).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith('c1', false);
+    expect(onDragStart).toHaveBeenCalledWith('c1', 12, 34, true);
+  });
+
+  it('adds to the selection without dragging on a shift press', () => {
+    const { hook, onSelect, onDragStart } = setup();
+    hook.result.current.handlePointerDown(pointerEvent({ shiftKey: true }));
+    expect(onSelect).toHaveBeenCalledWith('c1', true);
+    expect(onDragStart).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-left buttons and lets picks through while disabled', () => {
+    const { hook, onSelect } = setup({ disablePointerEvents: true });
+    const right = pointerEvent({ button: 2 });
+    hook.result.current.handlePointerDown(right);
+    const left = pointerEvent();
+    hook.result.current.handlePointerDown(left);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(left.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('reports a double click by id', () => {
+    const { hook, onDoubleClick } = setup();
+    hook.result.current.handleDoubleClick(pointerEvent());
+    expect(onDoubleClick).toHaveBeenCalledWith('c1');
+  });
+
+  it('tracks hover only while unselected', () => {
+    const { hook } = setup();
+    act(() => hook.result.current.handlePointerEnter());
+    expect(hook.result.current.isHovered).toBe(true);
+    act(() => hook.result.current.handlePointerLeave());
+    expect(hook.result.current.isHovered).toBe(false);
+
+    const selected = setup({ isSelected: true });
+    act(() => selected.hook.result.current.handlePointerEnter());
+    expect(selected.hook.result.current.isHovered).toBe(false);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.ts
@@ -12,7 +12,6 @@ export interface ShapeColors {
   readonly strokeHover: THREE.Color;
 }
 
-/** Fill and outline shades of one shape, all darkened from the bin's surface colour. */
 export function useShapeColors(binColor: string): ShapeColors {
   return useMemo(() => {
     const base = new THREE.Color(binColor);
@@ -50,7 +49,6 @@ interface ShapePointerOptions {
   readonly onDoubleClick?: (id: string) => void;
 }
 
-/** Selection, drag start, double-click and hover for one shape on the board. */
 export function useShapePointerHandlers({
   cutoutId,
   isSelected,

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/shapeInteraction.ts
@@ -1,0 +1,95 @@
+import { useMemo, useState } from 'react';
+import * as THREE from 'three';
+import type { ThreeEvent } from '@react-three/fiber';
+import { ACCENT_COLOR_HEX } from './constants';
+
+export const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
+
+export interface ShapeColors {
+  readonly cutFillColor: THREE.Color;
+  readonly strokeDefault: THREE.Color;
+  readonly strokeGrouped: THREE.Color;
+  readonly strokeHover: THREE.Color;
+}
+
+/** Fill and outline shades of one shape, all darkened from the bin's surface colour. */
+export function useShapeColors(binColor: string): ShapeColors {
+  return useMemo(() => {
+    const base = new THREE.Color(binColor);
+    return {
+      cutFillColor: base.clone().multiplyScalar(0.7),
+      strokeDefault: base.clone().multiplyScalar(0.5),
+      strokeGrouped: base.clone().multiplyScalar(0.35),
+      strokeHover: base.clone().multiplyScalar(0.4),
+    };
+  }, [binColor]);
+}
+
+interface StrokeState {
+  readonly isSelected: boolean;
+  readonly isHovered: boolean;
+  readonly isGrouped: boolean;
+}
+
+export function pickStrokeColor(
+  { isSelected, isHovered, isGrouped }: StrokeState,
+  colors: ShapeColors
+): THREE.Color {
+  if (isSelected) return STROKE_SELECTED;
+  if (isHovered) return colors.strokeHover;
+  if (isGrouped) return colors.strokeGrouped;
+  return colors.strokeDefault;
+}
+
+interface ShapePointerOptions {
+  readonly cutoutId: string;
+  readonly isSelected: boolean;
+  readonly disablePointerEvents?: boolean;
+  readonly onSelect: (id: string, additive: boolean) => void;
+  readonly onDragStart?: (id: string, mmX: number, mmY: number, altKey?: boolean) => void;
+  readonly onDoubleClick?: (id: string) => void;
+}
+
+/** Selection, drag start, double-click and hover for one shape on the board. */
+export function useShapePointerHandlers({
+  cutoutId,
+  isSelected,
+  disablePointerEvents,
+  onSelect,
+  onDragStart,
+  onDoubleClick,
+}: ShapePointerOptions) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
+    if (e.nativeEvent.button !== 0) return;
+    // Let the click fall through to the background while a tool owns picks.
+    if (disablePointerEvents) return;
+    e.stopPropagation();
+    const additive = e.nativeEvent.shiftKey;
+    onSelect(cutoutId, additive);
+    if (onDragStart && !additive) {
+      onDragStart(cutoutId, e.point.x, e.point.y, e.nativeEvent.altKey);
+    }
+  };
+
+  const handleDoubleClick = (e: ThreeEvent<MouseEvent>) => {
+    if (disablePointerEvents) return;
+    e.stopPropagation();
+    onDoubleClick?.(cutoutId);
+  };
+
+  const handlePointerEnter = () => {
+    if (!isSelected) setIsHovered(true);
+  };
+
+  const handlePointerLeave = () => setIsHovered(false);
+
+  return {
+    isHovered,
+    handlePointerDown,
+    handleDoubleClick,
+    handlePointerEnter,
+    handlePointerLeave,
+  };
+}


### PR DESCRIPTION
The five shape renderers on the cutout board (rectangle, path, polygon, STL footprint, text) each carried the same pointer plumbing and the same colour derivation: a `useState` for hover, a `handlePointerDown` that selects, shift-adds or starts a drag, a `handleDoubleClick`, enter/leave handlers, a `useMemo` darkening the bin colour into fill and outline shades, a module-level `STROKE_SELECTED`, and a four-way stroke ternary. jscpd counted these five files among the ten most duplicated in `src/`.

**`shapeInteraction.ts` in the renderer folder**

- `useShapePointerHandlers({ cutoutId, isSelected, disablePointerEvents, onSelect, onDragStart, onDoubleClick })` owns the hover state and returns the four handlers. The "let the click fall through while a tool owns picks" note lives on the one line it explains.
- `useShapeColors(binColor)` returns the four shades; `pickStrokeColor(state, colors)` encodes the selected, hover, grouped, default precedence.
- `STROKE_SELECTED` is exported once instead of built in each file.

`CutoutShapeMesh` keeps its own three-way stroke choice, since it expresses grouping through stroke width rather than colour; only its handlers, colour memo and constant move. The other four use `pickStrokeColor`. The polygon, footprint and text meshes had the hover handlers inline in JSX; they now use the same named handlers as the other two.

**Verification**

- Typecheck, lint, module boundaries and design-system gates pass.
- Vitest over the whole renderer folder: 45 files, 132 tests. The module has its own tests: shade factors and memoisation, stroke precedence, left-button and shift handling, disabled picks falling through, double click, and hover tracking only while unselected.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

