### PR TITLE
refactor: fold three in-feature clones into one home each

### DIFF
--- a/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
+++ b/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
@@ -1,10 +1,10 @@
 import { useTranslation, useFormatting } from '@/i18n';
-import { Button, Checkbox, Input, useInlineEdit } from '@/design-system';
+import { Button, Checkbox, Input } from '@/design-system';
 import { BinDesignThumbnail } from '../BinDesignThumbnail';
 import { DesignActions } from '../DesignActions';
 import { DesignTagChips } from '../DesignTagChips';
 import type { SavedDesign } from '../../types';
-import { designFootprint } from '../../utils/designKind';
+import { useDesignItem } from '../../hooks/useDesignItem';
 
 interface DesignGridItemProps {
   design: SavedDesign;
@@ -70,35 +70,11 @@ export function DesignGridItem({
     handleChange,
     handleFinish,
     handleKeyDown,
-  } = useInlineEdit({
-    initialValue: design.name,
-    onSave: onRename,
-  });
-
-  const { width, depth, height } = designFootprint(design);
-  const numCompartments = design.params ? new Set(design.params.compartments.cells).size : 0;
-
-  const activate = () => {
-    if (selectionActive) onToggleSelect?.();
-    else onSelect();
-  };
-
-  const handleClick = () => {
-    if (!isEditing) {
-      activate();
-    }
-  };
-
-  const handleItemKeyDown = (e: React.KeyboardEvent) => {
-    if (isEditing) {
-      handleKeyDown(e);
-      return;
-    }
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      activate();
-    }
-  };
+    footprint: { width, depth, height },
+    numCompartments,
+    handleClick,
+    handleItemKeyDown,
+  } = useDesignItem({ design, onSelect, onRename, selectionActive, onToggleSelect });
 
   return (
     <div

--- a/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
+++ b/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
@@ -1,10 +1,10 @@
 import { useTranslation, useFormatting } from '@/i18n';
-import { Checkbox, IconButton, Input, useInlineEdit } from '@/design-system';
+import { Checkbox, IconButton, Input } from '@/design-system';
 import { BinDesignThumbnail } from '../BinDesignThumbnail';
 import { DesignActions } from '../DesignActions';
 import { DesignTagChips } from '../DesignTagChips';
 import type { SavedDesign } from '../../types';
-import { designFootprint } from '../../utils/designKind';
+import { useDesignItem } from '../../hooks/useDesignItem';
 
 interface DesignListItemProps {
   design: SavedDesign;
@@ -69,35 +69,11 @@ export function DesignListItem({
     handleChange,
     handleFinish,
     handleKeyDown,
-  } = useInlineEdit({
-    initialValue: design.name,
-    onSave: onRename,
-  });
-
-  const { width, depth, height } = designFootprint(design);
-  const numCompartments = design.params ? new Set(design.params.compartments.cells).size : 0;
-
-  const activate = () => {
-    if (selectionActive) onToggleSelect?.();
-    else onSelect();
-  };
-
-  const handleClick = () => {
-    if (!isEditing) {
-      activate();
-    }
-  };
-
-  const handleItemKeyDown = (e: React.KeyboardEvent) => {
-    if (isEditing) {
-      handleKeyDown(e);
-      return;
-    }
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      activate();
-    }
-  };
+    footprint: { width, depth, height },
+    numCompartments,
+    handleClick,
+    handleItemKeyDown,
+  } = useDesignItem({ design, onSelect, onRename, selectionActive, onToggleSelect });
 
   return (
     <li

--- a/src/features/bin-designer/hooks/useDesignItem.test.ts
+++ b/src/features/bin-designer/hooks/useDesignItem.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { SavedDesign } from '@/features/bin-designer/types';
+import { useDesignItem } from './useDesignItem';
+
+const design = {
+  id: 'd1',
+  name: 'Box',
+  params: {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: { ...DEFAULT_BIN_PARAMS.compartments, cells: [0, 0, 1, 2] },
+  },
+  createdAt: 0,
+  updatedAt: 0,
+} as unknown as SavedDesign;
+
+function key(k: string) {
+  return { key: k, preventDefault: vi.fn() } as unknown as ReactKeyboardEvent;
+}
+
+describe('useDesignItem', () => {
+  it('counts distinct compartments and reports the footprint', () => {
+    const { result } = renderHook(() =>
+      useDesignItem({ design, onSelect: vi.fn(), onRename: vi.fn(), selectionActive: false })
+    );
+    expect(result.current.numCompartments).toBe(3);
+    expect(result.current.footprint.width).toBe(DEFAULT_BIN_PARAMS.width);
+  });
+
+  it('loads on click and on Enter, or toggles selection in bulk mode', () => {
+    const onSelect = vi.fn();
+    const onToggleSelect = vi.fn();
+    const plain = renderHook(() =>
+      useDesignItem({ design, onSelect, onRename: vi.fn(), selectionActive: false, onToggleSelect })
+    );
+    plain.result.current.handleClick();
+    const enter = key('Enter');
+    plain.result.current.handleItemKeyDown(enter);
+    expect(onSelect).toHaveBeenCalledTimes(2);
+    expect(enter.preventDefault).toHaveBeenCalled();
+    expect(onToggleSelect).not.toHaveBeenCalled();
+
+    const bulk = renderHook(() =>
+      useDesignItem({ design, onSelect, onRename: vi.fn(), selectionActive: true, onToggleSelect })
+    );
+    bulk.result.current.handleItemKeyDown(key(' '));
+    expect(onToggleSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/bin-designer/hooks/useDesignItem.ts
+++ b/src/features/bin-designer/hooks/useDesignItem.ts
@@ -1,0 +1,47 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useInlineEdit } from '@/design-system';
+import type { SavedDesign } from '../types';
+import { designFootprint } from '../utils/designKind';
+
+interface UseDesignItemOptions {
+  design: SavedDesign;
+  onSelect: () => void;
+  onRename: (newName: string) => void;
+  /** Bulk-selection mode: activating toggles selection instead of loading. */
+  selectionActive: boolean;
+  onToggleSelect?: () => void;
+}
+
+export function useDesignItem({
+  design,
+  onSelect,
+  onRename,
+  selectionActive,
+  onToggleSelect,
+}: UseDesignItemOptions) {
+  const edit = useInlineEdit({ initialValue: design.name, onSave: onRename });
+  const footprint = designFootprint(design);
+  const numCompartments = design.params ? new Set(design.params.compartments.cells).size : 0;
+
+  const activate = () => {
+    if (selectionActive) onToggleSelect?.();
+    else onSelect();
+  };
+
+  const handleClick = () => {
+    if (!edit.isEditing) activate();
+  };
+
+  const handleItemKeyDown = (e: ReactKeyboardEvent) => {
+    if (edit.isEditing) {
+      edit.handleKeyDown(e);
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      activate();
+    }
+  };
+
+  return { ...edit, footprint, numCompartments, handleClick, handleItemKeyDown };
+}

--- a/src/features/generation/bridge/WorkerPool.ts
+++ b/src/features/generation/bridge/WorkerPool.ts
@@ -120,41 +120,12 @@ export class WorkerPool {
       signal?: AbortSignal;
     }
   ): Promise<SplitPreviewResult> {
-    await this.ensureWorkers();
-
-    // Cap active workers to the piece count: each worker regenerates the full
-    // solid, so spinning up more workers than pieces only adds redundant
-    // full-gen work with no piece to show for it.
-    const activeWorkers = Math.min(totalPieceCount, this.bridges.length);
-    const groups = distributeRoundRobin(totalPieceCount, activeWorkers);
-    let completed = 0;
-
-    const taskGroups = groups.map((pieceIndices, bridgeIdx) => {
-      if (pieceIndices.length === 0) return [];
-      const bridge = this.bridges[bridgeIdx];
-      return [
-        async (): Promise<SplitPreviewResult> => {
-          const result = await bridge.generateSplitPreviewRange(
-            params,
-            cutPlanesX,
-            cutPlanesY,
-            pieceIndices,
-            { splitConnectorConfig: options?.splitConnectorConfig }
-          );
-          completed += pieceIndices.length;
-          options?.onProgress?.(completed, totalPieceCount);
-          return result;
-        },
-      ];
-    });
-
-    const results = await runGrouped(taskGroups, options?.signal);
-
-    // Merge and sort pieces back to col-major grid order for consistency
-    // with the non-pool single-bridge path
-    const allPieces = results.flatMap((r) => r.pieces);
-    allPieces.sort((a, b) => a.col - b.col || a.row - b.row);
-    return { pieces: allPieces };
+    const pieces = await this.runSplitPieces(totalPieceCount, options, (bridge, pieceIndices) =>
+      bridge.generateSplitPreviewRange(params, cutPlanesX, cutPlanesY, pieceIndices, {
+        splitConnectorConfig: options?.splitConnectorConfig,
+      })
+    );
+    return { pieces };
   }
 
   /**
@@ -177,9 +148,35 @@ export class WorkerPool {
       signal?: AbortSignal;
     }
   ): Promise<SplitExportResult> {
+    const pieces = await this.runSplitPieces(totalPieceCount, options, (bridge, pieceIndices) =>
+      bridge.exportSplitBinRange(params, cutPlanesX, cutPlanesY, pieceIndices, {
+        tolerance: options?.tolerance,
+        angularTolerance: options?.angularTolerance,
+        splitConnectorConfig: options?.splitConnectorConfig,
+        format: options?.format,
+      })
+    );
+    return { pieces };
+  }
+
+  /**
+   * Fan one split job out across the pool: each bridge regenerates the full
+   * solid and produces only its assigned pieces, then the pieces come back in
+   * col-major grid order to match the single-bridge path.
+   */
+  private async runSplitPieces<
+    R extends { readonly pieces: readonly { readonly col: number; readonly row: number }[] },
+  >(
+    totalPieceCount: number,
+    options:
+      { onProgress?: (completed: number, total: number) => void; signal?: AbortSignal } | undefined,
+    generate: (bridge: GenerationBridge, pieceIndices: number[]) => Promise<R>
+  ): Promise<R['pieces'][number][]> {
     await this.ensureWorkers();
 
-    // Cap active workers to the piece count (see generateSplitPreview).
+    // Cap active workers to the piece count: each worker regenerates the full
+    // solid, so spinning up more workers than pieces only adds redundant
+    // full-gen work with no piece to show for it.
     const activeWorkers = Math.min(totalPieceCount, this.bridges.length);
     const groups = distributeRoundRobin(totalPieceCount, activeWorkers);
     let completed = 0;
@@ -188,19 +185,8 @@ export class WorkerPool {
       if (pieceIndices.length === 0) return [];
       const bridge = this.bridges[bridgeIdx];
       return [
-        async (): Promise<SplitExportResult> => {
-          const result = await bridge.exportSplitBinRange(
-            params,
-            cutPlanesX,
-            cutPlanesY,
-            pieceIndices,
-            {
-              tolerance: options?.tolerance,
-              angularTolerance: options?.angularTolerance,
-              splitConnectorConfig: options?.splitConnectorConfig,
-              format: options?.format,
-            }
-          );
+        async (): Promise<R> => {
+          const result = await generate(bridge, pieceIndices);
           completed += pieceIndices.length;
           options?.onProgress?.(completed, totalPieceCount);
           return result;
@@ -209,11 +195,9 @@ export class WorkerPool {
     });
 
     const results = await runGrouped(taskGroups, options?.signal);
-
-    // Merge and sort pieces back to col-major grid order
     const allPieces = results.flatMap((r) => r.pieces);
     allPieces.sort((a, b) => a.col - b.col || a.row - b.row);
-    return { pieces: allPieces };
+    return allPieces;
   }
   /**
    * Generate multiple baseplate pieces in parallel across pool workers.

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutList/LayoutList.tsx
@@ -242,6 +242,25 @@ export function LayoutList({
     [searchScope, onDelete, announceToScreenReader, t]
   );
 
+  const layoutItemProps = (entry: LayoutEntry, index: number) => ({
+    entry,
+    isActive: entry.id === activeLayoutId,
+    isFocused: index === focusedIndex,
+    isOnlyLayout: searchScope.length <= 1,
+    onSelect: () => handleSwitch(entry.id),
+    onRename: (newName: string) => handleRename(entry.id, newName),
+    onDuplicate: () => handleDuplicate(entry.id),
+    onDelete: () => handleDelete(entry.id),
+    onCopyLink: () => onShare(entry.id),
+    onDownload: () => handleDownload(entry),
+    onMoveToFolder: onMoveToFolder ? () => onMoveToFolder(entry.id) : undefined,
+    onFocus: () => setFocusedIndex(index),
+    itemRef: (el: HTMLDivElement | null) => {
+      if (el) itemRefs.current.set(entry.id, el);
+      else itemRefs.current.delete(entry.id);
+    },
+  });
+
   return (
     <div className="h-full grid grid-rows-[auto_1fr_auto]">
       {/* Header: Search */}
@@ -344,25 +363,7 @@ export function LayoutList({
           onKeyDown={handleListKeyDown}
         >
           {sortedEntries.map((entry, index) => (
-            <LayoutGridItem
-              key={entry.id}
-              entry={entry}
-              isActive={entry.id === activeLayoutId}
-              isFocused={index === focusedIndex}
-              isOnlyLayout={searchScope.length <= 1}
-              onSelect={() => handleSwitch(entry.id)}
-              onRename={(newName) => handleRename(entry.id, newName)}
-              onDuplicate={() => handleDuplicate(entry.id)}
-              onDelete={() => handleDelete(entry.id)}
-              onCopyLink={() => onShare(entry.id)}
-              onDownload={() => handleDownload(entry)}
-              onMoveToFolder={onMoveToFolder ? () => onMoveToFolder(entry.id) : undefined}
-              onFocus={() => setFocusedIndex(index)}
-              itemRef={(el) => {
-                if (el) itemRefs.current.set(entry.id, el);
-                else itemRefs.current.delete(entry.id);
-              }}
-            />
+            <LayoutGridItem key={entry.id} {...layoutItemProps(entry, index)} />
           ))}
         </div>
       )}
@@ -378,25 +379,7 @@ export function LayoutList({
           onKeyDown={handleListKeyDown}
         >
           {sortedEntries.map((entry, index) => (
-            <LayoutListItem
-              key={entry.id}
-              entry={entry}
-              isActive={entry.id === activeLayoutId}
-              isFocused={index === focusedIndex}
-              isOnlyLayout={searchScope.length <= 1}
-              onSelect={() => handleSwitch(entry.id)}
-              onRename={(newName) => handleRename(entry.id, newName)}
-              onDuplicate={() => handleDuplicate(entry.id)}
-              onDelete={() => handleDelete(entry.id)}
-              onCopyLink={() => onShare(entry.id)}
-              onDownload={() => handleDownload(entry)}
-              onMoveToFolder={onMoveToFolder ? () => onMoveToFolder(entry.id) : undefined}
-              onFocus={() => setFocusedIndex(index)}
-              itemRef={(el) => {
-                if (el) itemRefs.current.set(entry.id, el);
-                else itemRefs.current.delete(entry.id);
-              }}
-            />
+            <LayoutListItem key={entry.id} {...layoutItemProps(entry, index)} />
           ))}
         </div>
       )}


### PR DESCRIPTION
Three in-feature clones from the jscpd scan, each a block that has to be edited twice today.

- **`useDesignItem`** (`bin-designer/hooks`): the design grid card and list row opened with the same 45 lines: inline-edit wiring for the name, the footprint and compartment count, and the click and keyboard handlers that either load the design or toggle bulk selection. Both components now destructure that from one hook.
- **`layoutItemProps`** in `LayoutList`: the grid and list branches passed fourteen identical props to `LayoutGridItem` and `LayoutListItem`. One builder produces them; each branch spreads it.
- **`runSplitPieces`** in `WorkerPool`: split preview and split export each fanned pieces across the pool with the same round-robin distribution, progress accounting and col-major merge. The private helper owns that; each method supplies only the bridge call.

No behaviour changes.

**Verification**

- Typecheck, lint, module boundaries and design-system gates pass.
- Vitest over the two design items, the design list dialog, the layout list and the generation bridge: 27 files, 361 tests. The hook has its own test (compartment count, footprint, click and Enter load, space toggles in bulk mode).

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

