### PR TITLE
chore(lint): promote the four zeroed rules to errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,12 +68,12 @@ export default defineConfig([
         allowBoolean: true,
       }],
       '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
       '@typescript-eslint/no-deprecated': 'warn',
       '@typescript-eslint/no-misused-promises': ['error', {
         checksVoidReturn: { attributes: false },
       }],
-      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
       '@typescript-eslint/restrict-plus-operands': ['error', {
         allowNumberAndString: true,
       }],
@@ -85,8 +85,8 @@ export default defineConfig([
       '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
       '@typescript-eslint/no-unnecessary-type-parameters': 'warn',
-      '@typescript-eslint/no-base-to-string': 'warn',
-      '@typescript-eslint/no-misused-spread': 'warn',
+      '@typescript-eslint/no-base-to-string': 'error',
+      '@typescript-eslint/no-misused-spread': 'error',
 
       // Accessibility
       'jsx-a11y/click-events-have-key-events': 'error',


### PR DESCRIPTION
Follow-up to #4187. With every occurrence gone, the four rules that sweep cleared move from `warn` to `error` so the count cannot climb back to where nobody reads it:

- `@typescript-eslint/no-unnecessary-condition`
- `@typescript-eslint/no-unnecessary-type-assertion`
- `@typescript-eslint/no-base-to-string`
- `@typescript-eslint/no-misused-spread`

The existing per-directory `off` overrides are unchanged. A future site that genuinely guards data whose type lies should widen the type or read through a function boundary, as the sweep did; a justified `eslint-disable` remains available and the suppression guard requires its reason.

The other warn-level rules in the same block (`no-deprecated`, the `no-unsafe-*` family, the remaining `no-unnecessary-*` rules) are also at zero today but are left as warnings; promoting them is a policy call rather than a cleanup.

**Verification**

- Full lint from main with the change: 43 messages, all `max-lines` warnings, zero errors.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

