### PR TITLE
refactor(sync): share the handler preamble across account, export and manifest

### DIFF
--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -1,10 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { Redis } from 'ioredis';
-import { requireMethod } from '../lib/method.js';
-import { rateLimited, serviceUnavailable, serverError } from '../lib/shared.js';
+import { serverError } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
-import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
-import { requireSession } from '../lib/session.js';
 import { clearSessionCookie } from '../lib/cookies.js';
 import { deleteBlob } from '../lib/blobStore.js';
 import {
@@ -43,6 +40,7 @@ import {
 } from '../lib/communityPrintStore.js';
 import { deriveAuthorPublicId } from '../lib/communityIds.js';
 import { unlinkSupporterAccount } from '../lib/supporterLink.js';
+import { requireSyncContext } from './lib/requireSyncContext.js';
 
 /**
  * DELETE /api/sync/account
@@ -79,23 +77,9 @@ import { unlinkSupporterAccount } from '../lib/supporterLink.js';
  * case, within budget.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['DELETE'])) return;
-
-  // CSRF defense is enforced inside `requireSession` (see api/lib/session.ts).
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const rate = await checkRateLimit(session.userId, 'sync.write');
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
+  const context = await requireSyncContext(req, res, ['DELETE'], 'sync.write');
+  if (!context) return;
+  const { session, redis } = context;
 
   const { userId } = session;
   try {

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -1,10 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { Zip, ZipDeflate, strToU8 } from 'fflate';
-import { requireMethod } from '../lib/method.js';
-import { rateLimited, serviceUnavailable, serverError } from '../lib/shared.js';
+import { serverError } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
-import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
-import { requireSession } from '../lib/session.js';
 import { getJson } from '../lib/blobStore.js';
 import {
   getIndex,
@@ -14,6 +11,7 @@ import {
 } from '../lib/userIndex.js';
 import { readCommunityDesignBlob } from '../lib/communityStore.js';
 import { communityPublishedKey } from '../lib/redisKeys.js';
+import { requireSyncContext } from './lib/requireSyncContext.js';
 
 /**
  * GET /api/sync/export
@@ -32,22 +30,9 @@ import { communityPublishedKey } from '../lib/redisKeys.js';
  * the audit trail of deletions.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['GET'])) return;
-
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const rate = await checkRateLimit(session.userId, 'sync.read');
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
+  const context = await requireSyncContext(req, res, ['GET'], 'sync.read');
+  if (!context) return;
+  const { session, redis } = context;
 
   try {
     const [

--- a/api/sync/lib/requireSyncContext.test.ts
+++ b/api/sync/lib/requireSyncContext.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const mocks = vi.hoisted(() => ({
+  requireMethod: vi.fn(),
+  requireSession: vi.fn(),
+  checkRateLimit: vi.fn(),
+  getRedis: vi.fn(),
+  rateLimited: vi.fn(),
+  serviceUnavailable: vi.fn(),
+}));
+vi.mock('../../lib/method.js', () => ({ requireMethod: mocks.requireMethod }));
+vi.mock('../../lib/session.js', () => ({ requireSession: mocks.requireSession }));
+vi.mock('../../lib/rateLimit.js', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRedis: mocks.getRedis,
+}));
+vi.mock('../../lib/shared.js', () => ({
+  rateLimited: mocks.rateLimited,
+  serviceUnavailable: mocks.serviceUnavailable,
+}));
+
+import { requireSyncContext } from './requireSyncContext';
+
+const req = {} as VercelRequest;
+const res = {} as VercelResponse;
+
+describe('requireSyncContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireMethod.mockReturnValue(true);
+    mocks.requireSession.mockResolvedValue({ userId: 'u1' });
+    mocks.checkRateLimit.mockResolvedValue({ allowed: true });
+    mocks.getRedis.mockReturnValue({ id: 'redis' });
+  });
+
+  it('returns the session and redis when every gate passes', async () => {
+    const ctx = await requireSyncContext(req, res, ['GET'], 'sync.read');
+    expect(ctx).toEqual({ session: { userId: 'u1' }, redis: { id: 'redis' } });
+    expect(mocks.requireMethod).toHaveBeenCalledWith(req, res, ['GET']);
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith('u1', 'sync.read');
+  });
+
+  it('stops at the first failing gate without touching the later ones', async () => {
+    mocks.requireSession.mockResolvedValue(null);
+    expect(await requireSyncContext(req, res, ['GET'], 'sync.read')).toBeNull();
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+
+    mocks.requireSession.mockResolvedValue({ userId: 'u1' });
+    mocks.checkRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 7 });
+    expect(await requireSyncContext(req, res, ['GET'], 'sync.read')).toBeNull();
+    expect(mocks.rateLimited).toHaveBeenCalledWith(res, 7);
+    expect(mocks.getRedis).not.toHaveBeenCalled();
+
+    mocks.checkRateLimit.mockResolvedValue({ allowed: true });
+    mocks.getRedis.mockReturnValue(null);
+    expect(await requireSyncContext(req, res, ['GET'], 'sync.read')).toBeNull();
+    expect(mocks.serviceUnavailable).toHaveBeenCalledWith(res);
+  });
+});

--- a/api/sync/lib/requireSyncContext.test.ts
+++ b/api/sync/lib/requireSyncContext.test.ts
@@ -42,6 +42,13 @@ describe('requireSyncContext', () => {
   });
 
   it('stops at the first failing gate without touching the later ones', async () => {
+    mocks.requireMethod.mockReturnValue(false);
+    expect(await requireSyncContext(req, res, ['GET'], 'sync.read')).toBeNull();
+    expect(mocks.requireSession).not.toHaveBeenCalled();
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.getRedis).not.toHaveBeenCalled();
+
+    mocks.requireMethod.mockReturnValue(true);
     mocks.requireSession.mockResolvedValue(null);
     expect(await requireSyncContext(req, res, ['GET'], 'sync.read')).toBeNull();
     expect(mocks.checkRateLimit).not.toHaveBeenCalled();

--- a/api/sync/lib/requireSyncContext.ts
+++ b/api/sync/lib/requireSyncContext.ts
@@ -1,0 +1,42 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { Redis } from 'ioredis';
+import { requireMethod } from '../../lib/method.js';
+import { rateLimited, serviceUnavailable } from '../../lib/shared.js';
+import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
+import { requireSession, type SessionRecord } from '../../lib/session.js';
+
+export interface SyncContext {
+  readonly session: SessionRecord;
+  readonly redis: Redis;
+}
+
+/**
+ * Method, session (which carries the CSRF defence), rate limit and Redis, in
+ * the order every sync handler checks them. Null means the response has
+ * already been sent.
+ */
+export async function requireSyncContext(
+  req: VercelRequest,
+  res: VercelResponse,
+  methods: readonly string[],
+  bucket: Parameters<typeof checkRateLimit>[1]
+): Promise<SyncContext | null> {
+  if (!requireMethod(req, res, methods)) return null;
+
+  const session = await requireSession(req, res);
+  if (!session) return null;
+
+  const rate = await checkRateLimit(session.userId, bucket);
+  if (!rate.allowed) {
+    rateLimited(res, rate.retryAfterSeconds);
+    return null;
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    serviceUnavailable(res);
+    return null;
+  }
+
+  return { session, redis };
+}

--- a/api/sync/manifest.ts
+++ b/api/sync/manifest.ts
@@ -1,10 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { requireMethod } from '../lib/method.js';
-import { rateLimited, serviceUnavailable, serverError } from '../lib/shared.js';
+import { serverError } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
-import { checkRateLimit, getRedis } from '../lib/rateLimit.js';
-import { requireSession } from '../lib/session.js';
 import { getIndex, getIndexUpdatedAt } from '../lib/userIndex.js';
+import { requireSyncContext } from './lib/requireSyncContext.js';
 
 /**
  * GET /api/sync/manifest
@@ -22,22 +20,9 @@ import { getIndex, getIndexUpdatedAt } from '../lib/userIndex.js';
  * hashes themselves.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['GET'])) return;
-
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const rate = await checkRateLimit(session.userId, 'sync.read');
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
+  const context = await requireSyncContext(req, res, ['GET'], 'sync.read');
+  if (!context) return;
+  const { session, redis } = context;
 
   try {
     const indexUpdatedAt = await getIndexUpdatedAt(redis, session.userId);


### PR DESCRIPTION
The three sync handlers outside the resource factory (`account`, `export`, `manifest`) opened with the same sixteen lines: method check, session (which carries the CSRF defence), rate limit against a named bucket, then Redis or 503, each with its own early return. `requireSyncContext(req, res, methods, bucket)` in `api/sync/lib` now runs that sequence and returns the session and Redis client, or null once a response has gone out.

Order, status codes and buckets are unchanged (`sync.write` for account deletion, `sync.read` for the two reads). Each handler's own comment about CSRF moves into the helper's docblock, since that is where the session check now lives.

**Verification**

- Root and api typechecks and lint pass.
- The three handler suites pass unchanged (their module mocks resolve to the same files the helper imports), and the helper has its own test covering the pass-through case and each early return in order: 5 files, 60 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

