### PR TITLE
refactor(bins): renumber compartments and resolve collab mode in one place

### DIFF
--- a/src/features/bin-designer/utils/bentoDraw.ts
+++ b/src/features/bin-designer/utils/bentoDraw.ts
@@ -29,18 +29,9 @@ import {
   getCellsForCompartment,
   getCompartmentBounds,
   getCompartmentReadingOrder,
-  normalizeIdsWithRemap,
-  remapCompartmentColors,
-  remapCompartmentColorScopes,
-  remapCompartmentTexts,
-  remapDividerOverrides,
-  remapBackgroundIds,
-  remapDrawnUnitCells,
-  remapFloorRaises,
-  remapLabelIcons,
-  remapLabelPlateWidths,
   validateDividerOverride,
 } from './compartments';
+import { renumberCompartments } from './compartmentRemap';
 
 export interface DrawResult {
   readonly config: CompartmentConfig;
@@ -200,38 +191,12 @@ function rebuild(
   const merged = config.mergeBackground
     ? mergeBackgroundRuns(config, newCells)
     : { cells: newCells, backgroundIds: [] };
-  const { cells, remap } = normalizeIdsWithRemap(merged.cells);
-  let next: CompartmentConfig = {
-    ...config,
-    cells,
-    ...(config.compartmentTexts && {
-      compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
-    }),
-    ...(config.labelPlateWidths && {
-      labelPlateWidths: remapLabelPlateWidths(config.labelPlateWidths, remap),
-    }),
-    ...(config.labelIcons && {
-      labelIcons: remapLabelIcons(config.labelIcons, remap),
-    }),
-    ...(config.compartmentColors && {
-      compartmentColors: remapCompartmentColors(config.compartmentColors, remap),
-    }),
-    ...(config.compartmentColorScopes && {
-      compartmentColorScopes: remapCompartmentColorScopes(config.compartmentColorScopes, remap),
-    }),
-    ...(config.floorRaises && {
-      floorRaises: remapFloorRaises(config.floorRaises, remap),
-    }),
-    ...(config.dividerOverrides && {
-      dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
-    }),
-    ...(config.drawnUnitCells && {
-      drawnUnitCells: remapDrawnUnitCells(config.drawnUnitCells, remap, cells),
-    }),
-    ...(merged.backgroundIds.length > 0 && {
-      backgroundIds: remapBackgroundIds(merged.backgroundIds, remap),
-    }),
-  };
+  const { config: renumbered, remap } = renumberCompartments(
+    config,
+    merged.cells,
+    merged.backgroundIds.length > 0 ? merged.backgroundIds : undefined
+  );
+  let next: CompartmentConfig = renumbered;
   const overrides = next.dividerOverrides;
   if (overrides && overrides.length > 0) {
     const kept = overrides.filter((o) => validateDividerOverride(next, o) === null);

--- a/src/features/bin-designer/utils/compartmentRemap.test.ts
+++ b/src/features/bin-designer/utils/compartmentRemap.test.ts
@@ -53,7 +53,7 @@ describe('renumberCompartments', () => {
   } as unknown as Parameters<typeof renumberCompartments>[0];
 
   it('normalises ids and carries every id-keyed array through the same remap', () => {
-    const { config, remap } = renumberCompartments(base, [...base.cells]);
+    const { config, remap } = renumberCompartments(base, [...base.cells], base.backgroundIds);
     expect(config.cells).toEqual([0, 0, 1, 1]);
     expect(config.compartmentTexts).toEqual(['top', 'bottom']);
     expect(config.backgroundIds).toEqual([1]);
@@ -64,5 +64,10 @@ describe('renumberCompartments', () => {
   it('remaps a caller-supplied background set instead of the config own', () => {
     const { config } = renumberCompartments(base, [...base.cells], [3]);
     expect(config.backgroundIds).toEqual([0]);
+  });
+
+  it('leaves the background field untouched when the caller passes undefined', () => {
+    const { config } = renumberCompartments(base, [...base.cells], undefined);
+    expect(config.backgroundIds).toBe(base.backgroundIds);
   });
 });

--- a/src/features/bin-designer/utils/compartmentRemap.test.ts
+++ b/src/features/bin-designer/utils/compartmentRemap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { remapFloorRaises } from './compartmentRemap';
+import { remapFloorRaises, renumberCompartments } from './compartmentRemap';
 import { mergeCells } from './compartments';
 import type { CompartmentConfig } from '../types';
 
@@ -39,5 +39,30 @@ describe('mergeCells keeps floor raises in lockstep', () => {
     const merged = mergeCells(config, [0, 1]);
     expect(merged?.cells).toEqual([0, 0, 1]);
     expect(merged?.floorRaises).toEqual([null, 9]);
+  });
+});
+
+describe('renumberCompartments', () => {
+  const base = {
+    cols: 2,
+    rows: 2,
+    thickness: 1.2,
+    cells: [3, 3, 7, 7],
+    compartmentTexts: ['', '', '', 'top', '', '', '', 'bottom'],
+    backgroundIds: [7],
+  } as unknown as Parameters<typeof renumberCompartments>[0];
+
+  it('normalises ids and carries every id-keyed array through the same remap', () => {
+    const { config, remap } = renumberCompartments(base, [...base.cells]);
+    expect(config.cells).toEqual([0, 0, 1, 1]);
+    expect(config.compartmentTexts).toEqual(['top', 'bottom']);
+    expect(config.backgroundIds).toEqual([1]);
+    expect(remap.get(3)).toBe(0);
+    expect(remap.get(7)).toBe(1);
+  });
+
+  it('remaps a caller-supplied background set instead of the config own', () => {
+    const { config } = renumberCompartments(base, [...base.cells], [3]);
+    expect(config.backgroundIds).toEqual([0]);
   });
 });

--- a/src/features/bin-designer/utils/compartmentRemap.ts
+++ b/src/features/bin-designer/utils/compartmentRemap.ts
@@ -344,13 +344,14 @@ export function remapDividerOverrides(
 /**
  * Renumber `cells` contiguously and carry every id-keyed parallel array across.
  * Every mutation that rebuilds `cells` ends here, so a new compartment-keyed
- * field is added in exactly one place. `backgroundIds` defaults to the
- * config's own; a caller that recomputed them passes the fresh set.
+ * field is added in exactly one place. `backgroundIds` is explicit rather than
+ * defaulted: a caller passes the config's own set, a freshly recomputed set, or
+ * `undefined` to leave the field exactly as it is.
  */
 export function renumberCompartments(
   config: CompartmentConfig,
   newCells: number[],
-  backgroundIds: readonly number[] | undefined = config.backgroundIds
+  backgroundIds: readonly number[] | undefined
 ): { config: CompartmentConfig; remap: Map<number, number> } {
   const { cells, remap } = normalizeIdsWithRemap(newCells);
   return {

--- a/src/features/bin-designer/utils/compartmentRemap.ts
+++ b/src/features/bin-designer/utils/compartmentRemap.ts
@@ -340,3 +340,51 @@ export function remapDividerOverrides(
   }
   return out;
 }
+
+/**
+ * Renumber `cells` contiguously and carry every id-keyed parallel array across.
+ * Every mutation that rebuilds `cells` ends here, so a new compartment-keyed
+ * field is added in exactly one place. `backgroundIds` defaults to the
+ * config's own; a caller that recomputed them passes the fresh set.
+ */
+export function renumberCompartments(
+  config: CompartmentConfig,
+  newCells: number[],
+  backgroundIds: readonly number[] | undefined = config.backgroundIds
+): { config: CompartmentConfig; remap: Map<number, number> } {
+  const { cells, remap } = normalizeIdsWithRemap(newCells);
+  return {
+    remap,
+    config: {
+      ...config,
+      cells,
+      ...(config.compartmentTexts && {
+        compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
+      }),
+      ...(config.labelPlateWidths && {
+        labelPlateWidths: remapLabelPlateWidths(config.labelPlateWidths, remap),
+      }),
+      ...(config.labelIcons && {
+        labelIcons: remapLabelIcons(config.labelIcons, remap),
+      }),
+      ...(config.compartmentColors && {
+        compartmentColors: remapCompartmentColors(config.compartmentColors, remap),
+      }),
+      ...(config.compartmentColorScopes && {
+        compartmentColorScopes: remapCompartmentColorScopes(config.compartmentColorScopes, remap),
+      }),
+      ...(config.floorRaises && {
+        floorRaises: remapFloorRaises(config.floorRaises, remap),
+      }),
+      ...(config.dividerOverrides && {
+        dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
+      }),
+      ...(config.drawnUnitCells && {
+        drawnUnitCells: remapDrawnUnitCells(config.drawnUnitCells, remap, cells),
+      }),
+      ...(backgroundIds && {
+        backgroundIds: remapBackgroundIds(backgroundIds, remap),
+      }),
+    },
+  };
+}

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -727,7 +727,7 @@ export function mergeCells(
   // selection being connected says nothing about what it leaves behind.
   if (!allCompartmentsContiguous(config.cols, newCells)) return null;
 
-  return renumberCompartments(config, newCells).config;
+  return renumberCompartments(config, newCells, config.backgroundIds).config;
 }
 
 /**
@@ -753,7 +753,7 @@ export function splitCompartment(
     }
   }
 
-  return renumberCompartments(config, newCells).config;
+  return renumberCompartments(config, newCells, config.backgroundIds).config;
 }
 
 /**

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -18,18 +18,7 @@
    count with an import cycle. */
 
 import type { CompartmentConfig, DividerOverride } from '../types';
-import {
-  normalizeIdsWithRemap,
-  remapBackgroundIds,
-  remapCompartmentColors,
-  remapCompartmentColorScopes,
-  remapFloorRaises,
-  remapCompartmentTexts,
-  remapDividerOverrides,
-  remapDrawnUnitCells,
-  remapLabelIcons,
-  remapLabelPlateWidths,
-} from './compartmentRemap';
+import { renumberCompartments } from './compartmentRemap';
 
 // Grid Creation
 
@@ -738,38 +727,7 @@ export function mergeCells(
   // selection being connected says nothing about what it leaves behind.
   if (!allCompartmentsContiguous(config.cols, newCells)) return null;
 
-  const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-  return {
-    ...config,
-    cells: normalized,
-    ...(config.compartmentTexts && {
-      compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
-    }),
-    ...(config.labelPlateWidths && {
-      labelPlateWidths: remapLabelPlateWidths(config.labelPlateWidths, remap),
-    }),
-    ...(config.labelIcons && {
-      labelIcons: remapLabelIcons(config.labelIcons, remap),
-    }),
-    ...(config.compartmentColors && {
-      compartmentColors: remapCompartmentColors(config.compartmentColors, remap),
-    }),
-    ...(config.compartmentColorScopes && {
-      compartmentColorScopes: remapCompartmentColorScopes(config.compartmentColorScopes, remap),
-    }),
-    ...(config.floorRaises && {
-      floorRaises: remapFloorRaises(config.floorRaises, remap),
-    }),
-    ...(config.dividerOverrides && {
-      dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
-    }),
-    ...(config.drawnUnitCells && {
-      drawnUnitCells: remapDrawnUnitCells(config.drawnUnitCells, remap, normalized),
-    }),
-    ...(config.backgroundIds && {
-      backgroundIds: remapBackgroundIds(config.backgroundIds, remap),
-    }),
-  };
+  return renumberCompartments(config, newCells).config;
 }
 
 /**
@@ -795,38 +753,7 @@ export function splitCompartment(
     }
   }
 
-  const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-  return {
-    ...config,
-    cells: normalized,
-    ...(config.compartmentTexts && {
-      compartmentTexts: remapCompartmentTexts(config.compartmentTexts, remap),
-    }),
-    ...(config.labelPlateWidths && {
-      labelPlateWidths: remapLabelPlateWidths(config.labelPlateWidths, remap),
-    }),
-    ...(config.labelIcons && {
-      labelIcons: remapLabelIcons(config.labelIcons, remap),
-    }),
-    ...(config.compartmentColors && {
-      compartmentColors: remapCompartmentColors(config.compartmentColors, remap),
-    }),
-    ...(config.compartmentColorScopes && {
-      compartmentColorScopes: remapCompartmentColorScopes(config.compartmentColorScopes, remap),
-    }),
-    ...(config.floorRaises && {
-      floorRaises: remapFloorRaises(config.floorRaises, remap),
-    }),
-    ...(config.dividerOverrides && {
-      dividerOverrides: remapDividerOverrides(config.dividerOverrides, remap),
-    }),
-    ...(config.drawnUnitCells && {
-      drawnUnitCells: remapDrawnUnitCells(config.drawnUnitCells, remap, normalized),
-    }),
-    ...(config.backgroundIds && {
-      backgroundIds: remapBackgroundIds(config.backgroundIds, remap),
-    }),
-  };
+  return renumberCompartments(config, newCells).config;
 }
 
 /**

--- a/src/shared/hooks/useCollabMode.test.ts
+++ b/src/shared/hooks/useCollabMode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useCollabMode, getCollabMode } from '@/shared/hooks/useCollabMode';
+import { useCollabMode, getCollabMode, resolveCollabMode } from '@/shared/hooks/useCollabMode';
 import { useLabsStore, useLibraryStore } from '@/core/store';
 import { useSharedPreviewStore } from '@/core/store/sharedPreview';
 import type { CloudShareInfo, LayoutLibrary, LayoutEntry, Layout } from '@/core/types';
@@ -357,5 +357,37 @@ describe('getCollabMode', () => {
     expect(result.isCollaborative).toBe(false);
     expect(result.canEdit).toBe(false);
     expect(result.shareId).toBe(TEST_SHARE_ID);
+  });
+});
+
+describe('resolveCollabMode', () => {
+  it('lets a shared preview outrank the owner cloud share', () => {
+    expect(
+      resolveCollabMode(
+        { cloudShareId: 'shared', permission: 'view' },
+        { id: 'own', permission: 'edit' }
+      )
+    ).toEqual({ isCollaborative: false, canEdit: false, shareId: 'shared' });
+  });
+
+  it('connects only for edit permission on either source', () => {
+    expect(resolveCollabMode({ cloudShareId: 's', permission: 'edit' }, null)).toEqual({
+      isCollaborative: true,
+      canEdit: true,
+      shareId: 's',
+    });
+    expect(resolveCollabMode(null, { id: 'own', permission: 'view' })).toEqual({
+      isCollaborative: false,
+      canEdit: false,
+      shareId: 'own',
+    });
+  });
+
+  it('is local and editable with neither', () => {
+    expect(resolveCollabMode(null, undefined)).toEqual({
+      isCollaborative: false,
+      canEdit: true,
+      shareId: null,
+    });
   });
 });

--- a/src/shared/hooks/useCollabMode.ts
+++ b/src/shared/hooks/useCollabMode.ts
@@ -47,39 +47,8 @@ export function useCollabMode(): CollabModeState {
 
   // Check for shared layout preview (viewing via /s/{shareId} URL)
   const sharedPreview = useSharedPreviewStore((state) => state.sharedPreview);
-  const sharedLayoutCloudShareId = sharedPreview?.cloudShareId ?? null;
-  const sharedLayoutPermission = sharedPreview?.permission ?? null;
 
-  // Check for shared preview mode first (viewer opened via /s/{shareId} URL)
-  // Only connect to Liveblocks if permission is "edit"
-  if (sharedLayoutCloudShareId) {
-    const canEdit = sharedLayoutPermission === 'edit';
-    return {
-      // Only collaborative (Liveblocks) for edit permission
-      isCollaborative: canEdit,
-      canEdit,
-      shareId: sharedLayoutCloudShareId,
-    };
-  }
-
-  // Check for saved layout with cloud share (owner's layout)
-  // Only connect to Liveblocks if permission is "edit"
-  if (cloudShare) {
-    const canEdit = cloudShare.permission === 'edit';
-    return {
-      // Only collaborative (Liveblocks) for edit permission
-      isCollaborative: canEdit,
-      canEdit,
-      shareId: cloudShare.id,
-    };
-  }
-
-  // No cloud share - local mode
-  return {
-    isCollaborative: false,
-    canEdit: true,
-    shareId: null,
-  };
+  return resolveCollabMode(sharedPreview, cloudShare);
 }
 
 /**
@@ -89,37 +58,29 @@ export function useCollabMode(): CollabModeState {
 export function getCollabMode(): CollabModeState {
   const { activeLayoutId, entries } = useLibraryStore.getState().library;
   const sharedPreview = useSharedPreviewStore.getState().sharedPreview;
-  const sharedLayoutCloudShareId = sharedPreview?.cloudShareId ?? null;
-  const sharedLayoutPermission = sharedPreview?.permission ?? null;
 
   const activeEntry = entries.find((e) => e.id === activeLayoutId);
-  const cloudShare = activeEntry?.cloudShare;
+  return resolveCollabMode(sharedPreview, activeEntry?.cloudShare);
+}
 
-  // Check for shared preview mode first
-  // Only connect to Liveblocks if permission is "edit"
-  if (sharedLayoutCloudShareId) {
-    const canEdit = sharedLayoutPermission === 'edit';
-    return {
-      isCollaborative: canEdit,
-      canEdit,
-      shareId: sharedLayoutCloudShareId,
-    };
+/**
+ * A shared preview (viewer arrived through a share URL) outranks the owner's
+ * own cloud share; either connects to Liveblocks only with edit permission.
+ */
+export function resolveCollabMode(
+  sharedPreview:
+    | { readonly cloudShareId?: string | null; readonly permission?: string | null }
+    | null
+    | undefined,
+  cloudShare: { readonly id: string; readonly permission: string } | null | undefined
+): CollabModeState {
+  if (sharedPreview?.cloudShareId) {
+    const canEdit = sharedPreview.permission === 'edit';
+    return { isCollaborative: canEdit, canEdit, shareId: sharedPreview.cloudShareId };
   }
-
-  // Check for saved layout with cloud share
-  // Only connect to Liveblocks if permission is "edit"
   if (cloudShare) {
     const canEdit = cloudShare.permission === 'edit';
-    return {
-      isCollaborative: canEdit,
-      canEdit,
-      shareId: cloudShare.id,
-    };
+    return { isCollaborative: canEdit, canEdit, shareId: cloudShare.id };
   }
-
-  return {
-    isCollaborative: false,
-    canEdit: true,
-    shareId: null,
-  };
+  return { isCollaborative: false, canEdit: true, shareId: null };
 }


### PR DESCRIPTION
Two within-file clones from the jscpd scan, both of the kind where a future edit to one copy silently misses the other.

**One renumbering step for compartments**

`mergeCells`, `splitCompartment` and the bento editor's `rebuild` each finished with the same 35-line block: normalise the cell ids, then thread the old-to-new map through every id-keyed parallel array (texts, plate widths, icons, colours, colour scopes, floor raises, divider overrides, drawn-unit markers, background markers). The bin-designer skill already documents that missing one array puts labels and colours on the wrong pocket. `renumberCompartments(config, cells, backgroundIds?)` in `compartmentRemap.ts` is now the single place that list lives; adding a compartment-keyed field means one remap helper and one line here. The bento caller passes its recomputed background set, which preserves its existing behaviour of leaving `backgroundIds` alone when that set is empty.

**One decision for collaboration mode**

`useCollabMode` and its non-reactive twin `getCollabMode` repeated the same precedence: a shared preview outranks the owner's cloud share, and either connects to Liveblocks only with edit permission. `resolveCollabMode(sharedPreview, cloudShare)` holds it once and both call it.

**Verification**

- Typecheck, lint and module-boundary gates pass.
- Vitest over `bin-designer/utils`, `bin-designer/store`, the collab-mode hook and `shell/Collab`: all green. New tests cover the remap carrying texts and background ids together, the caller-supplied background set, and the three collab-mode precedence cases.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

