### PR TITLE
test(import): cover upper-case .JSON drops and key preview rows by position and label

### DIFF
--- a/src/features/bin-designer/components/DesignImportView/DesignImportView.test.tsx
+++ b/src/features/bin-designer/components/DesignImportView/DesignImportView.test.tsx
@@ -224,6 +224,16 @@ describe('DesignImportView', () => {
     expect(screen.getByText('• Please drop a JSON file')).toBeInTheDocument();
   });
 
+  it('accepts an upper-case .JSON extension on drop', () => {
+    render(<DesignImportView {...defaultProps} />);
+    const file = new File(['{}'], 'DESIGN.JSON', { type: 'application/json' });
+    const dropZone = screen.getByText('Drag & drop a design JSON file here').closest('div');
+
+    fireEvent.drop(dropZone!, { dataTransfer: { files: [file], types: ['Files'] } });
+
+    expect(screen.queryByText('• Please drop a JSON file')).not.toBeInTheDocument();
+  });
+
   it('shows drag styling on drag over', () => {
     render(<DesignImportView {...defaultProps} />);
 

--- a/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.test.tsx
@@ -76,6 +76,16 @@ describe('ImportView', () => {
       expect(screen.getByText('Drag and drop JSON file here')).toBeInTheDocument();
     });
 
+    it('accepts an upper-case .JSON extension on drop', () => {
+      render(<ImportView onImport={mockOnImport} onCancel={mockOnCancel} />);
+      const file = new File(['{}'], 'LAYOUT.JSON', { type: 'application/json' });
+      const dropZone = screen.getByText('Drag and drop JSON file here').closest('div');
+
+      fireEvent.drop(dropZone!, { dataTransfer: { files: [file], types: ['Files'] } });
+
+      expect(screen.queryByText(/Please drop a JSON file/)).not.toBeInTheDocument();
+    });
+
     it('renders Browse Files button', () => {
       render(<ImportView onImport={mockOnImport} onCancel={mockOnCancel} />);
 

--- a/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
+++ b/src/shared/components/ImportPreviewPanel/ImportPreviewPanel.tsx
@@ -29,7 +29,7 @@ export function ImportPreviewPanel({
       </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-success/80">
         {rows.map((row, index) => (
-          <Fragment key={index}>
+          <Fragment key={`${index}:${row.label}`}>
             <div>{row.label}</div>
             <div className={row.emphasis ? 'font-medium' : undefined}>{row.value}</div>
           </Fragment>


### PR DESCRIPTION
Follow-up to #4180, which auto-merged before its last review round landed.

- Both import views gain a test that drops a `.JSON` file and asserts the non-JSON rejection does not appear.
- `ImportPreviewPanel` keys rows by position and label together: stable for the fixed positional lists the views pass, and immune to a repeated label.

**Verification**

- Lint passes. Vitest over both import views and the preview panel: 3 files, 58 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

