### PR TITLE
refactor(shared): one sample export button for the four calibration prints

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
@@ -6,101 +6,35 @@
  * dial in the fit that clicks before committing to a full split baseplate.
  */
 
-import { useCallback, useMemo, useState } from 'react';
-import { Button } from '@/design-system/Button';
 import { LayoutGridIcon } from '@/design-system/Icon';
-import { ExportDialog } from '@/shared/components/ExportDialog';
-import { useToastStore } from '@/core/store/toast';
+import { SampleExportButton } from '@/shared/components/SampleExportButton';
 import { useTranslation } from '@/i18n';
 import {
   useConnectorSampleExport,
   CONNECTOR_SAMPLE_BASE_NAME,
 } from '../../hooks/useConnectorSampleExport';
-import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
-import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 
 export function ConnectorSampleButton() {
   const t = useTranslation();
-  const { isExporting, canExport, downloadSample } = useConnectorSampleExport();
-
-  const [open, setOpen] = useState(false);
-  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
-    style: 'descriptive',
-    customName: '',
-    format: 'stl',
-  });
-
-  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
-  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
-  const baseName =
-    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
-      ? fileNameConfig.customName.trim()
-      : CONNECTOR_SAMPLE_BASE_NAME;
-
-  const handleDownload = useCallback(() => {
-    void downloadSample(activeFormat, baseName).then((succeeded) => {
-      if (!succeeded) return;
-      useToastStore
-        .getState()
-        .addToast(t('baseplate.connectorSample.exportComplete'), 'success', 3000);
-      setOpen(false);
-    });
-  }, [downloadSample, activeFormat, baseName, t]);
-
-  const tips = useMemo(
-    () => [
-      t('baseplate.connectorSample.tip1'),
-      t('baseplate.connectorSample.tip2'),
-      t('baseplate.connectorSample.tip3'),
-      t('baseplate.connectorSample.tip4'),
-    ],
-    [t]
-  );
-
+  const sample = useConnectorSampleExport();
   return (
-    <>
-      <Button
-        variant="secondary"
-        size="sm"
-        fullWidth
-        leftIcon={<LayoutGridIcon className="h-4 w-4" />}
-        onClick={() => setOpen(true)}
-        disabled={!canExport}
-      >
-        {t('baseplate.connectorSample.button')}
-      </Button>
-
-      <ExportDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        activeFormat={activeFormat}
-        fileNameConfig={fileNameConfig}
-        onFileNameConfigChange={setFileNameConfig}
-        fileName={`${baseName}${displayExtension}`}
-        displayExtension={displayExtension}
-        canExport={canExport}
-        isExporting={isExporting}
-        onDownload={handleDownload}
-        sectionTitle={t('baseplate.connectorSample.dialogTitle')}
-        sectionDescription={t('baseplate.connectorSample.dialogDescription')}
-        extras={
-          <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
-              {t('baseplate.connectorSample.tipsTitle')}
-            </h3>
-            <ul className="space-y-1 text-xs text-content-secondary">
-              {tips.map((tip) => (
-                <li key={tip} className="flex gap-2">
-                  <span aria-hidden="true" className="text-content-tertiary">
-                    •
-                  </span>
-                  <span>{tip}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        }
-      />
-    </>
+    <SampleExportButton
+      {...sample}
+      defaultBaseName={CONNECTOR_SAMPLE_BASE_NAME}
+      label={t('baseplate.connectorSample.button')}
+      leftIcon={<LayoutGridIcon className="h-4 w-4" />}
+      dialogTitle={t('baseplate.connectorSample.dialogTitle')}
+      dialogDescription={t('baseplate.connectorSample.dialogDescription')}
+      exportCompleteMessage={t('baseplate.connectorSample.exportComplete')}
+      tips={{
+        title: t('baseplate.connectorSample.tipsTitle'),
+        items: [
+          t('baseplate.connectorSample.tip1'),
+          t('baseplate.connectorSample.tip2'),
+          t('baseplate.connectorSample.tip3'),
+          t('baseplate.connectorSample.tip4'),
+        ],
+      }}
+    />
   );
 }

--- a/src/features/baseplate/components/BaseplatePanel/StackSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/StackSampleButton.tsx
@@ -6,72 +6,24 @@
  * is disabled — stacking is a print arrangement, not a CAD interchange concept.
  */
 
-import { useCallback, useState } from 'react';
-import { Button } from '@/design-system/Button';
 import { LayoutGridIcon } from '@/design-system/Icon';
-import { ExportDialog } from '@/shared/components/ExportDialog';
-import { useToastStore } from '@/core/store/toast';
+import { SampleExportButton } from '@/shared/components/SampleExportButton';
 import { useTranslation } from '@/i18n';
 import { useStackSampleExport, STACK_SAMPLE_BASE_NAME } from '../../hooks/useStackSampleExport';
-import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
-import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 
 export function StackSampleButton() {
   const t = useTranslation();
-  const { isExporting, canExport, downloadSample } = useStackSampleExport();
-
-  const [open, setOpen] = useState(false);
-  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
-    style: 'descriptive',
-    customName: '',
-    format: 'stl',
-  });
-
-  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
-  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
-  const baseName =
-    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
-      ? fileNameConfig.customName.trim()
-      : STACK_SAMPLE_BASE_NAME;
-
-  const handleDownload = useCallback(() => {
-    void downloadSample(activeFormat, baseName).then((succeeded) => {
-      if (!succeeded) return;
-      useToastStore
-        .getState()
-        .addToast(t('baseplate.stackPrint.sampleExportComplete'), 'success', 3000);
-      setOpen(false);
-    });
-  }, [downloadSample, activeFormat, baseName, t]);
-
+  const sample = useStackSampleExport();
   return (
-    <>
-      <Button
-        variant="secondary"
-        size="sm"
-        fullWidth
-        leftIcon={<LayoutGridIcon className="h-4 w-4" />}
-        onClick={() => setOpen(true)}
-        disabled={!canExport}
-      >
-        {t('baseplate.stackPrint.sampleButton')}
-      </Button>
-
-      <ExportDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        activeFormat={activeFormat}
-        fileNameConfig={fileNameConfig}
-        onFileNameConfigChange={setFileNameConfig}
-        fileName={`${baseName}${displayExtension}`}
-        displayExtension={displayExtension}
-        canExport={canExport}
-        isExporting={isExporting}
-        onDownload={handleDownload}
-        sectionTitle={t('baseplate.stackPrint.sampleTitle')}
-        sectionDescription={t('baseplate.stackPrint.sampleDescription')}
-        formatStates={{ step: { disabled: true } }}
-      />
-    </>
+    <SampleExportButton
+      {...sample}
+      defaultBaseName={STACK_SAMPLE_BASE_NAME}
+      label={t('baseplate.stackPrint.sampleButton')}
+      leftIcon={<LayoutGridIcon className="h-4 w-4" />}
+      dialogTitle={t('baseplate.stackPrint.sampleTitle')}
+      dialogDescription={t('baseplate.stackPrint.sampleDescription')}
+      exportCompleteMessage={t('baseplate.stackPrint.sampleExportComplete')}
+      formatStates={{ step: { disabled: true } }}
+    />
   );
 }

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelFitSampleButton.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelFitSampleButton.tsx
@@ -7,96 +7,32 @@
  * fit-offset field above.
  */
 
-import { useCallback, useMemo, useState } from 'react';
-import { Button } from '@/design-system/Button';
-import { ExportDialog } from '@/shared/components/ExportDialog';
-import { useToastStore } from '@/core/store/toast';
+import { SampleExportButton } from '@/shared/components/SampleExportButton';
 import { useTranslation } from '@/i18n';
 import {
   useLabelFitSampleExport,
   LABEL_FIT_SAMPLE_BASE_NAME,
 } from '../../../hooks/useLabelFitSampleExport';
-import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
-import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 
 export function LabelFitSampleButton() {
   const t = useTranslation();
-  const { isExporting, canExport, downloadSample } = useLabelFitSampleExport();
-
-  const [open, setOpen] = useState(false);
-  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
-    style: 'descriptive',
-    customName: '',
-    format: 'stl',
-  });
-
-  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
-  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
-  const baseName =
-    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
-      ? fileNameConfig.customName.trim()
-      : LABEL_FIT_SAMPLE_BASE_NAME;
-
-  const handleDownload = useCallback(() => {
-    void downloadSample(activeFormat, baseName).then((succeeded) => {
-      if (!succeeded) return;
-      useToastStore.getState().addToast(t('binDesigner.fitSample.exportComplete'), 'success', 3000);
-      setOpen(false);
-    });
-  }, [downloadSample, activeFormat, baseName, t]);
-
-  const tips = useMemo(
-    () => [
-      t('binDesigner.fitSample.tip1'),
-      t('binDesigner.fitSample.tip2'),
-      t('binDesigner.fitSample.tip3'),
-    ],
-    [t]
-  );
-
+  const sample = useLabelFitSampleExport();
   return (
-    <>
-      <Button
-        variant="secondary"
-        size="sm"
-        fullWidth
-        onClick={() => setOpen(true)}
-        disabled={!canExport}
-      >
-        {t('binDesigner.fitSample.button')}
-      </Button>
-
-      <ExportDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        activeFormat={activeFormat}
-        fileNameConfig={fileNameConfig}
-        onFileNameConfigChange={setFileNameConfig}
-        fileName={`${baseName}${displayExtension}`}
-        displayExtension={displayExtension}
-        canExport={canExport}
-        isExporting={isExporting}
-        onDownload={handleDownload}
-        sectionTitle={t('binDesigner.fitSample.dialogTitle')}
-        sectionDescription={t('binDesigner.fitSample.dialogDescription')}
-        extras={
-          <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
-              {t('binDesigner.fitSample.tipsTitle')}
-            </h3>
-            <ul className="space-y-1 text-xs text-content-secondary">
-              {tips.map((tip) => (
-                <li key={tip} className="flex gap-2">
-                  <span aria-hidden="true" className="text-content-tertiary">
-                    •
-                  </span>
-                  <span>{tip}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        }
-      />
-    </>
+    <SampleExportButton
+      {...sample}
+      defaultBaseName={LABEL_FIT_SAMPLE_BASE_NAME}
+      label={t('binDesigner.fitSample.button')}
+      dialogTitle={t('binDesigner.fitSample.dialogTitle')}
+      dialogDescription={t('binDesigner.fitSample.dialogDescription')}
+      exportCompleteMessage={t('binDesigner.fitSample.exportComplete')}
+      tips={{
+        title: t('binDesigner.fitSample.tipsTitle'),
+        items: [
+          t('binDesigner.fitSample.tip1'),
+          t('binDesigner.fitSample.tip2'),
+          t('binDesigner.fitSample.tip3'),
+        ],
+      }}
+    />
   );
 }

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.tsx
@@ -10,98 +10,32 @@
  * nozzle most of these will be printed on.
  */
 
-import { useCallback, useMemo, useState } from 'react';
-import { Button } from '@/design-system/Button';
-import { ExportDialog } from '@/shared/components/ExportDialog';
-import { useToastStore } from '@/core/store/toast';
+import { SampleExportButton } from '@/shared/components/SampleExportButton';
 import { useTranslation } from '@/i18n';
 import {
   useSlideFitSampleExport,
   SLIDE_FIT_SAMPLE_BASE_NAME,
 } from '../../../hooks/useSlideFitSampleExport';
-import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
-import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 
 export function SlideFitSampleButton() {
   const t = useTranslation();
-  const { isExporting, canExport, downloadSample } = useSlideFitSampleExport();
-
-  const [open, setOpen] = useState(false);
-  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
-    style: 'descriptive',
-    customName: '',
-    format: 'stl',
-  });
-
-  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
-  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
-  const baseName =
-    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
-      ? fileNameConfig.customName.trim()
-      : SLIDE_FIT_SAMPLE_BASE_NAME;
-
-  const handleDownload = useCallback(() => {
-    void downloadSample(activeFormat, baseName).then((succeeded) => {
-      if (!succeeded) return;
-      useToastStore
-        .getState()
-        .addToast(t('binDesigner.slideTray.fitSample.exportComplete'), 'success', 3000);
-      setOpen(false);
-    });
-  }, [downloadSample, activeFormat, baseName, t]);
-
-  const tips = useMemo(
-    () => [
-      t('binDesigner.slideTray.fitSample.tip1'),
-      t('binDesigner.slideTray.fitSample.tip2'),
-      t('binDesigner.slideTray.fitSample.tip3'),
-    ],
-    [t]
-  );
-
+  const sample = useSlideFitSampleExport();
   return (
-    <>
-      <Button
-        variant="secondary"
-        size="sm"
-        fullWidth
-        onClick={() => setOpen(true)}
-        disabled={!canExport}
-      >
-        {t('binDesigner.slideTray.fitSample.button')}
-      </Button>
-
-      <ExportDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        activeFormat={activeFormat}
-        fileNameConfig={fileNameConfig}
-        onFileNameConfigChange={setFileNameConfig}
-        fileName={`${baseName}${displayExtension}`}
-        displayExtension={displayExtension}
-        canExport={canExport}
-        isExporting={isExporting}
-        onDownload={handleDownload}
-        sectionTitle={t('binDesigner.slideTray.fitSample.dialogTitle')}
-        sectionDescription={t('binDesigner.slideTray.fitSample.dialogDescription')}
-        extras={
-          <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
-              {t('binDesigner.slideTray.fitSample.tipsTitle')}
-            </h3>
-            <ul className="space-y-1 text-xs text-content-secondary">
-              {tips.map((tip) => (
-                <li key={tip} className="flex gap-2">
-                  <span aria-hidden="true" className="text-content-tertiary">
-                    •
-                  </span>
-                  <span>{tip}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        }
-      />
-    </>
+    <SampleExportButton
+      {...sample}
+      defaultBaseName={SLIDE_FIT_SAMPLE_BASE_NAME}
+      label={t('binDesigner.slideTray.fitSample.button')}
+      dialogTitle={t('binDesigner.slideTray.fitSample.dialogTitle')}
+      dialogDescription={t('binDesigner.slideTray.fitSample.dialogDescription')}
+      exportCompleteMessage={t('binDesigner.slideTray.fitSample.exportComplete')}
+      tips={{
+        title: t('binDesigner.slideTray.fitSample.tipsTitle'),
+        items: [
+          t('binDesigner.slideTray.fitSample.tip1'),
+          t('binDesigner.slideTray.fitSample.tip2'),
+          t('binDesigner.slideTray.fitSample.tip3'),
+        ],
+      }}
+    />
   );
 }

--- a/src/shared/components/SampleExportButton/SampleExportButton.test.tsx
+++ b/src/shared/components/SampleExportButton/SampleExportButton.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useToastStore } from '@/core/store/toast';
+import { SampleExportButton } from './SampleExportButton';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+function renderButton(overrides: Partial<Parameters<typeof SampleExportButton>[0]> = {}) {
+  const downloadSample = vi.fn().mockResolvedValue(true);
+  render(
+    <SampleExportButton
+      isExporting={false}
+      canExport
+      downloadSample={downloadSample}
+      defaultBaseName="my-sample"
+      label="Print sample"
+      dialogTitle="Sample title"
+      dialogDescription="Sample description"
+      exportCompleteMessage="Sample saved"
+      tips={{ title: 'Tips', items: ['first tip', 'second tip'] }}
+      {...overrides}
+    />
+  );
+  return { downloadSample };
+}
+
+describe('SampleExportButton', () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it('opens the dialog with the tips and downloads under the default name', async () => {
+    const { downloadSample } = renderButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Print sample' }));
+    expect(screen.getByText('Sample title')).toBeInTheDocument();
+    expect(screen.getByText('Tips')).toBeInTheDocument();
+    expect(screen.getByText('second tip')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'export.downloadFormat' }));
+
+    await waitFor(() => expect(downloadSample).toHaveBeenCalledWith('stl', 'my-sample'));
+    await waitFor(() => expect(useToastStore.getState().toasts[0]?.message).toBe('Sample saved'));
+    expect(screen.queryByText('Sample title')).not.toBeInTheDocument();
+  });
+
+  it('stays open and quiet when the download reports failure', async () => {
+    const { downloadSample } = renderButton();
+    downloadSample.mockResolvedValue(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Print sample' }));
+    fireEvent.click(screen.getByRole('button', { name: 'export.downloadFormat' }));
+
+    await waitFor(() => expect(downloadSample).toHaveBeenCalled());
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(screen.getByText('Sample title')).toBeInTheDocument();
+  });
+
+  it('disables the trigger when nothing can export', () => {
+    renderButton({ canExport: false });
+    expect(screen.getByRole('button', { name: 'Print sample' })).toBeDisabled();
+  });
+});

--- a/src/shared/components/SampleExportButton/SampleExportButton.tsx
+++ b/src/shared/components/SampleExportButton/SampleExportButton.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Button } from '@/design-system/Button';
+import { ExportDialog } from '@/shared/components/ExportDialog';
+import type { ExportDialogProps } from '@/shared/components/ExportDialog/ExportDialog';
+import { useToastStore } from '@/core/store/toast';
+import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
+import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
+
+interface SampleExportButtonProps {
+  isExporting: boolean;
+  canExport: boolean;
+  downloadSample: (format: ExportFileFormat, baseName: string) => Promise<boolean>;
+  defaultBaseName: string;
+  label: string;
+  leftIcon?: ReactNode;
+  dialogTitle: string;
+  dialogDescription: string;
+  exportCompleteMessage: string;
+  tips?: { readonly title: string; readonly items: readonly string[] };
+  formatStates?: ExportDialogProps['formatStates'];
+}
+
+/** A "print a calibration sample" button and the export dialog it opens. */
+export function SampleExportButton({
+  isExporting,
+  canExport,
+  downloadSample,
+  defaultBaseName,
+  label,
+  leftIcon,
+  dialogTitle,
+  dialogDescription,
+  exportCompleteMessage,
+  tips,
+  formatStates,
+}: SampleExportButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
+    style: 'descriptive',
+    customName: '',
+    format: 'stl',
+  });
+
+  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
+  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
+  const baseName =
+    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
+      ? fileNameConfig.customName.trim()
+      : defaultBaseName;
+
+  const handleDownload = useCallback(() => {
+    void downloadSample(activeFormat, baseName).then((succeeded) => {
+      if (!succeeded) return;
+      useToastStore.getState().addToast(exportCompleteMessage, 'success', 3000);
+      setOpen(false);
+    });
+  }, [downloadSample, activeFormat, baseName, exportCompleteMessage]);
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        fullWidth
+        {...(leftIcon ? { leftIcon } : {})}
+        onClick={() => setOpen(true)}
+        disabled={!canExport}
+      >
+        {label}
+      </Button>
+
+      <ExportDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        activeFormat={activeFormat}
+        fileNameConfig={fileNameConfig}
+        onFileNameConfigChange={setFileNameConfig}
+        fileName={`${baseName}${displayExtension}`}
+        displayExtension={displayExtension}
+        canExport={canExport}
+        isExporting={isExporting}
+        onDownload={handleDownload}
+        sectionTitle={dialogTitle}
+        sectionDescription={dialogDescription}
+        {...(formatStates ? { formatStates } : {})}
+        {...(tips
+          ? {
+              extras: (
+                <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
+                    {tips.title}
+                  </h3>
+                  <ul className="space-y-1 text-xs text-content-secondary">
+                    {tips.items.map((tip) => (
+                      <li key={tip} className="flex gap-2">
+                        <span aria-hidden="true" className="text-content-tertiary">
+                          •
+                        </span>
+                        <span>{tip}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ),
+            }
+          : {})}
+      />
+    </>
+  );
+}

--- a/src/shared/components/SampleExportButton/SampleExportButton.tsx
+++ b/src/shared/components/SampleExportButton/SampleExportButton.tsx
@@ -21,7 +21,6 @@ interface SampleExportButtonProps {
   formatStates?: ExportDialogProps['formatStates'];
 }
 
-/** A "print a calibration sample" button and the export dialog it opens. */
 export function SampleExportButton({
   isExporting,
   canExport,

--- a/src/shared/components/SampleExportButton/index.ts
+++ b/src/shared/components/SampleExportButton/index.ts
@@ -1,0 +1,1 @@
+export { SampleExportButton } from './SampleExportButton';


### PR DESCRIPTION
Four "print a calibration sample" buttons (baseplate connector fit, baseplate stack gap, label-tab socket fit, slide-tray fit) were the same 90-line component with different translation keys and export hooks: open state, the file-name config, the format and extension derivation, the download handler with its success toast, the trigger button and the `ExportDialog` with a tips panel. jscpd flagged them against each other three blocks at a time.

`SampleExportButton` in `src/shared/components` owns all of that. Each feature button keeps its own header comment (which is where the purpose of each sample is explained), calls its own export hook, and passes its labels, tips, optional icon and optional format restrictions. The four files shrink from roughly 95 lines each to about 30. The cutout fit-test button stays as is: it adds a warning banner, estimates and custom extras that the shared component does not model.

No behaviour changes: file naming, format default, toast text and duration, and the stack button's disabled STEP format are unchanged.

**Verification**

- Typecheck, lint, module boundaries, design-system and component-structure gates pass.
- The four buttons' existing tests pass unchanged (each mocks its export hook and drives the dialog through to a download). The shared component has its own tests: open, tips, default-name download with toast and close; failed download leaves the dialog open with no toast; disabled trigger. Vitest over the baseplate panel and both bin-designer sections: 25 files, 343 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

