### PR TITLE
refactor(share): collapse the repeated request and blob plumbing

### DIFF
--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -1,3 +1,4 @@
+import { head } from '@vercel/blob';
 import { timingSafeEqual as nodeTimingSafeEqual } from 'node:crypto';
 import type { VercelResponse } from '@vercel/node';
 
@@ -214,4 +215,17 @@ export function getBaseUrl(): string {
     return `https://${process.env.VERCEL_URL}`;
   }
   return 'https://localhost:3000';
+}
+
+/**
+ * The stored share, or null when the blob is missing or unreadable. Any Blob
+ * failure reads as "not found": the handlers answer 404 rather than leak the
+ * storage error, which is the behaviour they each had inline.
+ */
+export async function loadShare(blobPath: string): Promise<ShareData | null> {
+  const blobInfo = await head(blobPath).catch(() => null);
+  if (!blobInfo) return null;
+  const response = await fetch(blobInfo.url);
+  if (!response.ok) return null;
+  return (await response.json()) as ShareData;
 }

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -218,9 +218,10 @@ export function getBaseUrl(): string {
 }
 
 /**
- * The stored share, or null when the blob is missing or unreadable. Any Blob
- * failure reads as "not found": the handlers answer 404 rather than leak the
- * storage error, which is the behaviour they each had inline.
+ * The stored share, or null when `head` fails or the blob fetch is not OK,
+ * which the handlers answer with 404 (the behaviour they each had inline). A
+ * rejected fetch or an unparsable body still throws, and the handler's own
+ * catch turns that into a 500.
  */
 export async function loadShare(blobPath: string): Promise<ShareData | null> {
   const blobInfo = await head(blobPath).catch(() => null);

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -1,5 +1,4 @@
 import { Liveblocks } from '@liveblocks/node';
-import { head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
 import {
@@ -8,9 +7,9 @@ import {
   isValidShareId,
   methodNotAllowed,
   sendError,
+  loadShare,
 } from './lib/shared.js';
 import { logger } from './lib/logger.js';
-import type { ShareData } from './lib/shared.js';
 
 /**
  * Liveblocks authentication endpoint.
@@ -124,18 +123,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Fetch share metadata from Vercel Blob to check permission
     const blobPath = `shares/${shareId}.json`;
-    const blobInfo = await head(blobPath).catch(() => null);
-
-    if (!blobInfo) {
+    const shareData = await loadShare(blobPath);
+    if (!shareData) {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
-
-    const blobResponse = await fetch(blobInfo.url);
-    if (!blobResponse.ok) {
-      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
-    }
-
-    const shareData = (await blobResponse.json()) as ShareData;
     const permission = shareData.metadata.permission;
 
     const session = getLiveblocks().prepareSession(userId, {

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -1,4 +1,4 @@
-import { put, del, head } from '@vercel/blob';
+import { put, del } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
 import {
@@ -24,6 +24,7 @@ import {
   type ShareData,
   rateLimited,
   sendError,
+  loadShare,
 } from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -62,19 +63,10 @@ async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, b
       return rateLimited(res, rateLimit.retryAfterSeconds);
     }
 
-    // Check if blob exists
-    const blobInfo = await head(blobPath).catch(() => null);
-    if (!blobInfo) {
+    const shareData = await loadShare(blobPath);
+    if (!shareData) {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
-
-    // Fetch the blob content
-    const response = await fetch(blobInfo.url);
-    if (!response.ok) {
-      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
-    }
-
-    const shareData = (await response.json()) as ShareData;
 
     // Track lastAccessedAt in Redis instead of rewriting the blob on every GET.
     // Cheap, atomic, and avoids the per-view Blob-write amplification that
@@ -137,31 +129,16 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Delete token required for updates');
     }
 
-    // Fetch existing share
-    const blobInfo = await head(blobPath).catch(() => null);
-    if (!blobInfo) {
+    const existingData = await loadShare(blobPath);
+    if (!existingData) {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
-    const response = await fetch(blobInfo.url);
-    if (!response.ok) {
+    const tokenCheck = await verifyDeleteToken(id, existingData, deleteToken);
+    if (tokenCheck === 'missing') {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
-
-    const existingData = (await response.json()) as ShareData;
-
-    // Fetch the stored hash — check Redis first (new shares), fall back to blob (pre-migration shares)
-    const redis = getRedis();
-    const storedHash =
-      (redis ? await redis.get(shareHashKey(id)) : null) ?? existingData.metadata.deleteTokenHash;
-
-    if (!storedHash) {
-      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
-    }
-
-    // Verify delete token (constant-time comparison prevents timing attacks)
-    const tokenHash = await hashToken(deleteToken);
-    if (!timingSafeCompare(tokenHash, storedHash)) {
+    if (tokenCheck === 'mismatch') {
       return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid delete token');
     }
 
@@ -195,20 +172,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
         },
       };
 
-      await put(blobPath, JSON.stringify(updatedData), {
-        access: 'public',
-        contentType: 'application/json',
-        addRandomSuffix: false,
-        allowOverwrite: true,
-      });
-
-      const shareUrl = `${getBaseUrl()}/l/${id}`;
-
-      return res.status(200).json({
-        id,
-        url: shareUrl,
-        permission: newPermission,
-      });
+      return await writeShareAndRespond(res, id, blobPath, updatedData, newPermission);
     }
 
     // Full update with layout
@@ -263,20 +227,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       },
     };
 
-    await put(blobPath, JSON.stringify(updatedData), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-      allowOverwrite: true,
-    });
-
-    const shareUrl = `${getBaseUrl()}/l/${id}`;
-
-    return res.status(200).json({
-      id,
-      url: shareUrl,
-      permission: newPermission,
-    });
+    return await writeShareAndRespond(res, id, blobPath, updatedData, newPermission);
   } catch (error) {
     logger.error('Share update error', {
       error: error instanceof Error ? error.message : String(error),
@@ -318,36 +269,22 @@ async function handleDelete(
       return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Delete token required');
     }
 
-    // Fetch existing share
-    const blobInfo = await head(blobPath).catch(() => null);
-    if (!blobInfo) {
+    const existingData = await loadShare(blobPath);
+    if (!existingData) {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
-    const response = await fetch(blobInfo.url);
-    if (!response.ok) {
+    const tokenCheck = await verifyDeleteToken(_id, existingData, deleteToken);
+    if (tokenCheck === 'missing') {
       return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
-
-    const existingData = (await response.json()) as ShareData;
-
-    // Fetch the stored hash — check Redis first (new shares), fall back to blob (pre-migration shares)
-    const redis = getRedis();
-    const storedHash =
-      (redis ? await redis.get(shareHashKey(_id)) : null) ?? existingData.metadata.deleteTokenHash;
-
-    if (!storedHash) {
-      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
-    }
-
-    // Verify delete token (constant-time comparison prevents timing attacks)
-    const tokenHash = await hashToken(deleteToken);
-    if (!timingSafeCompare(tokenHash, storedHash)) {
+    if (tokenCheck === 'mismatch') {
       return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid delete token');
     }
 
     // Delete the blob and clean up Redis keys
     await del(blobPath);
+    const redis = getRedis();
     if (redis) {
       await redis.del(shareHashKey(_id), shareReportKey(_id), shareLastAccessedKey(_id));
     }
@@ -363,4 +300,33 @@ async function handleDelete(
     });
     return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to delete share');
   }
+}
+
+async function verifyDeleteToken(
+  id: string,
+  existing: ShareData,
+  deleteToken: string
+): Promise<'ok' | 'missing' | 'mismatch'> {
+  // New shares keep the hash in Redis; pre-migration shares carry it in the blob.
+  const redis = getRedis();
+  const storedHash =
+    (redis ? await redis.get(shareHashKey(id)) : null) ?? existing.metadata.deleteTokenHash;
+  if (!storedHash) return 'missing';
+  return timingSafeCompare(await hashToken(deleteToken), storedHash) ? 'ok' : 'mismatch';
+}
+
+async function writeShareAndRespond(
+  res: VercelResponse,
+  id: string,
+  blobPath: string,
+  data: ShareData,
+  permission: ShareData['metadata']['permission']
+) {
+  await put(blobPath, JSON.stringify(data), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+    allowOverwrite: true,
+  });
+  return res.status(200).json({ id, url: `${getBaseUrl()}/l/${id}`, permission });
 }

--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -7,7 +7,14 @@
 
 import type { Layout, SharePermission } from '@/core/types';
 import type { Result, ApiError, ValidationError } from '@/core/result';
-import { ok, err, apiServerError, apiNetworkError, validationImportFailed } from '@/core/result';
+import {
+  ok,
+  err,
+  isErr,
+  apiServerError,
+  apiNetworkError,
+  validationImportFailed,
+} from '@/core/result';
 import { isApiErrorResponse, mapApiErrorResponse } from './mapApiError';
 import { validateImport } from '@/shared/utils/validation';
 
@@ -164,6 +171,51 @@ function validateFetchShareResponse(
   return { valid: true, data: { ...data, linkedDesigns } };
 }
 
+function isSuccessMessage(data: unknown): data is { success: true; message: string } {
+  return typeof data === 'object' && data !== null && 'success' in data && 'message' in data;
+}
+
+function jsonInit(
+  method: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): RequestInit {
+  return {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  };
+}
+
+async function withNetworkErrors<T, E>(
+  run: () => Promise<Result<T, E>>
+): Promise<Result<T, E | ApiError>> {
+  try {
+    return await run();
+  } catch (error) {
+    return err(apiNetworkError(error));
+  }
+}
+
+async function requestJson(input: string, init?: RequestInit): Promise<Result<unknown, ApiError>> {
+  const response = await fetch(input, init);
+  const data: unknown = await response.json();
+  if (!response.ok) {
+    return err(isApiErrorResponse(data) ? mapApiErrorResponse(data) : apiServerError());
+  }
+  return ok(data);
+}
+
+async function requestShare<T>(
+  input: string,
+  init: RequestInit | undefined,
+  isValid: (data: unknown) => data is T
+): Promise<Result<T, ApiError>> {
+  const result = await requestJson(input, init);
+  if (isErr(result)) return result;
+  return isValid(result.value) ? ok(result.value) : err(apiServerError());
+}
+
 /**
  * Create a new cloud share.
  *
@@ -188,30 +240,14 @@ export async function createShare(
   permission: SharePermission = 'view',
   authorName?: string
 ): Promise<Result<ShareResponse, ApiError>> {
-  try {
+  return withNetworkErrors(async () => {
     const linkedDesigns = await collectDesignsForShare(layout);
-    const response = await fetch('/api/share', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ layoutId, layout, permission, authorName, linkedDesigns }),
-    });
-
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    if (isShareResponse(data)) {
-      return ok(data);
-    }
-    return err(apiServerError());
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+    return requestShare(
+      '/api/share',
+      jsonInit('POST', { layoutId, layout, permission, authorName, linkedDesigns }),
+      isShareResponse
+    );
+  });
 }
 
 /**
@@ -223,30 +259,14 @@ export async function updateShare(
   layout: Layout,
   permission?: SharePermission
 ): Promise<Result<UpdateShareResponse, ApiError>> {
-  try {
+  return withNetworkErrors(async () => {
     const linkedDesigns = await collectDesignsForShare(layout);
-    const response = await fetch(`/api/share/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ layout, permission, deleteToken, linkedDesigns }),
-    });
-
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    if (isUpdateShareResponse(data)) {
-      return ok(data);
-    }
-    return err(apiServerError());
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+    return requestShare(
+      `/api/share/${id}`,
+      jsonInit('PUT', { layout, permission, deleteToken, linkedDesigns }),
+      isUpdateShareResponse
+    );
+  });
 }
 
 /**
@@ -257,29 +277,13 @@ export async function updatePermission(
   deleteToken: string,
   permission: SharePermission
 ): Promise<Result<UpdateShareResponse, ApiError>> {
-  try {
-    const response = await fetch(`/api/share/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ permission, deleteToken }),
-    });
-
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    if (isUpdateShareResponse(data)) {
-      return ok(data);
-    }
-    return err(apiServerError());
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+  return withNetworkErrors(() =>
+    requestShare(
+      `/api/share/${id}`,
+      jsonInit('PUT', { permission, deleteToken }),
+      isUpdateShareResponse
+    )
+  );
 }
 
 /**
@@ -289,27 +293,12 @@ export async function updatePermission(
 export async function fetchShare(
   id: string
 ): Promise<Result<FetchShareResponse, ApiError | ValidationError>> {
-  try {
-    const response = await fetch(`/api/share/${id}`);
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    // Validate both structure and layout contents
-    const validation = validateFetchShareResponse(data);
-    if (!validation.valid) {
-      return err(validationImportFailed(validation.errors));
-    }
-
-    return ok(validation.data);
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+  return withNetworkErrors<FetchShareResponse, ApiError | ValidationError>(async () => {
+    const result = await requestJson(`/api/share/${id}`);
+    if (isErr(result)) return result;
+    const validation = validateFetchShareResponse(result.value);
+    return validation.valid ? ok(validation.data) : err(validationImportFailed(validation.errors));
+  });
 }
 
 /**
@@ -319,32 +308,16 @@ export async function deleteShare(
   id: string,
   deleteToken: string
 ): Promise<Result<{ success: true; message: string }, ApiError>> {
-  try {
-    const response = await fetch(`/api/share/${id}`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Delete-Token': deleteToken,
+  return withNetworkErrors(() =>
+    requestShare(
+      `/api/share/${id}`,
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', 'X-Delete-Token': deleteToken },
       },
-    });
-
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    // Validate success response structure
-    if (typeof data === 'object' && data !== null && 'success' in data && 'message' in data) {
-      return ok(data as { success: true; message: string });
-    }
-    return err(apiServerError());
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+      isSuccessMessage
+    )
+  );
 }
 
 /**
@@ -354,28 +327,7 @@ export async function reportShare(
   id: string,
   reason?: string
 ): Promise<Result<{ success: true; message: string }, ApiError>> {
-  try {
-    const response = await fetch(`/api/report/${id}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ reason }),
-    });
-
-    const data: unknown = await response.json();
-
-    if (!response.ok) {
-      if (isApiErrorResponse(data)) {
-        return err(mapApiErrorResponse(data));
-      }
-      return err(apiServerError());
-    }
-
-    // Validate success response structure
-    if (typeof data === 'object' && data !== null && 'success' in data && 'message' in data) {
-      return ok(data as { success: true; message: string });
-    }
-    return err(apiServerError());
-  } catch (error) {
-    return err(apiNetworkError(error));
-  }
+  return withNetworkErrors(() =>
+    requestShare(`/api/report/${id}`, jsonInit('POST', { reason }), isSuccessMessage)
+  );
 }


### PR DESCRIPTION
The share API repeated its plumbing on both sides of the wire. jscpd listed the server handler and the client module among the most self-duplicated files in the repo.

**Client (`src/core/api/share.ts`)**

Six functions each did fetch, parse JSON, map a non-OK body through `isApiErrorResponse`, then type-guard the success body, all inside a try that turned a throw into `apiNetworkError`. Three small helpers replace that: `requestJson` (fetch, parse, map errors), `requestShare` (adds the success guard) and `withNetworkErrors` (the catch). `createShare` and `updateShare` still gather linked designs inside the guarded scope, so a storage failure there maps to the same network error as before. The two success-message endpoints share one `isSuccessMessage` guard. The file drops from 384 to 318 lines with the same exports and the same `Result` types.

**Server (`api/share/[id].ts`, `api/liveblocks-auth.ts`, `api/lib/shared.ts`)**

- `loadShare(blobPath)` in `api/lib/shared.ts` is the head, fetch, parse sequence that GET, PUT, DELETE and the Liveblocks auth handler each spelled out. It keeps their lenient semantics: any Blob failure reads as not found.
- `verifyDeleteToken(id, existing, token)` holds the Redis-first, blob-fallback hash lookup and the constant-time compare that PUT and DELETE both ran.
- `writeShareAndRespond` is the blob write plus the `{ id, url, permission }` reply that PUT's two branches duplicated.

No status codes, messages, Blob options or Redis keys change.

**Verification**

- Root and api typechecks, lint, and the handler test suites (`api/share`, `api/liveblocks-auth`, `api/report`) plus the client `src/core/api` tests pass unchanged: 7 files, 113 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

