### PR TITLE
fix(import): keep drag state over child nodes and accept upper-case .JSON

### DIFF
--- a/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
+++ b/src/features/bin-designer/components/DesignImportView/DesignImportView.tsx
@@ -87,7 +87,7 @@ export function DesignImportView({ onImport, onCancel, onStlFile }: DesignImport
         onStlFile(file);
         return;
       }
-      if (!file.name.endsWith('.json')) {
+      if (!file.name.toLowerCase().endsWith('.json')) {
         setErrors([t('binDesigner.designJson.error.mustBeJsonFile')]);
         return;
       }

--- a/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.tsx
@@ -146,7 +146,7 @@ export function ImportView({ onImport, onImportArchive, onCancel }: ImportViewPr
 
   const handleFile = useCallback(
     (file: File) => {
-      if (!file.name.endsWith('.json')) {
+      if (!file.name.toLowerCase().endsWith('.json')) {
         setErrors([t('binDesigner.designJson.error.mustBeJsonFile')]);
         return;
       }

--- a/src/shared/components/ImportDropZone/ImportDropZone.test.tsx
+++ b/src/shared/components/ImportDropZone/ImportDropZone.test.tsx
@@ -31,4 +31,22 @@ describe('ImportDropZone', () => {
     expect(input.value).toBe('');
     expect(input).toHaveAttribute('accept', '.json');
   });
+
+  it('keeps the drag state while moving between the zone and its children', () => {
+    render(<ImportDropZone accept=".json" prompt="Drop it" onFile={vi.fn()} />);
+    const prompt = screen.getByText('Drop it');
+    const zone = prompt.parentElement as HTMLElement;
+
+    // jsdom has no DragEvent; a MouseEvent carries relatedTarget and React
+    // dispatches it by name.
+    const leave = (relatedTarget: Element) =>
+      fireEvent(zone, new MouseEvent('dragleave', { bubbles: true, relatedTarget }));
+
+    fireEvent.dragOver(zone);
+    leave(screen.getByText('layouts.browseFiles'));
+    expect(screen.getByText('layouts.dropFileHere')).toBeInTheDocument();
+
+    leave(document.body);
+    expect(screen.getByText('Drop it')).toBeInTheDocument();
+  });
 });

--- a/src/shared/components/ImportDropZone/ImportDropZone.tsx
+++ b/src/shared/components/ImportDropZone/ImportDropZone.tsx
@@ -4,9 +4,7 @@ import { useTranslation } from '@/i18n';
 import { Button } from '@/design-system';
 
 interface ImportDropZoneProps {
-  /** Accept list for the hidden file input, e.g. `.json` or `.json,.stl`. */
   accept: string;
-  /** Prompt shown at rest; while a file is dragged over, the shared drop prompt replaces it. */
   prompt: string;
   onFile: (file: File) => void;
 }
@@ -25,6 +23,8 @@ export function ImportDropZone({ accept, prompt, onFile }: ImportDropZoneProps) 
   const handleDragLeave = useCallback((e: DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // Leaving the icon or the button for the zone itself is not leaving the zone.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
     setIsDragging(false);
   }, []);
 

--- a/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
+++ b/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
@@ -28,8 +28,8 @@ export function ImportPreviewPanel({
         {title}
       </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
-        {rows.map((row) => (
-          <Fragment key={row.label}>
+        {rows.map((row, index) => (
+          <Fragment key={index}>
             <div>{row.label}</div>
             <div className={row.emphasis ? 'font-medium' : undefined}>{row.value}</div>
           </Fragment>


### PR DESCRIPTION
Follow-up to #4178. The review fixes for that PR were pushed as its auto-merge fired and did not make the squash, so they land here.

- `ImportDropZone` ignores a `dragleave` whose `relatedTarget` is still inside the zone, so crossing the icon or the browse button keeps the highlight. A test drives the inner and outer leave with a `MouseEvent`, since jsdom has no `DragEvent`.
- Both import views lower-case the file name before the `.json` extension check, matching the STL check beside it.
- `ImportPreviewPanel` keys rows by position.
- The drop-zone prop comments that restated the types are gone.

**Verification**

- Typecheck and lint pass. Vitest over the drop zone, the preview panel and both import views: 5 files, 57 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

