### PR TITLE
chore(lint): clear every warning except max-lines

### DIFF
--- a/api/auth/providers/github.ts
+++ b/api/auth/providers/github.ts
@@ -53,7 +53,7 @@ async function fetchProfile(accessToken: string): Promise<ProviderProfile> {
   const user = (await userRes.json()) as GitHubUser;
 
   const verified = await fetchVerifiedEmails(headers, !user.email);
-  const email = user.email ?? verified[0] ?? null;
+  const email = user.email ?? verified.at(0) ?? null;
   if (!email) throw new Error('GitHub account has no verified email');
 
   return {
@@ -63,6 +63,12 @@ async function fetchProfile(accessToken: string): Promise<ProviderProfile> {
     displayName: user.name ?? user.login,
     handle: user.login,
   };
+}
+
+function isVerifiedEmail(e: unknown): e is GitHubEmail & { email: string } {
+  if (typeof e !== 'object' || e === null) return false;
+  const record = e as Partial<GitHubEmail>;
+  return record.verified === true && typeof record.email === 'string';
 }
 
 /**
@@ -76,18 +82,18 @@ async function fetchVerifiedEmails(
   headers: Record<string, string>,
   required: boolean
 ): Promise<string[]> {
-  let emails: GitHubEmail[];
+  let emails: unknown;
   try {
     const res = await fetch('https://api.github.com/user/emails', { headers });
     if (!res.ok) throw new Error(`GitHub /user/emails ${res.status}`);
-    emails = (await res.json()) as GitHubEmail[];
+    emails = await res.json();
   } catch (error) {
     if (required) throw error;
     return [];
   }
   if (!Array.isArray(emails)) return [];
   return emails
-    .filter((e) => e?.verified && typeof e.email === 'string')
+    .filter(isVerifiedEmail)
     .sort((a, b) => Number(b.primary) - Number(a.primary))
     .map((e) => e.email);
 }

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -779,10 +779,11 @@ async function handleSetCoverAction(
         'photoUrl must be a photo from a live print of this design'
       );
     }
-    // Optional-chained: a record that reached here without going through
+    // Read as optional: a record that reached here without going through
     // parsePrint has no normalised array, and a missing browsing copy must
     // cost the optimisation, not 500 the promote.
-    coverPhotoThumbUrl = owner.photoThumbs?.[owner.photos.indexOf(photoUrl)] ?? '';
+    const thumbs = (owner as { photoThumbs?: readonly string[] }).photoThumbs;
+    coverPhotoThumbUrl = thumbs?.[owner.photos.indexOf(photoUrl)] ?? '';
   }
 
   await redis.hset(communityDesignKey(id), {

--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -421,7 +421,7 @@ function seatHeightMm(type: string, params: Record<string, unknown>): number {
   if (type === 'riser') {
     return (params.stepCount as number) * (params.stepHeight as number);
   }
-  return (params.height as number) ?? 0;
+  return typeof params.height === 'number' ? params.height : 0;
 }
 
 export interface SanitizedAssembly {

--- a/api/lib/communityLowEffort.ts
+++ b/api/lib/communityLowEffort.ts
@@ -63,7 +63,7 @@ export function classifyCommunityDescription(
   // Code points, not UTF-16 code units: `.length` counts an emoji or a
   // supplementary-plane kanji as 2, so "ab😀😃😄😁😆" would clear a floor
   // documented in characters with seven of them.
-  if ([...trimmed].length < COMMUNITY_DESCRIPTION_MIN_LENGTH) return 'too-short';
+  if (Array.from(trimmed).length < COMMUNITY_DESCRIPTION_MIN_LENGTH) return 'too-short';
   if (!/\p{L}/u.test(trimmed)) return 'low-effort';
   if (new Set(trimmed.replace(/\s+/gu, '')).size < COMMUNITY_DESCRIPTION_MIN_DISTINCT_CHARS) {
     return 'low-effort';

--- a/src/core/cqrs/v2/domain/layout/setActiveBaseplate.ts
+++ b/src/core/cqrs/v2/domain/layout/setActiveBaseplate.ts
@@ -13,6 +13,7 @@ import type { BaseplateDesignId, StoredBaseplateParams } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import { defineCommand } from '../../defineCommand';
 import { computeDisplacedBins } from '../drawer/displacement';
+import type { ActiveBaseplateSetEvent } from '../../../events/drawerEvents';
 
 const payloadSchema = z.object({
   designId: z.string().min(1).nullable(),
@@ -60,12 +61,16 @@ export const setActiveBaseplate = defineCommand({
           )
         : [];
 
-    return ok({
-      value: undefined,
-      event: {
-        payload: { designId, params, previousActiveBaseplateId, previousParams, displacedBinIds },
-      },
-    });
+    // Typed as the declared event so apply() sees the same optional
+    // `displacedBinIds` that persisted events predating the field carry.
+    const eventPayload: ActiveBaseplateSetEvent['payload'] = {
+      designId,
+      params,
+      previousActiveBaseplateId,
+      previousParams,
+      displacedBinIds,
+    };
+    return ok({ value: undefined, event: { payload: eventPayload } });
   },
   apply: (event, draft) => {
     draft.activeBaseplateId = event.payload.designId;

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
@@ -15,6 +15,7 @@ import { effectiveGridUnitMmY } from '@/core/types';
 import { BASEPLATE_CONNECTOR_STYLES } from '@/shared/types/bin';
 import { defineCommand } from '../../defineCommand';
 import { computeDisplacedBins } from '../drawer/displacement';
+import type { BaseplateParamsSetEvent } from '../../../events/drawerEvents';
 
 /**
  * Chunk sizes for one axis of a custom split plan. A plate caps at
@@ -126,10 +127,14 @@ export const setBaseplateParams = defineCommand({
           )
         : [];
 
-    return ok({
-      value: undefined,
-      event: { payload: { params, previousParams, displacedBinIds } },
-    });
+    // Typed as the declared event so apply() sees the same optional
+    // `displacedBinIds` that persisted events predating the field carry.
+    const eventPayload: BaseplateParamsSetEvent['payload'] = {
+      params,
+      previousParams,
+      displacedBinIds,
+    };
+    return ok({ value: undefined, event: { payload: eventPayload } });
   },
   apply: (event, draft) => {
     draft.baseplateParams = event.payload.params;

--- a/src/core/store/labs.ts
+++ b/src/core/store/labs.ts
@@ -60,8 +60,9 @@ function savePreferences(prefs: LabsPreferences): Result<void, StorageError> {
  * what remains if it is ever un-graduated.
  */
 function resolveStoredEnabled(preferences: LabsPreferences, featureId: string): boolean {
-  const stored = preferences.enabledFeatures[featureId];
-  if (stored !== undefined) return stored;
+  if (Object.hasOwn(preferences.enabledFeatures, featureId)) {
+    return preferences.enabledFeatures[featureId];
+  }
   return getFeature(featureId)?.defaultEnabled ?? false;
 }
 

--- a/src/features/baseplate/utils/connectorKeys.ts
+++ b/src/features/baseplate/utils/connectorKeys.ts
@@ -159,7 +159,7 @@ function marginSeamJunctions(
   const halfDmm = (tiling.totalDepthUnits * gy) / 2;
   const junctions: SeamJunction[] = [];
 
-  for (const margin of tiling.margins ?? []) {
+  for (const margin of tiling.margins) {
     const seam = margin.seamConnector;
     if (margin.role !== 'long' || !seam) continue;
     // A front/back rail runs along X, so its `cellUnits` are width cells (X

--- a/src/features/bin-designer/components/BinPanelShell/BinPanelShell.tsx
+++ b/src/features/bin-designer/components/BinPanelShell/BinPanelShell.tsx
@@ -103,7 +103,7 @@ export function BinPanelShell({
   // dispatcher's DOM watch finds the target visible.
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<HelpJumpEventDetail>).detail;
+      const detail = (e as CustomEvent<HelpJumpEventDetail | undefined>).detail;
       const category = detail?.controlId ? categoryForControl(detail.controlId) : undefined;
       if (category) {
         setActiveCategory(category);

--- a/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeList.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeList.tsx
@@ -113,7 +113,7 @@ export function ShapeList({
   }, [nodes, collapsed]);
 
   const [activeId, setActiveId] = useState<string | null>(null);
-  const active = activeId ?? visibleRows[0]?.id ?? null;
+  const active = activeId ?? visibleRows.at(0)?.id ?? null;
 
   const focusRow = useCallback((id: string) => {
     setActiveId(id);

--- a/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
@@ -81,7 +81,7 @@ export function PartProxyMesh({
     const height = partSeatHeight(node);
     const isCutter = node.type === 'cutter';
     return {
-      from: isCutter && node.type === 'cutter' ? placed.z - node.params.depth : placed.z,
+      from: node.type === 'cutter' ? placed.z - node.params.depth : placed.z,
       to: isCutter ? placed.z + 0.5 : placed.z + Math.max(height, 1),
     };
   }, [node, placed.z]);

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -183,7 +183,7 @@ export function useWorkshopInteraction(
   const rotationHub = useMemo((): RotationHub | null => {
     if (topLevelSelected.length === 0) return null;
     if (topLevelSelected.length === 1) {
-      const placed = topLevelSelected[0];
+      const placed = topLevelSelected.at(0);
       if (!placed) return null;
       const footprint = partFootprint(placed.node);
       return {

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -102,7 +102,7 @@ export function ColorsSection() {
   const setColorTool = useDesignerStore((s) => s.setColorTool);
   const swapZoneWithToast = useSwapZoneWithToast();
   const multiColorEnabled = rawColors.enabled;
-  const topAccent = rawColors.topAccent ?? DEFAULT_FEATURE_COLOR_CONFIG.topAccent;
+  const topAccent = rawColors.topAccent;
   const bottomAccent = rawColors.bottomAccent;
   // Cap a band at the wall top — nominal height (units × mm/unit) plus any
   // exterior-wall collar — so it can't exceed the bin yet still reaches the top

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
@@ -198,7 +198,7 @@ export function handleVertexEditPointerMove(
     // Same stale-index hazard as the pointer-down hit test: the path can
     // shrink mid-drag (an undo, a remote edit), and reading past its end threw
     // rather than simply dropping the frame.
-    const pt = path[dragTarget.index];
+    const pt = path.at(dragTarget.index);
     if (pt === undefined) {
       // Dropping the frame is not enough. The last preview was computed
       // against the longer path and pointer-up commits whatever it finds, so

--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
@@ -107,9 +107,8 @@ export function CompartmentTextInput({
   // geometry when the user merely collapses the section or navigates away.
   useEffect(() => clearIdleTimer, [clearIdleTimer]);
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const next = e.target.value;
+  const handleValue = useCallback(
+    (next: string) => {
       setDraft(next);
       clearIdleTimer();
       idleTimerRef.current = setTimeout(() => {
@@ -118,6 +117,11 @@ export function CompartmentTextInput({
       }, COMMIT_IDLE_MS);
     },
     [clearIdleTimer, commit]
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => handleValue(e.target.value),
+    [handleValue]
   );
 
   const handleFocus = useCallback(() => {
@@ -194,13 +198,8 @@ export function CompartmentTextInput({
   // Normalising on the way in keeps the field showing exactly what will be
   // stored, rather than letting the store silently truncate a paste later.
   const handleAreaChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      handleChange({
-        ...e,
-        target: { ...e.target, value: normalizeTextInput(e.target.value) },
-      } as unknown as React.ChangeEvent<HTMLInputElement>);
-    },
-    [handleChange]
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => handleValue(normalizeTextInput(e.target.value)),
+    [handleValue]
   );
 
   if (multiline) {

--- a/src/features/bin-designer/components/panel/VariantSection/VariantSection.tsx
+++ b/src/features/bin-designer/components/panel/VariantSection/VariantSection.tsx
@@ -50,7 +50,9 @@ export function VariantSection({
 
   const setDimension = (field: DimensionOverrideField, value: number | undefined) => {
     const dimensions = Object.fromEntries(
-      Object.entries({ ...overrides.dimensions, [field]: value }).filter(([, v]) => v !== undefined)
+      Object.entries<number | undefined>({ ...overrides.dimensions, [field]: value }).filter(
+        ([, v]) => v !== undefined
+      )
     );
     onChange({ ...overrides, dimensions });
   };
@@ -61,9 +63,10 @@ export function VariantSection({
     value: number | undefined
   ) => {
     const current = Object.fromEntries(
-      Object.entries({ ...overrides.cutouts?.[cutoutId], [field]: value }).filter(
-        ([, v]) => v !== undefined
-      )
+      Object.entries<number | undefined>({
+        ...overrides.cutouts?.[cutoutId],
+        [field]: value,
+      }).filter(([, v]) => v !== undefined)
     );
     // A cutout entry with nothing left in it is dropped, so `isEmptyOverrides`
     // and the claimed-count badge cannot report a claim that no longer exists.
@@ -75,7 +78,7 @@ export function VariantSection({
     onChange({ ...overrides, cutouts });
   };
 
-  const cutouts = parentParams.cutouts ?? [];
+  const cutouts = parentParams.cutouts;
 
   return (
     <PanelSection>

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -101,6 +101,12 @@ export function useAutoSave(): void {
   // updates once the write resolves, so without this the unmount flush would
   // re-issue an identical write for a save already in flight.
   const inFlight = useRef<{ params: BinParams; config: ExportFileNameConfig } | null>(null);
+  // Read behind a function boundary so a check after an await sees the slot as
+  // it is now, not as it was narrowed to at the assignment above the await.
+  const isInFlight = (params: BinParams, config: ExportFileNameConfig): boolean => {
+    const current = inFlight.current;
+    return current !== null && current.params === params && current.config === config;
+  };
 
   // The write itself plus the bookkeeping every consumer downstream depends on
   // (registry entry for the planner palette, `design-saved` for linked bins).
@@ -124,10 +130,7 @@ export function useAutoSave(): void {
         );
       } finally {
         // Only clear if a newer persist hasn't already claimed the slot.
-        if (
-          inFlight.current?.params === paramsToSave &&
-          inFlight.current?.config === configToSave
-        ) {
+        if (isInFlight(paramsToSave, configToSave)) {
           inFlight.current = null;
         }
       }
@@ -274,10 +277,7 @@ export function useAutoSave(): void {
       }
       // A save already writing exactly this will land on its own; an in-flight
       // save for older params still needs the flush.
-      if (
-        inFlight.current?.params === state.params &&
-        inFlight.current?.config === state.exportFileNameConfig
-      ) {
+      if (isInFlight(state.params, state.exportFileNameConfig)) {
         return;
       }
       void persist(state.params, state.exportFileNameConfig, id, undefined);

--- a/src/features/bin-designer/hooks/useVariantContext.ts
+++ b/src/features/bin-designer/hooks/useVariantContext.ts
@@ -54,24 +54,27 @@ export function useVariantContext(currentDesignId: string | null): VariantContex
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    // Read through a function so a check after an await is not narrowed by the
+    // check before it.
+    const isCancelled = (): boolean => controller.signal.aborted;
 
     // Every write happens in the async body, including the reset: a synchronous
     // setState here would cascade a render before the effect has done anything.
     void (async () => {
       if (!currentDesignId) {
-        if (!cancelled) setResolved({ forId: null, context: NONE });
+        if (!isCancelled()) setResolved({ forId: null, context: NONE });
         return;
       }
       const self = await loadDesign(toDesignId(currentDesignId));
-      if (cancelled) return;
+      if (isCancelled()) return;
       if (!isOk(self) || !self.value.variantOf) {
         setResolved({ forId: currentDesignId, context: NONE });
         return;
       }
 
       const parent = await loadDesign(self.value.variantOf);
-      if (cancelled) return;
+      if (isCancelled()) return;
       // A variant whose parent is gone keeps the params it has and stops
       // reporting as a variant: there is nothing left to inherit from, and
       // showing an inherit UI against a design that does not exist is worse
@@ -97,7 +100,7 @@ export function useVariantContext(currentDesignId: string | null): VariantContex
     })();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [currentDesignId, generation]);
 

--- a/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
@@ -352,15 +352,15 @@ export function createAssemblyActions(set: Set, get: Get) {
       const siblings = findAssemblySiblings(current, id);
       if (!siblings || siblings.length < 3) return;
       const sorted = [...siblings].sort((a, b) => a.transform[axis] - b.transform[axis]);
-      const first = sorted[0];
-      const last = sorted[sorted.length - 1];
+      const first = sorted.at(0);
+      const last = sorted.at(-1);
       if (!first || !last) return;
       const span = last.transform[axis] - first.transform[axis];
       const step = span / (sorted.length - 1);
       let next: AssemblyPartNode[] | null = current;
       let changed = false;
       for (let i = 1; i < sorted.length - 1; i += 1) {
-        const sibling = sorted[i];
+        const sibling = sorted.at(i);
         if (!sibling) continue;
         const target = first.transform[axis] + step * i;
         if (sibling.transform[axis] === target) continue;
@@ -477,8 +477,8 @@ export function createAssemblyActions(set: Set, get: Get) {
       const placements = top.flatMap((id) => map.get(id) ?? []);
       if (placements.length < 3) return;
       const sorted = [...placements].sort((a, b) => a[axis] - b[axis]);
-      const first = sorted[0];
-      const last = sorted[sorted.length - 1];
+      const first = sorted.at(0);
+      const last = sorted.at(-1);
       if (!first || !last) return;
       const step = (last[axis] - first[axis]) / (sorted.length - 1);
       applyWorldTargets(

--- a/src/features/bin-designer/utils/assemblyTree.ts
+++ b/src/features/bin-designer/utils/assemblyTree.ts
@@ -42,6 +42,15 @@ export function collectAssemblyIds(parts: readonly AssemblyPartNode[]): string[]
   return parts.flatMap((n) => [n.id, ...collectAssemblyIds(n.children)]);
 }
 
+/** Map that keeps the input array when no node changed identity. */
+function mapNodes(
+  nodes: AssemblyPartNode[],
+  fn: (node: AssemblyPartNode) => AssemblyPartNode
+): AssemblyPartNode[] {
+  const next = nodes.map(fn);
+  return next.some((n, i) => n !== nodes[i]) ? next : nodes;
+}
+
 export function withAssemblyPartAdded(
   parts: AssemblyPartNode[],
   parentId: string | null,
@@ -52,20 +61,12 @@ export function withAssemblyPartAdded(
   if (parentId !== null && parentDepth === 0) return null;
   if (parentDepth + subtreeDepth(node) > MAX_ASSEMBLY_DEPTH) return null;
   if (parentId === null) return [...parts, node];
-  const attach = (nodes: AssemblyPartNode[]): AssemblyPartNode[] => {
-    let changed = false;
-    const next = nodes.map((n) => {
-      if (n.id === parentId) {
-        changed = true;
-        return { ...n, children: [...n.children, node] };
-      }
+  const attach = (nodes: AssemblyPartNode[]): AssemblyPartNode[] =>
+    mapNodes(nodes, (n) => {
+      if (n.id === parentId) return { ...n, children: [...n.children, node] };
       const children = attach(n.children);
-      if (children === n.children) return n;
-      changed = true;
-      return { ...n, children };
+      return children === n.children ? n : { ...n, children };
     });
-    return changed ? next : nodes;
-  };
   return attach(parts);
 }
 
@@ -73,27 +74,17 @@ export function withAssemblyPartRemoved(
   parts: AssemblyPartNode[],
   id: string
 ): AssemblyPartNode[] | null {
-  let removed = false;
   const strip = (nodes: AssemblyPartNode[]): AssemblyPartNode[] => {
-    const kept = nodes.filter((n) => {
-      if (n.id === id) {
-        removed = true;
-        return false;
-      }
-      return true;
-    });
+    const kept = nodes.filter((n) => n.id !== id);
     if (kept.length !== nodes.length) return kept;
-    let changed = false;
-    const next = nodes.map((n) => {
+    return mapNodes(nodes, (n) => {
       const children = strip(n.children);
-      if (children === n.children) return n;
-      changed = true;
-      return { ...n, children };
+      return children === n.children ? n : { ...n, children };
     });
-    return changed ? next : nodes;
   };
   const next = strip(parts);
-  return removed ? next : null;
+  // Every change strip makes is a removal, so an unchanged tree means no match.
+  return next === parts ? null : next;
 }
 
 export function withAssemblyPartUpdated(
@@ -101,24 +92,18 @@ export function withAssemblyPartUpdated(
   id: string,
   update: (node: AssemblyPartNode) => AssemblyPartNode
 ): AssemblyPartNode[] | null {
-  let found = false;
-  const walk = (nodes: AssemblyPartNode[]): AssemblyPartNode[] => {
-    let changed = false;
-    const next = nodes.map((n) => {
+  const hit = { found: false };
+  const walk = (nodes: AssemblyPartNode[]): AssemblyPartNode[] =>
+    mapNodes(nodes, (n) => {
       if (n.id === id) {
-        found = true;
-        changed = true;
+        hit.found = true;
         return update(n);
       }
       const children = walk(n.children);
-      if (children === n.children) return n;
-      changed = true;
-      return { ...n, children };
+      return children === n.children ? n : { ...n, children };
     });
-    return changed ? next : nodes;
-  };
   const next = walk(parts);
-  return found ? next : null;
+  return hit.found ? next : null;
 }
 
 /**

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -12,11 +12,6 @@
  * path for the compartment model.
  */
 
-/* eslint-disable max-lines -- The grid model and the divider geometry that reads it are one
-   mutually recursive unit: override validation, divider eligibility and merge/split all call
-   back into the contiguity and bounds rules they sit above. Splitting further would buy line
-   count with an import cycle. */
-
 import type { CompartmentConfig, DividerOverride } from '../types';
 import { renumberCompartments } from './compartmentRemap';
 import {

--- a/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
+++ b/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
@@ -148,6 +148,9 @@ export function SharedLayoutImporter() {
   const hasStartedCloudFetch = useRef(false);
   // Track mounted state across effect re-runs (not just a local variable that resets on cleanup)
   const isMountedRef = useRef(true);
+  // Read behind a function boundary so checks after an await see the current
+  // value rather than the `true` the effect assigned before it.
+  const isMounted = (): boolean => isMountedRef.current;
 
   // Set mounted ref on mount/unmount (not on effect re-runs)
   useEffect(() => {
@@ -202,7 +205,7 @@ export function SharedLayoutImporter() {
 
       // Prevent state updates if component unmounted during fetch
       // Use ref instead of local variable so it survives effect re-runs
-      if (!isMountedRef.current) {
+      if (!isMounted()) {
         return;
       }
 
@@ -240,7 +243,7 @@ export function SharedLayoutImporter() {
         }
       }
 
-      if (!isMountedRef.current) {
+      if (!isMounted()) {
         return;
       }
 

--- a/src/features/drawer-shape/utils/penShape.ts
+++ b/src/features/drawer-shape/utils/penShape.ts
@@ -427,7 +427,7 @@ export function clampGroupDelta(
   let lo = { x: Infinity, y: Infinity };
   let hi = { x: -Infinity, y: -Infinity };
   for (const i of indices) {
-    const v = vertices[i];
+    const v = vertices.at(i);
     if (v === undefined) continue;
     lo = { x: Math.min(lo.x, v.x), y: Math.min(lo.y, v.y) };
     hi = { x: Math.max(hi.x, v.x), y: Math.max(hi.y, v.y) };

--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -83,14 +83,14 @@ export function hasNoNaNOrInfinity(arr: Float32Array): boolean {
 export function meshVolume({ vertices, indices }: MeshData): number {
   let volume = 0;
   const vertexIndex = (i: number): number => {
-    const value = indices[i];
+    const value = indices.at(i);
     if (value === undefined) {
       throw new Error(`meshVolume: index buffer length ${indices.length} is not a multiple of 3`);
     }
     return value;
   };
   const at = (index: number, axis: number): number => {
-    const value = vertices[index * 3 + axis];
+    const value = vertices.at(index * 3 + axis);
     if (value === undefined) {
       throw new Error(`meshVolume: vertex index ${index} is out of range`);
     }

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -287,7 +287,7 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
         taperDeg > 0
           ? cone(rBottom, rTop, total, { at: [0, 0, -sink] })
           : cylinder(rBottom, total, { at: [0, 0, -sink] });
-      const tip = Math.min(tipChamfer ?? 1, rTop - 0.3, height / 4);
+      const tip = Math.min(tipChamfer, rTop - 0.3, height / 4);
       return chamferedOrOriginal(body, edgesNearPlane(body, height), tip);
     }
     case 'fin': {

--- a/src/features/generation/worker/generators/binDirectMesh.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.ts
@@ -316,7 +316,7 @@ export function generateBinDirect(
         cell.depthUnits * gridUnitY - CLEARANCE
       );
     },
-    { x: params.fractionalEdgeX ?? 'end', y: params.fractionalEdgeY ?? 'end' }
+    { x: params.fractionalEdgeX, y: params.fractionalEdgeY }
   );
 
   onProgress?.('base', 0.9);

--- a/src/features/generation/worker/generators/lidCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/lidCutoutBuilder.ts
@@ -109,7 +109,7 @@ function buildTools(cutouts: LidCutoutInputs): Shape3D[] {
     // Text elements cut nothing; their captions are applied by
     // `applyLidTextElements` after the holes.
     if (c.shape === 'text') continue;
-    if (c.groupId === null || c.groupId === undefined) {
+    if (c.groupId === null) {
       singles.push(c);
       continue;
     }

--- a/src/features/generation/worker/generators/lidInputs.ts
+++ b/src/features/generation/worker/generators/lidInputs.ts
@@ -394,7 +394,7 @@ export function resolveLidInputs(params: BinParams): LidInputs {
   const hingeDetentSide =
     hingePlan !== null && hingePlan.catchMode === 'detent' ? hingePlan.catchSide : null;
   const hingeMagnetCatch = hingePlan !== null && hingePlan.catchMode === 'magnets';
-  const retentionMagnetSide = hingeMagnetCatch && hingePlan ? hingePlan.catchSide : null;
+  const retentionMagnetSide = hingePlan?.catchMode === 'magnets' ? hingePlan.catchSide : null;
   // Magnetic attachment OR a hinged lid's magnet catch. Both put the same
   // bosses on the lid; only how many and on which wall differs, and
   // `retentionMagnetPlacementsFor` owns that.

--- a/src/features/generation/worker/generators/scenarios/variantOverrides.ts
+++ b/src/features/generation/worker/generators/scenarios/variantOverrides.ts
@@ -72,7 +72,7 @@ export const variantOverrides: ScenarioCase[] = [
     customAssert: (result, params) => {
       // The resolver held the pocket's center rather than its corner, so the
       // widened pocket is still centered on 33.175 and not shifted to 36.35.
-      const pocket = params.cutouts?.[0];
+      const pocket = params.cutouts.at(0);
       expect(pocket?.width).toBe(12.7);
       expect((pocket?.x ?? 0) + (pocket?.width ?? 0) / 2).toBeCloseTo(33.175, 6);
       expect(result.triangleCount).toBeGreaterThan(0);

--- a/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/LinkedBinMesh.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/LinkedBinMesh.tsx
@@ -41,10 +41,10 @@ export const LinkedBinMesh = memo(function LinkedBinMesh({
   // Rest mesh extents carry the 0.5mm body clearance; snap to the half-unit
   // grid or the rotation comparison (epsilon 1e-6) can never match.
   const toHalfUnits = (mm: number): number => Math.round((mm / gridUnitMm) * 2) / 2;
-  const designW = isRest && entry.rest ? toHalfUnits(entry.rest.widthMm) : entry.width;
-  const designD = isRest && entry.rest ? toHalfUnits(entry.rest.depthMm) : entry.depth;
+  const designW = isRest ? toHalfUnits(entry.rest.widthMm) : entry.width;
+  const designD = isRest ? toHalfUnits(entry.rest.depthMm) : entry.depth;
   const rotated = isRotatedPlacement(bin.width, bin.depth, designW, designD);
-  const geometry = isRest && entry.rest ? entry.rest.geometry : entry.geometry;
+  const geometry = isRest ? entry.rest.geometry : entry.geometry;
 
   return (
     <group

--- a/src/features/labs/components/FeatureCard/FeatureCard.tsx
+++ b/src/features/labs/components/FeatureCard/FeatureCard.tsx
@@ -50,12 +50,12 @@ export function FeatureCard({ feature, isEnabled, onToggle, children }: FeatureC
               status: isEnabled ? t('labs.enabled') : t('labs.disabled'),
             })}
           />
-        ) : isGraduated ? (
+        ) : (
           <div className="flex items-center gap-2 text-xs text-success">
             <CheckIcon className="w-4 h-4" />
             <span>{t('labs.alwaysOn')}</span>
           </div>
-        ) : null}
+        )}
       </div>
 
       {children}

--- a/src/shared/analytics/posthog/eventsCore.ts
+++ b/src/shared/analytics/posthog/eventsCore.ts
@@ -265,7 +265,7 @@ function checkEngagementMilestones(): void {
 export function trackDesignCreated(): void {
   try {
     const data = loadAnalyticsData();
-    data.designsCreated = (data.designsCreated ?? 0) + 1;
+    data.designsCreated += 1;
 
     for (const { key, min } of DESIGNER_MILESTONE_THRESHOLDS) {
       if (data.designsCreated >= min && !data.milestones[key]) {

--- a/src/shared/analytics/posthog/eventsPerson.ts
+++ b/src/shared/analytics/posthog/eventsPerson.ts
@@ -88,12 +88,12 @@ export function updatePersonProperties(): void {
       uses_fill_operations: flag('fill'),
       uses_paint_mode: flag('paint_mode'),
 
-      engagement_tier: computeEngagementTier(layoutCount, data.designsCreated ?? 0),
+      engagement_tier: computeEngagementTier(layoutCount, data.designsCreated),
 
       // Distinct designs made. The designer milestone ladder keys on this, so
       // it has to be segmentable here too — a milestone that fires into an
       // event stream nobody can cohort on answers nothing.
-      designs_created: data.designsCreated ?? 0,
+      designs_created: data.designsCreated,
 
       // Device preference
       primary_device: getDeviceType(),

--- a/src/shared/components/MoreDisclosure/MoreDisclosure.tsx
+++ b/src/shared/components/MoreDisclosure/MoreDisclosure.tsx
@@ -51,7 +51,7 @@ export function MoreDisclosure({
 
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<HelpJumpEventDetail>).detail;
+      const detail = (e as CustomEvent<HelpJumpEventDetail | undefined>).detail;
       if (!detail?.controlId || !contentRef.current) return;
       const selector = `[${HELP_TARGET_ATTR}="${CSS.escape(detail.controlId)}"]`;
       const target = document.querySelector(selector);

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -458,7 +458,8 @@ export function usePWAUpdate(): void {
       // rejected with — including `undefined`. Reading `.message` off that
       // throws out of an unhandled rejection handler, which is the one place
       // nothing is left to catch it.
-      const message = error instanceof Error ? error.message : String(error ?? '');
+      const message =
+        error instanceof Error ? error.message : typeof error === 'string' ? error : '';
 
       // App still works without SW, but offline features won't be available
       // Only warn if it seems like a persistent issue

--- a/src/shared/utils/applyOverrides.ts
+++ b/src/shared/utils/applyOverrides.ts
@@ -68,15 +68,16 @@ export function applyOverrides(
   const overriddenIds = Object.keys(cutoutOverrides);
   if (overriddenIds.length === 0) return { params, orphans: [] };
 
-  const present = new Set((params.cutouts ?? []).map((c) => c.id));
+  const present = new Set(params.cutouts.map((c) => c.id));
   const orphans: OrphanedOverride[] = overriddenIds
     .filter((id) => !present.has(id))
     .map((id) => ({ cutoutId: id, override: cutoutOverrides[id] }));
 
-  const cutouts = (params.cutouts ?? []).map((cutout) => {
-    const override = cutoutOverrides[cutout.id];
-    return override ? applyCutoutOverride(cutout, override) : cutout;
-  });
+  const cutouts = params.cutouts.map((cutout) =>
+    Object.hasOwn(cutoutOverrides, cutout.id)
+      ? applyCutoutOverride(cutout, cutoutOverrides[cutout.id])
+      : cutout
+  );
 
   return { params: { ...params, cutouts }, orphans };
 }

--- a/src/shared/utils/communityLowEffort.ts
+++ b/src/shared/utils/communityLowEffort.ts
@@ -65,7 +65,7 @@ export function classifyCommunityDescription(
   // Code points, not UTF-16 code units: `.length` counts an emoji or a
   // supplementary-plane kanji as 2, so "ab😀😃😄😁😆" would clear a floor
   // documented in characters with seven of them.
-  if ([...trimmed].length < COMMUNITY_DESCRIPTION_MIN_LENGTH) return 'too-short';
+  if (Array.from(trimmed).length < COMMUNITY_DESCRIPTION_MIN_LENGTH) return 'too-short';
   if (!/\p{L}/u.test(trimmed)) return 'low-effort';
   if (new Set(trimmed.replace(/\s+/gu, '')).size < COMMUNITY_DESCRIPTION_MIN_DISTINCT_CHARS) {
     return 'low-effort';

--- a/src/shared/utils/textFonts.ts
+++ b/src/shared/utils/textFonts.ts
@@ -23,7 +23,7 @@ export function collectTextFontFamilies(params: BinParams): Set<TextFontFamily> 
   add(params.surfaceText?.lidStyle);
   for (const style of Object.values(params.surfaceText?.wallStyles ?? {})) add(style);
   add(params.label.textStyle);
-  for (const cutout of params.cutouts ?? []) add(cutout.textStyle);
+  for (const cutout of params.cutouts) add(cutout.textStyle);
 
   // Through-cut swaps to the stencil whatever the pick, and the swap is decided
   // per style deep inside the builders. Adding it unconditionally is cheaper

--- a/src/shell/Modals/WhatsNewModal/WhatsNewModal.test.tsx
+++ b/src/shell/Modals/WhatsNewModal/WhatsNewModal.test.tsx
@@ -151,10 +151,9 @@ describe('WhatsNewModal', () => {
     const assign = vi.fn();
     // Restored in afterEach: nothing here auto-restores mocks, and a leaked
     // window.location getter would follow into every later test.
-    vi.spyOn(window, 'location', 'get').mockReturnValue({
-      ...window.location,
-      assign,
-    });
+    vi.spyOn(window, 'location', 'get').mockReturnValue(
+      Object.assign({}, window.location, { assign })
+    );
 
     rewindPastFirstFeatured();
     open();

--- a/src/shell/Print/SplitPreview/SplitPreview.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.tsx
@@ -36,7 +36,7 @@ function span(units: number, cellSize: number, gap: number): number {
  * the count beside it still said three.
  */
 export function SplitPreview({ width, depth, pieces, cellSize = 16, gap = 2 }: SplitPreviewProps) {
-  const piece = pieces[0];
+  const piece = pieces.at(0);
   if (!piece || piece.width <= 0 || piece.depth <= 0) return null;
 
   // Recovered rather than passed: the pieces tile the bin exactly, so the grid

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,8 +42,9 @@ const collectEagerChunks = (): PluginOption => ({
     eagerChunks.clear();
     const walk = (fileName: string): void => {
       if (eagerChunks.has(fileName)) return;
+      if (!Object.hasOwn(bundle, fileName)) return;
       const chunk = bundle[fileName];
-      if (!chunk || chunk.type !== 'chunk') return;
+      if (chunk.type !== 'chunk') return;
       eagerChunks.add(fileName);
       for (const imported of chunk.imports) walk(imported);
     };


### PR DESCRIPTION
`pnpm run lint` reported 112 warnings on main and nobody was fixing them, so the output carried no signal. This zeroes every rule except `max-lines`: 63 `no-unnecessary-condition`, 4 `no-misused-spread`, 1 `no-base-to-string`, and one unused `eslint-disable`. What remains is 43 `max-lines` warnings, which are decomposition work rather than a sweep and are listed in the vault backlog.

Each `no-unnecessary-condition` site was judged rather than pattern-replaced, because several guard runtime data whose types lie. Four kinds of fix:

- **Defensive index reads TypeScript could not see** (unchecked indexed access is off): `first = sorted[0]; if (!first)` becomes `sorted.at(0)`, which keeps the guard and gives it a type the checker agrees with. Same for `.at(-1)` on last elements and `.at(i)` inside loops, in assembly actions, path editing, the pen shape, mesh assertions, the split preview and the workshop selection.
- **Flags mutated inside callbacks**, which the checker narrows to their initial value: `assemblyTree` derives "changed" from element identity (`mapNodes`) instead of a `let` flag, and its removal and update walkers report a hit through a plain object or by array identity; `useVariantContext` uses an `AbortController` read through a function; the shared-layout importer and the designer autosave read their refs through a function so a check after an `await` is not narrowed by the assignment before it.
- **Dead fallbacks on migrated data**: `?? []` and `?? 'end'` on `BinParams` fields that param migration always fills (cutouts, fractional edges, top accent, tiling margins, the analytics `designsCreated` that `loadAnalyticsData` backfills) are gone. The two baseplate commands were the opposite case: their declared events already mark `displacedBinIds` optional for persisted events that predate it, but `defineCommand` inferred the payload from the handler's literal, so `apply` saw it as required. The handlers now type the payload as the declared event and the fallback stands.
- **Types that lied at a boundary**: the GitHub e-mail list is parsed as `unknown` and filtered with a type guard instead of a cast; the help-jump `CustomEvent` detail is typed as possibly undefined; the community print's browsing thumbnails are read as optional where the comment already said the record may not have them; casts like (`(params.height as number) ?? 0`) become `typeof` checks; sparse records use `Object.hasOwn` rather than an index that types as present.

The spreads: `[...str].length` becomes `Array.from(str).length` in both community low-effort mirrors (same code-point count); the compartment text input's handler takes the string instead of a faked, spread `ChangeEvent`; the What's New test builds its `location` mock with `Object.assign`. The PWA registration error message now formats a non-`Error`, non-string rejection value as empty instead of its default stringification.

**Verification**

- Typecheck (root and api) and full lint: 43 warnings left, all `max-lines`, zero errors.
- Vitest over every touched module's folder, unit and dom projects: 299 files, 4117 tests, plus the CQRS, designer-hook and What's New suites after the last round: 103 files, 857 tests.
- The generator-worker edits (`lidInputs`, `lidCutoutBuilder`, `binDirectMesh`, `assemblyGenerator`, one scenario file) only remove fallbacks on required fields; the heavy generator snapshots run on main.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

