### PR TITLE
refactor(import): share the drop zone, error list and preview panel

### DIFF
--- a/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
+++ b/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
@@ -6,12 +6,14 @@
  */
 
 import { useState, useRef, useCallback } from 'react';
-import type { ChangeEvent, DragEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { parseDesignJSON } from '@/features/bin-designer/utils/designJson';
 import type { BinParams } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { Button } from '@/design-system';
-import { SchemaDocsLink } from '@/shared/components/SchemaDocsLink';
+import { ImportDropZone } from '@/shared/components/ImportDropZone';
+import { ImportValidationErrors } from '@/shared/components/ImportValidationErrors';
+import { ImportPreviewPanel } from '@/shared/components/ImportPreviewPanel';
 
 interface DesignImportViewProps {
   onImport: (design: { name: string; params: BinParams }) => void;
@@ -37,11 +39,9 @@ export function DesignImportView({ onImport, onCancel, onStlFile }: DesignImport
   const [jsonText, setJsonText] = useState('');
   const [errors, setErrors] = useState<string[]>([]);
   const [preview, setPreview] = useState<ImportPreview | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
   const [validDesign, setValidDesign] = useState<{ name: string; params: BinParams } | null>(null);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const processInput = useCallback(
     (text: string) => {
@@ -81,49 +81,8 @@ export function DesignImportView({ onImport, onCancel, onStlFile }: DesignImport
     [processInput]
   );
 
-  const handleFileUpload = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
-      if (onStlFile && file.name.toLowerCase().endsWith('.stl')) {
-        onStlFile(file);
-        e.target.value = '';
-        return;
-      }
-
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const text = event.target?.result as string;
-        processInput(text);
-      };
-      reader.readAsText(file);
-    },
-    [processInput, onStlFile]
-  );
-
-  const handleDragOver = useCallback((e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-  }, []);
-
-  const handleDragLeave = useCallback((e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDragging(false);
-
-      const files = e.dataTransfer.files;
-      if (files.length === 0) return;
-
-      const file = files[0];
+  const handleFile = useCallback(
+    (file: File) => {
       if (onStlFile && file.name.toLowerCase().endsWith('.stl')) {
         onStlFile(file);
         return;
@@ -158,54 +117,13 @@ export function DesignImportView({ onImport, onCancel, onStlFile }: DesignImport
 
   return (
     <div className="flex flex-col h-full">
-      {/* Drop Zone */}
-      <div
-        className={`
-          relative border-2 border-dashed rounded-lg p-8 mb-4 text-center transition-colors
-          ${isDragging ? 'border-accent bg-accent/10' : 'border-stroke hover:border-stroke-subtle'}
-        `}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={onStlFile ? '.json,.stl' : '.json'}
-          onChange={handleFileUpload}
-          className="hidden"
-        />
-
-        <svg
-          className={`w-12 h-12 mx-auto mb-3 transition-colors ${isDragging ? 'text-accent' : 'text-content-tertiary'}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-          />
-        </svg>
-
-        <p className="text-content-secondary mb-2">
-          {isDragging
-            ? t('layouts.dropFileHere')
-            : onStlFile
-              ? t('binDesigner.dragDropDesignFile')
-              : t('binDesigner.dragDropDesignJson')}
-        </p>
-        <p className="text-content-tertiary text-sm mb-4">{t('layouts.or')}</p>
-        <Button
-          variant="secondary"
-          onClick={() => fileInputRef.current?.click()}
-          className="px-4 py-2 bg-surface-secondary hover:bg-surface border border-stroke text-content text-sm rounded-lg transition-colors"
-        >
-          {t('layouts.browseFiles')}
-        </Button>
-      </div>
+      <ImportDropZone
+        accept={onStlFile ? '.json,.stl' : '.json'}
+        prompt={
+          onStlFile ? t('binDesigner.dragDropDesignFile') : t('binDesigner.dragDropDesignJson')
+        }
+        onFile={handleFile}
+      />
 
       {/* Divider */}
       <div className="flex items-center gap-4 mb-4">
@@ -240,51 +158,17 @@ export function DesignImportView({ onImport, onCancel, onStlFile }: DesignImport
         />
       </div>
 
-      {/* Validation Errors */}
-      {errors.length > 0 && (
-        <div className="bg-danger-muted border border-danger rounded-lg p-3 mb-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-danger mb-1">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            {t('layouts.validationErrors')}
-          </div>
-          <ul className="text-sm text-danger/80 space-y-1 ml-6">
-            {errors.map((error, index) => (
-              <li key={index}>• {error}</li>
-            ))}
-          </ul>
-          <SchemaDocsLink className="mt-2 ml-6 inline-block text-danger/80 hover:text-danger" />
-        </div>
-      )}
+      <ImportValidationErrors errors={errors} />
 
       {preview && (
-        <div className="bg-success-muted border border-success rounded-lg p-4 mb-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-success mb-2">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            {t('binDesigner.readyToImportDesign')}
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
-            <div>{t('layouts.name')}</div>
-            <div className="font-medium">{preview.name}</div>
-            <div>{t('binDesigner.dimensions')}</div>
-            <div>{preview.dimensions}</div>
-            <div>{t('binDesigner.compartments')}</div>
-            <div>{preview.compartmentCount}</div>
-          </div>
-        </div>
+        <ImportPreviewPanel
+          title={t('binDesigner.readyToImportDesign')}
+          rows={[
+            { label: t('layouts.name'), value: preview.name, emphasis: true },
+            { label: t('binDesigner.dimensions'), value: preview.dimensions },
+            { label: t('binDesigner.compartments'), value: preview.compartmentCount },
+          ]}
+        />
       )}
 
       {/* Action Buttons */}

--- a/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
@@ -1,12 +1,14 @@
 import { useState, useRef, useCallback } from 'react';
-import type { ChangeEvent, DragEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { validateImport } from '@/shared/utils/validation';
 import { decodeLayoutFromURL, isArchiveFormat } from '@/core/storage';
 import type { Layout } from '@/core/types';
 import type { LayoutArchive } from '@/core/storage';
 import { useTranslation } from '@/i18n';
 import { Button } from '@/design-system';
-import { SchemaDocsLink } from '@/shared/components/SchemaDocsLink';
+import { ImportDropZone } from '@/shared/components/ImportDropZone';
+import { ImportValidationErrors } from '@/shared/components/ImportValidationErrors';
+import { ImportPreviewPanel } from '@/shared/components/ImportPreviewPanel';
 
 interface ImportViewProps {
   onImport: (layout: Layout) => void;
@@ -38,12 +40,10 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
   const [errors, setErrors] = useState<string[]>([]);
   const [preview, setPreview] = useState<ImportPreview | null>(null);
   const [archivePreview, setArchivePreview] = useState<ArchivePreview | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
   const [validLayout, setValidLayout] = useState<Layout | null>(null);
   const [validArchive, setValidArchive] = useState<LayoutArchive | null>(null);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const processInput = useCallback(
     (text: string) => {
@@ -144,42 +144,12 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
     [processInput, t]
   );
 
-  const handleFileUpload = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-      readFile(file);
-    },
-    [readFile]
-  );
-
-  const handleDragOver = useCallback((e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-  }, []);
-
-  const handleDragLeave = useCallback((e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDragging(false);
-
-      const files = e.dataTransfer.files;
-      if (files.length === 0) return;
-
-      const file = files[0];
+  const handleFile = useCallback(
+    (file: File) => {
       if (!file.name.endsWith('.json')) {
         setErrors([t('binDesigner.designJson.error.mustBeJsonFile')]);
         return;
       }
-
       readFile(file);
     },
     [readFile, t]
@@ -224,46 +194,7 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
         {t('layouts.importedLayoutsAreSavedToMyLayouts')}
       </p>
 
-      {/* Drop Zone */}
-      <div
-        className={`
-          relative border-2 border-dashed rounded-lg p-8 mb-4 text-center transition-colors
-          ${isDragging ? 'border-accent bg-accent/10' : 'border-stroke hover:border-stroke-subtle'}
-        `}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          onChange={handleFileUpload}
-          className="hidden"
-        />
-
-        <svg
-          className={`w-12 h-12 mx-auto mb-3 transition-colors ${isDragging ? 'text-accent' : 'text-content-tertiary'}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-          />
-        </svg>
-
-        <p className="text-content-secondary mb-2">
-          {isDragging ? t('layouts.dropFileHere') : t('layouts.dragDropJson')}
-        </p>
-        <p className="text-content-tertiary text-sm mb-4">{t('layouts.or')}</p>
-        <Button variant="secondary" onClick={() => fileInputRef.current?.click()}>
-          {t('layouts.browseFiles')}
-        </Button>
-      </div>
+      <ImportDropZone accept=".json" prompt={t('layouts.dragDropJson')} onFile={handleFile} />
 
       {/* Divider */}
       <div className="flex items-center gap-4 mb-4">
@@ -299,80 +230,34 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
         />
       </div>
 
-      {/* Validation Errors */}
-      {errors.length > 0 && (
-        <div className="bg-danger-muted border border-danger rounded-lg p-3 mb-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-danger mb-1">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            {t('layouts.validationErrors')}
-          </div>
-          <ul className="text-sm text-danger/80 space-y-1 ml-6">
-            {errors.map((error, index) => (
-              <li key={index}>• {error}</li>
-            ))}
-          </ul>
-          <SchemaDocsLink className="mt-2 ml-6 inline-block text-danger/80 hover:text-danger" />
-        </div>
-      )}
+      <ImportValidationErrors errors={errors} />
 
-      {/* Preview (single layout) */}
       {preview && (
-        <div className="bg-success-muted border border-success rounded-lg p-4 mb-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-success mb-2">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            {t('layouts.readyToImport')}
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
-            <div>{t('layouts.name')}</div>
-            <div className="font-medium">{preview.name}</div>
-            <div>{t('layouts.drawerSize')}</div>
-            <div>{preview.drawerSize}</div>
-            <div>{t('layouts.layers')}</div>
-            <div>{preview.layerCount}</div>
-            <div>{t('layouts.bins')}</div>
-            <div>{preview.binCount}</div>
-            {preview.linkedDesignCount !== undefined && preview.linkedDesignCount > 0 && (
-              <>
-                <div>{t('layouts.binDesigns')}</div>
-                <div>{preview.linkedDesignCount}</div>
-              </>
-            )}
-          </div>
-        </div>
+        <ImportPreviewPanel
+          title={t('layouts.readyToImport')}
+          rows={[
+            { label: t('layouts.name'), value: preview.name, emphasis: true },
+            { label: t('layouts.drawerSize'), value: preview.drawerSize },
+            { label: t('layouts.layers'), value: preview.layerCount },
+            { label: t('layouts.bins'), value: preview.binCount },
+            ...(preview.linkedDesignCount !== undefined && preview.linkedDesignCount > 0
+              ? [{ label: t('layouts.binDesigns'), value: preview.linkedDesignCount }]
+              : []),
+          ]}
+        />
       )}
 
       {archivePreview && (
-        <div className="bg-success-muted border border-success rounded-lg p-4 mb-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-success mb-2">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            {t('layouts.archiveDetected')}
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
-            <div>{t('layouts.layoutsInArchive')}</div>
-            <div className="font-medium">{archivePreview.layoutCount}</div>
-          </div>
-        </div>
+        <ImportPreviewPanel
+          title={t('layouts.archiveDetected')}
+          rows={[
+            {
+              label: t('layouts.layoutsInArchive'),
+              value: archivePreview.layoutCount,
+              emphasis: true,
+            },
+          ]}
+        />
       )}
 
       {/* Action Buttons */}

--- a/src/shared/components/ImportDropZone/ImportDropZone.test.tsx
+++ b/src/shared/components/ImportDropZone/ImportDropZone.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImportDropZone } from './ImportDropZone';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+describe('ImportDropZone', () => {
+  it('hands a dropped file over and swaps the prompt while dragging', () => {
+    const onFile = vi.fn();
+    render(<ImportDropZone accept=".json" prompt="Drop a layout" onFile={onFile} />);
+    const zone = screen.getByText('Drop a layout').parentElement as HTMLElement;
+    const file = new File(['{}'], 'a.json', { type: 'application/json' });
+
+    fireEvent.dragOver(zone);
+    expect(screen.getByText('layouts.dropFileHere')).toBeInTheDocument();
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+
+    expect(onFile).toHaveBeenCalledWith(file);
+    expect(screen.getByText('Drop a layout')).toBeInTheDocument();
+  });
+
+  it('hands a browsed file over and clears the input for a repeat pick', () => {
+    const onFile = vi.fn();
+    const { container } = render(<ImportDropZone accept=".json" prompt="p" onFile={onFile} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{}'], 'a.json', { type: 'application/json' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onFile).toHaveBeenCalledWith(file);
+    expect(input.value).toBe('');
+    expect(input).toHaveAttribute('accept', '.json');
+  });
+});

--- a/src/shared/components/ImportDropZone/ImportDropZone.tsx
+++ b/src/shared/components/ImportDropZone/ImportDropZone.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useRef, useState } from 'react';
+import type { ChangeEvent, DragEvent } from 'react';
+import { useTranslation } from '@/i18n';
+import { Button } from '@/design-system';
+
+interface ImportDropZoneProps {
+  /** Accept list for the hidden file input, e.g. `.json` or `.json,.stl`. */
+  accept: string;
+  /** Prompt shown at rest; while a file is dragged over, the shared drop prompt replaces it. */
+  prompt: string;
+  onFile: (file: File) => void;
+}
+
+export function ImportDropZone({ accept, prompt, onFile }: ImportDropZoneProps) {
+  const t = useTranslation();
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      const files = e.dataTransfer.files;
+      if (files.length === 0) return;
+      onFile(files[0]);
+    },
+    [onFile]
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      onFile(file);
+      // Clearing lets the same file be picked again after a failed attempt.
+      e.target.value = '';
+    },
+    [onFile]
+  );
+
+  return (
+    <div
+      className={`
+        relative border-2 border-dashed rounded-lg p-8 mb-4 text-center transition-colors
+        ${isDragging ? 'border-accent bg-accent/10' : 'border-stroke hover:border-stroke-subtle'}
+      `}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        onChange={handleChange}
+        className="hidden"
+      />
+
+      <svg
+        className={`w-12 h-12 mx-auto mb-3 transition-colors ${isDragging ? 'text-accent' : 'text-content-tertiary'}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+        />
+      </svg>
+
+      <p className="text-content-secondary mb-2">
+        {isDragging ? t('layouts.dropFileHere') : prompt}
+      </p>
+      <p className="text-content-tertiary text-sm mb-4">{t('layouts.or')}</p>
+      <Button variant="secondary" onClick={() => fileInputRef.current?.click()}>
+        {t('layouts.browseFiles')}
+      </Button>
+    </div>
+  );
+}

--- a/src/shared/components/ImportDropZone/index.ts
+++ b/src/shared/components/ImportDropZone/index.ts
@@ -1,0 +1,1 @@
+export { ImportDropZone } from './ImportDropZone';

--- a/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.test.tsx
+++ b/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ImportPreviewPanel } from './ImportPreviewPanel';
+
+describe('ImportPreviewPanel', () => {
+  it('renders the title and each label/value pair in order', () => {
+    render(
+      <ImportPreviewPanel
+        title="Ready"
+        rows={[
+          { label: 'Name', value: 'Kitchen', emphasis: true },
+          { label: 'Bins', value: 12 },
+        ]}
+      />
+    );
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(screen.getByText('Kitchen')).toHaveClass('font-medium');
+    expect(screen.getByText('12')).not.toHaveClass('font-medium');
+    const cells = screen.getAllByText(/Name|Kitchen|Bins|12/).map((el) => el.textContent);
+    expect(cells).toEqual(['Name', 'Kitchen', 'Bins', '12']);
+  });
+});

--- a/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
+++ b/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
@@ -1,0 +1,40 @@
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+
+export interface ImportPreviewRow {
+  readonly label: string;
+  readonly value: ReactNode;
+  readonly emphasis?: boolean;
+}
+
+export function ImportPreviewPanel({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: readonly ImportPreviewRow[];
+}) {
+  return (
+    <div className="bg-success-muted border border-success rounded-lg p-4 mb-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-success mb-2">
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        {title}
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
+        {rows.map((row) => (
+          <Fragment key={row.label}>
+            <div>{row.label}</div>
+            <div className={row.emphasis ? 'font-medium' : undefined}>{row.value}</div>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/ImportPreviewPanel/index.ts
+++ b/src/shared/components/ImportPreviewPanel/index.ts
@@ -1,0 +1,2 @@
+export { ImportPreviewPanel } from './ImportPreviewPanel';
+export type { ImportPreviewRow } from './ImportPreviewPanel';

--- a/src/shared/components/ImportValidationErrors/ImportValidationErrors.test.tsx
+++ b/src/shared/components/ImportValidationErrors/ImportValidationErrors.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ImportValidationErrors } from './ImportValidationErrors';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+vi.mock('@/shared/components/SchemaDocsLink', () => ({
+  SchemaDocsLink: () => <a href="#schema">schema</a>,
+}));
+
+describe('ImportValidationErrors', () => {
+  it('renders nothing without errors', () => {
+    const { container } = render(<ImportValidationErrors errors={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists every error under the heading with the schema link', () => {
+    render(<ImportValidationErrors errors={['too wide', 'no layers']} />);
+    expect(screen.getByText('layouts.validationErrors')).toBeInTheDocument();
+    expect(screen.getByText('• too wide')).toBeInTheDocument();
+    expect(screen.getByText('• no layers')).toBeInTheDocument();
+    expect(screen.getByText('schema')).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/ImportValidationErrors/ImportValidationErrors.tsx
+++ b/src/shared/components/ImportValidationErrors/ImportValidationErrors.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from '@/i18n';
+import { SchemaDocsLink } from '@/shared/components/SchemaDocsLink';
+
+export function ImportValidationErrors({ errors }: { errors: readonly string[] }) {
+  const t = useTranslation();
+  if (errors.length === 0) return null;
+  return (
+    <div className="bg-danger-muted border border-danger rounded-lg p-3 mb-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-danger mb-1">
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        {t('layouts.validationErrors')}
+      </div>
+      <ul className="text-sm text-danger/80 space-y-1 ml-6">
+        {errors.map((error, index) => (
+          <li key={index}>• {error}</li>
+        ))}
+      </ul>
+      <SchemaDocsLink className="mt-2 ml-6 inline-block text-danger/80 hover:text-danger" />
+    </div>
+  );
+}

--- a/src/shared/components/ImportValidationErrors/index.ts
+++ b/src/shared/components/ImportValidationErrors/index.ts
@@ -1,0 +1,1 @@
+export { ImportValidationErrors } from './ImportValidationErrors';


### PR DESCRIPTION
The bin designer's design import view and the layout library's import view are the same screen with different parsers. Each carried its own drop zone (drag state, three drag handlers, hidden file input, cloud icon, prompts, browse button), the same validation-error block, and the same green "ready to import" panel. jscpd flagged three separate clones between the two files.

**Three shared components in `src/shared/components/`**

- `ImportDropZone`: owns the drag state and handlers, the hidden input and the browse button. Takes `accept`, the resting `prompt` and `onFile`. Dropping and browsing now go through one callback per view, so the design view's non-JSON rejection (which only the drop path used to apply) also covers a browsed file that slips past `accept`, and the input clears after every pick so the same file can be chosen again after a failed attempt (previously only the STL branch cleared it).
- `ImportValidationErrors`: the error list with its heading and schema-docs link; renders nothing for an empty list.
- `ImportPreviewPanel`: the success panel as a title plus label/value rows. The layout view's archive panel uses it too.

The design view goes from 310 to 189 lines and the layout view from 405 to 291. Copy, class names and translation keys are unchanged, apart from the design view's browse button dropping a hand-written class string that reproduced the secondary variant.

**Verification**

- Typecheck, lint, module boundaries, design-system and component-structure gates pass.
- Both views' existing test suites pass unchanged, including the drop, drag-styling, STL routing and archive cases. The three components have their own tests (drop and browse hand-off, input clearing, prompt swap while dragging, empty and populated error lists, row rendering).

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

