### PR TITLE
test(import): narrow the drop zone instead of asserting non-null

### DIFF
--- a/src/features/bin-designer/components/DesignImportView/DesignImportView.test.tsx
+++ b/src/features/bin-designer/components/DesignImportView/DesignImportView.test.tsx
@@ -228,8 +228,9 @@ describe('DesignImportView', () => {
     render(<DesignImportView {...defaultProps} />);
     const file = new File(['{}'], 'DESIGN.JSON', { type: 'application/json' });
     const dropZone = screen.getByText('Drag & drop a design JSON file here').closest('div');
+    if (!dropZone) throw new Error('drop zone not rendered');
 
-    fireEvent.drop(dropZone!, { dataTransfer: { files: [file], types: ['Files'] } });
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file], types: ['Files'] } });
 
     expect(screen.queryByText('• Please drop a JSON file')).not.toBeInTheDocument();
   });

--- a/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ImportView/ImportView.test.tsx
@@ -80,8 +80,9 @@ describe('ImportView', () => {
       render(<ImportView onImport={mockOnImport} onCancel={mockOnCancel} />);
       const file = new File(['{}'], 'LAYOUT.JSON', { type: 'application/json' });
       const dropZone = screen.getByText('Drag and drop JSON file here').closest('div');
+      if (!dropZone) throw new Error('drop zone not rendered');
 
-      fireEvent.drop(dropZone!, { dataTransfer: { files: [file], types: ['Files'] } });
+      fireEvent.drop(dropZone, { dataTransfer: { files: [file], types: ['Files'] } });
 
       expect(screen.queryByText(/Please drop a JSON file/)).not.toBeInTheDocument();
     });


### PR DESCRIPTION
Follow-up to #4183: the two tests it added used a non-null assertion on the drop zone, which the repo forbids. They now throw a named error when the zone is missing and use the narrowed element.

**Verification**

Vitest over both import views: 2 files, 53 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

