### PR TITLE
refactor: lift a cohesive unit out of seven files at the max-lines limit

### DIFF
--- a/api/community/prints.ts
+++ b/api/community/prints.ts
@@ -60,6 +60,8 @@ import {
   writeCommunityPrint,
 } from '../lib/communityPrintStore.js';
 import type { CommunityPrintRecord, CommunityPrintStatus } from '../lib/communityPrintStore.js';
+import { toPrintResponse } from '../lib/communityPrintResponse.js';
+import type { PrintResponse } from '../lib/communityPrintResponse.js';
 
 const COMMUNITY_DESIGN_ID_REGEX = /^[a-zA-Z0-9]{12}$/;
 const AUTHOR_PUBLIC_ID_REGEX = /^[a-f0-9]{32}$/;
@@ -138,56 +140,6 @@ async function readOptionalSession(req: VercelRequest): Promise<SessionRecord | 
   } catch {
     return null;
   }
-}
-
-interface PrintResponse {
-  id: string;
-  designId: string;
-  authorPublicId: string;
-  authorName: string;
-  photos: string[];
-  photoThumbs: string[];
-  /** Every field omitted rather than nulled when unreported, so a client that
-      reads `settings.nozzleMm` gets `undefined` and cannot format a 0. */
-  settings: {
-    material?: string;
-    nozzleMm?: number;
-    layerHeightMm?: number;
-    printMinutes?: number;
-    filamentGrams?: number;
-    printer?: string;
-    printerOther?: string;
-  };
-  fitVerdict: string;
-  note: string;
-  createdAt: number;
-  updatedAt: number;
-  status: string;
-}
-
-function toPrintResponse(record: CommunityPrintRecord): PrintResponse {
-  return {
-    id: `${record.designId}:${record.authorPublicId}`,
-    designId: record.designId,
-    authorPublicId: record.authorPublicId,
-    authorName: record.authorName,
-    photos: record.photos,
-    photoThumbs: record.photoThumbs,
-    settings: {
-      ...(record.material !== null && { material: record.material }),
-      ...(record.nozzleMm !== null && { nozzleMm: record.nozzleMm }),
-      ...(record.layerHeightMm !== null && { layerHeightMm: record.layerHeightMm }),
-      ...(record.printMinutes !== null && { printMinutes: record.printMinutes }),
-      ...(record.filamentGrams !== null && { filamentGrams: record.filamentGrams }),
-      ...(record.printer !== null && { printer: record.printer }),
-      ...(record.printerOther !== '' && { printerOther: record.printerOther }),
-    },
-    fitVerdict: record.fitVerdict,
-    note: record.note,
-    createdAt: record.createdAt,
-    updatedAt: record.updatedAt,
-    status: record.status,
-  };
 }
 
 async function handleList(

--- a/api/lib/communityPrintResponse.ts
+++ b/api/lib/communityPrintResponse.ts
@@ -1,0 +1,51 @@
+import type { CommunityPrintRecord } from './communityPrintStore.js';
+
+export interface PrintResponse {
+  id: string;
+  designId: string;
+  authorPublicId: string;
+  authorName: string;
+  photos: string[];
+  photoThumbs: string[];
+  /** Every field omitted rather than nulled when unreported, so a client that
+      reads `settings.nozzleMm` gets `undefined` and cannot format a 0. */
+  settings: {
+    material?: string;
+    nozzleMm?: number;
+    layerHeightMm?: number;
+    printMinutes?: number;
+    filamentGrams?: number;
+    printer?: string;
+    printerOther?: string;
+  };
+  fitVerdict: string;
+  note: string;
+  createdAt: number;
+  updatedAt: number;
+  status: string;
+}
+
+export function toPrintResponse(record: CommunityPrintRecord): PrintResponse {
+  return {
+    id: `${record.designId}:${record.authorPublicId}`,
+    designId: record.designId,
+    authorPublicId: record.authorPublicId,
+    authorName: record.authorName,
+    photos: record.photos,
+    photoThumbs: record.photoThumbs,
+    settings: {
+      ...(record.material !== null && { material: record.material }),
+      ...(record.nozzleMm !== null && { nozzleMm: record.nozzleMm }),
+      ...(record.layerHeightMm !== null && { layerHeightMm: record.layerHeightMm }),
+      ...(record.printMinutes !== null && { printMinutes: record.printMinutes }),
+      ...(record.filamentGrams !== null && { filamentGrams: record.filamentGrams }),
+      ...(record.printer !== null && { printer: record.printer }),
+      ...(record.printerOther !== '' && { printerOther: record.printerOther }),
+    },
+    fitVerdict: record.fitVerdict,
+    note: record.note,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    status: record.status,
+  };
+}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltList.test.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltList.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { DividerTiltList } from './DividerTiltList';
+
+vi.mock('./DividerDiagrams', () => ({
+  DividerMiniDiagram: () => <svg data-testid="mini" />,
+}));
+
+type Props = ComponentProps<typeof DividerTiltList>;
+type Row = Props['rows'][number];
+
+const row = (key: string, a: number, b: number, extra: Partial<Row> = {}): Row =>
+  ({
+    key,
+    numberA: a,
+    numberB: b,
+    offsetStart: 0,
+    offsetEnd: 0,
+    leanDeg: 0,
+    hasTilt: false,
+    angleDeg: 0,
+    ...extra,
+  }) as Row;
+
+function renderList(rows: Row[], hasAnyOverride = false) {
+  const handlers = {
+    hoverDivider: vi.fn(),
+    selectDivider: vi.fn(),
+    resetAll: vi.fn(),
+  } as unknown as Props['handlers'];
+  const t = ((key: string, vars?: Record<string, string>) =>
+    vars ? `${key}:${Object.values(vars).join(',')}` : key) as unknown as Props['t'];
+  render(
+    <DividerTiltList
+      rows={rows}
+      compartments={{ cols: 2, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3] }}
+      hoveredKey={null}
+      hasAnyOverride={hasAnyOverride}
+      handlers={handlers}
+      t={t}
+    />
+  );
+  return { handlers };
+}
+
+describe('DividerTiltList', () => {
+  it('lists rows by ascending display number and selects on click', () => {
+    const { handlers } = renderList([row('b', 3, 4), row('a', 2, 1)]);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveAccessibleName('binDesigner.angledDividers.editRowLabel:1,2');
+    expect(buttons[1]).toHaveAccessibleName('binDesigner.angledDividers.editRowLabel:3,4');
+    fireEvent.click(buttons[1]);
+    expect(handlers.selectDivider).toHaveBeenCalledWith('b');
+  });
+
+  it('offers reset-all only once an override exists', () => {
+    renderList([row('a', 1, 2)]);
+    expect(screen.queryByText('binDesigner.angledDividers.resetAll')).not.toBeInTheDocument();
+    const { handlers } = renderList([row('a', 1, 2)], true);
+    fireEvent.click(screen.getByText('binDesigner.angledDividers.resetAll'));
+    expect(handlers.resetAll).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltList.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltList.tsx
@@ -1,0 +1,120 @@
+import { Button } from '@/design-system';
+import type { CompartmentConfig } from '@/features/bin-designer/types';
+import { DividerMiniDiagram } from './DividerDiagrams';
+import type { TiltRow, useDividerTiltSubsection } from './useDividerTiltSubsection';
+
+type Hook = ReturnType<typeof useDividerTiltSubsection>;
+type Handlers = Hook['handlers'];
+type Translate = Hook['t'];
+
+interface DividerTiltListProps {
+  readonly rows: readonly TiltRow[];
+  readonly compartments: CompartmentConfig;
+  readonly hoveredKey: string | null;
+  readonly hasAnyOverride: boolean;
+  readonly handlers: Handlers;
+  readonly t: Translate;
+}
+
+export function DividerTiltList({
+  rows,
+  compartments,
+  hoveredKey,
+  hasAnyOverride,
+  handlers,
+  t,
+}: DividerTiltListProps) {
+  // Present in display-number order so the list scans like the numbers on the
+  // grid. Display-only: the hook's row order (stable ID pairs) is what the
+  // Bento dock and the hit targets key off, and stays untouched.
+  const sorted = [...rows].sort(
+    (a, b) =>
+      Math.min(a.numberA, a.numberB) - Math.min(b.numberA, b.numberB) ||
+      Math.max(a.numberA, a.numberB) - Math.max(b.numberA, b.numberB)
+  );
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+        {sorted.map((row) => (
+          <DividerRow
+            key={row.key}
+            row={row}
+            compartments={compartments}
+            isHovered={hoveredKey === row.key}
+            handlers={handlers}
+            t={t}
+          />
+        ))}
+      </div>
+      {hasAnyOverride && (
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={handlers.resetAll}
+          className="self-end px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
+        >
+          {t('binDesigner.angledDividers.resetAll')}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface DividerRowProps {
+  readonly row: TiltRow;
+  readonly compartments: CompartmentConfig;
+  readonly isHovered: boolean;
+  readonly handlers: Handlers;
+  readonly t: Translate;
+}
+
+function DividerRow({ row, compartments, isHovered, handlers, t }: DividerRowProps) {
+  // Ascending display numbers: the ID-canonical pair order can put the higher
+  // number first (bottom-row IDs display as high numbers), which reads as noise.
+  const lo = String(Math.min(row.numberA, row.numberB));
+  const hi = String(Math.max(row.numberA, row.numberB));
+  const rowLabel = t('binDesigner.angledDividers.rowLabel', { a: lo, b: hi });
+  const hasPlanTilt = row.offsetStart !== 0 || row.offsetEnd !== 0;
+  const leanRounded = Math.round(row.leanDeg);
+
+  return (
+    <div
+      onPointerEnter={() => handlers.hoverDivider(row.key)}
+      onPointerLeave={() => handlers.hoverDivider(null)}
+      onFocusCapture={() => handlers.hoverDivider(row.key)}
+      onBlurCapture={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) handlers.hoverDivider(null);
+      }}
+      className={`flex items-center rounded-md border bg-surface-elevated transition-colors ${
+        isHovered
+          ? 'border-accent/60 bg-accent/5'
+          : 'border-stroke-subtle hover:border-stroke-subtle/80'
+      }`}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => handlers.selectDivider(row.key)}
+        aria-label={t('binDesigner.angledDividers.editRowLabel', { a: lo, b: hi })}
+        className="flex flex-1 items-center gap-2 px-2 py-1.5 text-left hover:bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-2px]"
+      >
+        <DividerMiniDiagram compartments={compartments} row={row} />
+        <span className="text-xs font-medium text-content-secondary tabular-nums">{rowLabel}</span>
+        <span className="ml-auto flex items-center gap-1.5">
+          {row.hasTilt && hasPlanTilt && (
+            <span className="text-label font-medium tabular-nums text-accent">
+              {t('binDesigner.angledDividers.badgeAngle', {
+                angle: String(Math.round(row.angleDeg)),
+              })}
+            </span>
+          )}
+          {leanRounded !== 0 && (
+            <span className="text-label font-medium tabular-nums text-content-secondary">
+              {t('binDesigner.angledDividers.rowBadgeLean', { angle: String(leanRounded) })}
+            </span>
+          )}
+        </span>
+      </Button>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
@@ -18,13 +18,9 @@ import {
   applyAngleShift,
 } from '@/features/bin-designer/utils/dividerAngle';
 import type { CompartmentConfig } from '@/features/bin-designer/types';
-import {
-  DividerMiniDiagram,
-  DividerPlanDiagram,
-  LeanSpecimen,
-  TeaserDiagram,
-} from './DividerDiagrams';
+import { DividerPlanDiagram, LeanSpecimen, TeaserDiagram } from './DividerDiagrams';
 import { useDividerTiltSubsection, type TiltRow } from './useDividerTiltSubsection';
+import { DividerTiltList } from './DividerTiltList';
 
 export function DividerTiltSubsection() {
   const {
@@ -98,7 +94,7 @@ export function DividerTiltSubsection() {
             t={t}
           />
         ) : (
-          <ListView
+          <DividerTiltList
             rows={rows}
             compartments={compartments}
             hoveredKey={hoveredKey}
@@ -128,111 +124,6 @@ function Teaser({ t }: { readonly t: Translate }) {
       <p className="flex-1 text-label leading-relaxed text-content-tertiary">
         {t('binDesigner.angledDividers.teaser')}
       </p>
-    </div>
-  );
-}
-
-interface ListViewProps {
-  readonly rows: readonly TiltRow[];
-  readonly compartments: CompartmentConfig;
-  readonly hoveredKey: string | null;
-  readonly hasAnyOverride: boolean;
-  readonly handlers: Handlers;
-  readonly t: Translate;
-}
-
-function ListView({ rows, compartments, hoveredKey, hasAnyOverride, handlers, t }: ListViewProps) {
-  // Present in display-number order so the list scans like the numbers on the
-  // grid. Display-only: the hook's row order (stable ID pairs) is what the
-  // Bento dock and the hit targets key off, and stays untouched.
-  const sorted = [...rows].sort(
-    (a, b) =>
-      Math.min(a.numberA, a.numberB) - Math.min(b.numberA, b.numberB) ||
-      Math.max(a.numberA, a.numberB) - Math.max(b.numberA, b.numberB)
-  );
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
-        {sorted.map((row) => (
-          <DividerRow
-            key={row.key}
-            row={row}
-            compartments={compartments}
-            isHovered={hoveredKey === row.key}
-            handlers={handlers}
-            t={t}
-          />
-        ))}
-      </div>
-      {hasAnyOverride && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={handlers.resetAll}
-          className="self-end px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
-        >
-          {t('binDesigner.angledDividers.resetAll')}
-        </Button>
-      )}
-    </div>
-  );
-}
-
-interface DividerRowProps {
-  readonly row: TiltRow;
-  readonly compartments: CompartmentConfig;
-  readonly isHovered: boolean;
-  readonly handlers: Handlers;
-  readonly t: Translate;
-}
-
-function DividerRow({ row, compartments, isHovered, handlers, t }: DividerRowProps) {
-  // Ascending display numbers: the ID-canonical pair order can put the higher
-  // number first (bottom-row IDs display as high numbers), which reads as noise.
-  const lo = String(Math.min(row.numberA, row.numberB));
-  const hi = String(Math.max(row.numberA, row.numberB));
-  const rowLabel = t('binDesigner.angledDividers.rowLabel', { a: lo, b: hi });
-  const hasPlanTilt = row.offsetStart !== 0 || row.offsetEnd !== 0;
-  const leanRounded = Math.round(row.leanDeg);
-
-  return (
-    <div
-      onPointerEnter={() => handlers.hoverDivider(row.key)}
-      onPointerLeave={() => handlers.hoverDivider(null)}
-      onFocusCapture={() => handlers.hoverDivider(row.key)}
-      onBlurCapture={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget)) handlers.hoverDivider(null);
-      }}
-      className={`flex items-center rounded-md border bg-surface-elevated transition-colors ${
-        isHovered
-          ? 'border-accent/60 bg-accent/5'
-          : 'border-stroke-subtle hover:border-stroke-subtle/80'
-      }`}
-    >
-      <Button
-        type="button"
-        variant="ghost"
-        onClick={() => handlers.selectDivider(row.key)}
-        aria-label={t('binDesigner.angledDividers.editRowLabel', { a: lo, b: hi })}
-        className="flex flex-1 items-center gap-2 px-2 py-1.5 text-left hover:bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-2px]"
-      >
-        <DividerMiniDiagram compartments={compartments} row={row} />
-        <span className="text-xs font-medium text-content-secondary tabular-nums">{rowLabel}</span>
-        <span className="ml-auto flex items-center gap-1.5">
-          {row.hasTilt && hasPlanTilt && (
-            <span className="text-label font-medium tabular-nums text-accent">
-              {t('binDesigner.angledDividers.badgeAngle', {
-                angle: String(Math.round(row.angleDeg)),
-              })}
-            </span>
-          )}
-          {leanRounded !== 0 && (
-            <span className="text-label font-medium tabular-nums text-content-secondary">
-              {t('binDesigner.angledDividers.rowBadgeLean', { angle: String(leanRounded) })}
-            </span>
-          )}
-        </span>
-      </Button>
     </div>
   );
 }

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -6,8 +6,9 @@
  * whatever they need.
  */
 
+import { formatPieceDisplayName } from './binDownloadNaming';
+export { formatPieceDisplayName, buildReportIssueUrl } from './binDownloadNaming';
 import { isErr, getUserMessage } from '@/core/result';
-import { GITHUB_ISSUES_URL } from '@/shared/constants/links';
 import { export3MF, export3MFMultiObject } from '@/shared/generation/export';
 import { captureException } from '@/shared/analytics/posthog';
 import {
@@ -48,108 +49,6 @@ import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { FORMAT_MIME_TYPES } from '@/shared/generation/exportUtils';
 import type { BinParams, ExportFileFormat } from '@/features/bin-designer/types';
 import type { CombinedExportResult, ExportFormat } from '@/shared/generation/bridge';
-
-/** Map piece labels from the worker to descriptive display names for 3MF/STEP. */
-export function formatPieceDisplayName(
-  label: string,
-  params: { width: number; depth: number; height: number }
-): string {
-  const dims = `${params.width}x${params.depth}x${params.height}`;
-  switch (label) {
-    case 'bin':
-      return `Bin ${dims}`;
-    case 'lid':
-      return `Lid ${dims}`;
-    case 'lid-baseplate':
-      return `Lid Baseplate ${dims}`;
-    case 'slide-tray':
-      return `Sliding Tray ${dims}`;
-    case 'feet':
-      return `Feet ${dims}`;
-    case 'knife-rest':
-      return `Handle Rest ${dims}`;
-    case 'divider-horizontal':
-      return 'Divider Horizontal';
-    case 'divider-vertical':
-      return 'Divider Vertical';
-    case 'assembly':
-      return `Bin ${dims} Assembly`;
-    default:
-      return label;
-  }
-}
-
-/**
- * Build a GitHub issue URL with bin params + error class prefilled. Lets the
- * "Report issue" toast action drop users into a complete bug report instead
- * of asking them to copy/paste failure context.
- *
- * The snapshot covers every BinParams field that materially affects the
- * generated solid (so reports are reproducible). Fields added carelessly
- * here will balloon the URL — keep the shape compact and prefer counts /
- * enabled flags over full nested config when the nested data is large.
- */
-export function buildReportIssueUrl(
-  params: BinParams,
-  error: Error,
-  format: ExportFileFormat
-): string {
-  const title = `Bin export failed: ${error.name || 'Error'}`;
-  const body = [
-    '**Format:** ' + format.toUpperCase(),
-    '**Error:** ' + error.message,
-    '',
-    '**Bin params:**',
-    '```json',
-    JSON.stringify(
-      {
-        width: params.width,
-        depth: params.depth,
-        height: params.height,
-        gridUnitMm: params.gridUnitMm,
-        heightUnitMm: params.heightUnitMm,
-        wallThickness: params.wallThickness,
-        style: params.style,
-        base: { style: params.base.style, stackingLip: params.base.stackingLip },
-        compartments: {
-          cols: params.compartments.cols,
-          rows: params.compartments.rows,
-          // Duplicate IDs = at least two cells share a compartment. Robust
-          // against renumbered-but-unmerged designs (where a positional
-          // `id !== i` check would false-positive).
-          merged: new Set(params.compartments.cells).size !== params.compartments.cells.length,
-        },
-        scoop: params.scoop.enabled
-          ? {
-              enabled: true,
-              radius: params.scoop.radius,
-              run: params.scoop.run,
-              style: params.scoop.style,
-              autoMaxHeight: params.scoop.autoMaxHeight,
-            }
-          : false,
-        label: params.label.enabled
-          ? { enabled: true, support: params.label.support, depth: params.label.depth }
-          : false,
-        wallPattern: params.wallPattern.enabled ? params.wallPattern.pattern : null,
-        walls: params.walls.enabled ? { shape: params.walls.shape } : false,
-        handles: params.handles.enabled,
-        cutouts: params.cutouts.length,
-        inserts: params.inserts.length,
-        lid: params.lid.enabled,
-        featureColors: params.featureColors.enabled,
-      },
-      null,
-      2
-    ),
-    '```',
-  ].join('\n');
-  const url = new URL(`${GITHUB_ISSUES_URL}/new`);
-  url.searchParams.set('title', title);
-  url.searchParams.set('body', body);
-  url.searchParams.set('labels', 'bin-export-failure');
-  return url.toString();
-}
 
 /**
  * Convert a single STL piece into a 3MF Blob. Throws on malformed STL input

--- a/src/features/bin-designer/utils/binDownloadNaming.ts
+++ b/src/features/bin-designer/utils/binDownloadNaming.ts
@@ -1,0 +1,104 @@
+import { GITHUB_ISSUES_URL } from '@/shared/constants/links';
+import type { BinParams, ExportFileFormat } from '@/features/bin-designer/types';
+
+/** Map piece labels from the worker to descriptive display names for 3MF/STEP. */
+export function formatPieceDisplayName(
+  label: string,
+  params: { width: number; depth: number; height: number }
+): string {
+  const dims = `${params.width}x${params.depth}x${params.height}`;
+  switch (label) {
+    case 'bin':
+      return `Bin ${dims}`;
+    case 'lid':
+      return `Lid ${dims}`;
+    case 'lid-baseplate':
+      return `Lid Baseplate ${dims}`;
+    case 'slide-tray':
+      return `Sliding Tray ${dims}`;
+    case 'feet':
+      return `Feet ${dims}`;
+    case 'knife-rest':
+      return `Handle Rest ${dims}`;
+    case 'divider-horizontal':
+      return 'Divider Horizontal';
+    case 'divider-vertical':
+      return 'Divider Vertical';
+    case 'assembly':
+      return `Bin ${dims} Assembly`;
+    default:
+      return label;
+  }
+}
+
+/**
+ * Build a GitHub issue URL with bin params + error class prefilled. Lets the
+ * "Report issue" toast action drop users into a complete bug report instead
+ * of asking them to copy/paste failure context.
+ *
+ * The snapshot covers every BinParams field that materially affects the
+ * generated solid (so reports are reproducible). Fields added carelessly
+ * here will balloon the URL — keep the shape compact and prefer counts /
+ * enabled flags over full nested config when the nested data is large.
+ */
+export function buildReportIssueUrl(
+  params: BinParams,
+  error: Error,
+  format: ExportFileFormat
+): string {
+  const title = `Bin export failed: ${error.name || 'Error'}`;
+  const body = [
+    '**Format:** ' + format.toUpperCase(),
+    '**Error:** ' + error.message,
+    '',
+    '**Bin params:**',
+    '```json',
+    JSON.stringify(
+      {
+        width: params.width,
+        depth: params.depth,
+        height: params.height,
+        gridUnitMm: params.gridUnitMm,
+        heightUnitMm: params.heightUnitMm,
+        wallThickness: params.wallThickness,
+        style: params.style,
+        base: { style: params.base.style, stackingLip: params.base.stackingLip },
+        compartments: {
+          cols: params.compartments.cols,
+          rows: params.compartments.rows,
+          // Duplicate IDs = at least two cells share a compartment. Robust
+          // against renumbered-but-unmerged designs (where a positional
+          // `id !== i` check would false-positive).
+          merged: new Set(params.compartments.cells).size !== params.compartments.cells.length,
+        },
+        scoop: params.scoop.enabled
+          ? {
+              enabled: true,
+              radius: params.scoop.radius,
+              run: params.scoop.run,
+              style: params.scoop.style,
+              autoMaxHeight: params.scoop.autoMaxHeight,
+            }
+          : false,
+        label: params.label.enabled
+          ? { enabled: true, support: params.label.support, depth: params.label.depth }
+          : false,
+        wallPattern: params.wallPattern.enabled ? params.wallPattern.pattern : null,
+        walls: params.walls.enabled ? { shape: params.walls.shape } : false,
+        handles: params.handles.enabled,
+        cutouts: params.cutouts.length,
+        inserts: params.inserts.length,
+        lid: params.lid.enabled,
+        featureColors: params.featureColors.enabled,
+      },
+      null,
+      2
+    ),
+    '```',
+  ].join('\n');
+  const url = new URL(`${GITHUB_ISSUES_URL}/new`);
+  url.searchParams.set('title', title);
+  url.searchParams.set('body', body);
+  url.searchParams.set('labels', 'bin-export-failure');
+  return url.toString();
+}

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -1,3 +1,13 @@
+import {
+  isDesignResponse,
+  isDetailResponse,
+  isListPage,
+  isCapabilities,
+  isOptionalNumber,
+  parseHiddenReason,
+} from './clientGuards';
+import type { CommunityListPage, CommunityCapabilities } from './clientGuards';
+export type { CommunityCapabilities } from './clientGuards';
 import type { Result } from '@/core/result';
 import { ok, err, isErr } from '@/core/result';
 import { isApiErrorResponse } from '@/core/api/mapApiError';
@@ -14,14 +24,10 @@ import type {
   CommunityHiddenReason,
   CommunityReportReason,
 } from '@/shared/types/community';
-import type { CommunityFeatureReason } from '@/shared/types/community';
 import {
-  COMMUNITY_CATEGORIES,
-  COMMUNITY_FEATURE_REASONS,
   COMMUNITY_REPORT_NOTE_MAX_LENGTH,
   COMMUNITY_REPORT_REASONS,
 } from '@/shared/types/community';
-import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { isRecord } from '@/shared/utils/isRecord';
 
 const COMMUNITY_ENDPOINT = '/api/community';
@@ -103,33 +109,6 @@ function isPublishResult(value: unknown): value is CommunityPublishResult {
   return isRecord(value) && typeof value.id === 'string' && typeof value.url === 'string';
 }
 
-function isCommunityDesign(value: unknown): value is CommunityDesign {
-  if (!isRecord(value)) return false;
-  return (
-    typeof value.id === 'string' &&
-    typeof value.authorPublicId === 'string' &&
-    typeof value.authorName === 'string' &&
-    typeof value.name === 'string' &&
-    typeof value.description === 'string' &&
-    isKnownCategory(value.category) &&
-    Array.isArray(value.techniques) &&
-    value.techniques.every(isKnownTechnique) &&
-    (isRecord(value.params) ||
-      (value.kind === 'assembly' && isRecord(value.envelope) && isRecord(value.structure))) &&
-    isRecord(value.metrics) &&
-    (value.lineage === null || isRecord(value.lineage)) &&
-    Array.isArray(value.thumbnails) &&
-    typeof value.meshUrl === 'string' &&
-    typeof value.createdAt === 'number' &&
-    typeof value.updatedAt === 'number' &&
-    (value.status === 'live' || value.status === 'hidden' || value.status === 'removed')
-  );
-}
-
-function isDesignResponse(value: unknown): value is { design: CommunityDesign } {
-  return isRecord(value) && isCommunityDesign(value.design);
-}
-
 export interface CommunityDesignDetail {
   design: CommunityDesign;
   /** Server-verified against the session's published set, never a client-sent id. */
@@ -153,10 +132,6 @@ export interface CommunityDesignDetail {
   hiddenReasonCategory: CommunityReportReason | null;
 }
 
-function isOptionalNumber(value: unknown): boolean {
-  return value === undefined || typeof value === 'number';
-}
-
 function isCountsShape(value: unknown): value is CommunityDesignCounts {
   return (
     isRecord(value) &&
@@ -168,10 +143,6 @@ function isCountsShape(value: unknown): value is CommunityDesignCounts {
   );
 }
 
-function parseHiddenReason(value: unknown): CommunityHiddenReason | null {
-  return value === 'reports' || value === 'denylist' || value === 'moderation' ? value : null;
-}
-
 function parseReportReason(value: unknown): CommunityReportReason | null {
   return typeof value === 'string' &&
     (COMMUNITY_REPORT_REASONS as readonly string[]).includes(value)
@@ -179,112 +150,9 @@ function parseReportReason(value: unknown): CommunityReportReason | null {
     : null;
 }
 
-function isDetailResponse(value: unknown): value is {
-  design: CommunityDesign;
-  isOwner?: boolean;
-  counts?: unknown;
-  likedByMe?: unknown;
-  authorIsSupporter?: unknown;
-  hiddenReason?: unknown;
-  hiddenReasonCategory?: unknown;
-} {
-  return isDesignResponse(value) && (!('isOwner' in value) || typeof value.isOwner === 'boolean');
-}
-
-const KNOWN_TECHNIQUES: readonly string[] = Object.keys(TECHNIQUE_CONFIG);
-
-function isKnownCategory(value: unknown): value is CommunityCategory {
-  return typeof value === 'string' && (COMMUNITY_CATEGORIES as readonly string[]).includes(value);
-}
-
-function isKnownTechnique(value: unknown): boolean {
-  return typeof value === 'string' && KNOWN_TECHNIQUES.includes(value);
-}
-
-function isKnownFeatureReason(value: unknown): value is CommunityFeatureReason {
-  return (
-    typeof value === 'string' && (COMMUNITY_FEATURE_REASONS as readonly string[]).includes(value)
-  );
-}
-
-function isCommunityCard(value: unknown): value is CommunityCard {
-  if (!isRecord(value)) return false;
-  const counts: unknown = value.counts;
-  const metrics: unknown = value.metrics;
-  return (
-    typeof value.id === 'string' &&
-    typeof value.name === 'string' &&
-    typeof value.authorName === 'string' &&
-    typeof value.authorPublicId === 'string' &&
-    isKnownCategory(value.category) &&
-    Array.isArray(value.techniques) &&
-    value.techniques.every(isKnownTechnique) &&
-    isRecord(metrics) &&
-    typeof metrics.width === 'number' &&
-    typeof metrics.depth === 'number' &&
-    typeof metrics.height === 'number' &&
-    typeof metrics.gridUnitMm === 'number' &&
-    typeof value.thumbnailUrl === 'string' &&
-    typeof value.isRemix === 'boolean' &&
-    (value.parentId === undefined || typeof value.parentId === 'string') &&
-    typeof value.featured === 'boolean' &&
-    // A reason outside the union fails the whole card rather than flowing
-    // through as a typed value the UI will index into a label map.
-    (value.featureReason === undefined || isKnownFeatureReason(value.featureReason)) &&
-    isRecord(counts) &&
-    typeof counts.likes === 'number' &&
-    typeof counts.remixes === 'number' &&
-    typeof counts.exports === 'number' &&
-    isOptionalNumber(counts.opens) &&
-    isOptionalNumber(counts.views) &&
-    typeof value.createdAt === 'number' &&
-    typeof value.updatedAt === 'number' &&
-    (value.status === 'live' || value.status === 'hidden' || value.status === 'removed') &&
-    (value.hiddenReason === undefined || parseHiddenReason(value.hiddenReason) !== null)
-  );
-}
-
-interface CommunityListPage {
-  items: CommunityCard[];
-  nextCursor: string | null;
-  /** Ids on this page the session user has liked; empty for anonymous callers. */
-  likedIds?: string[];
-  /**
-   * Author public ids on this page whose supporter badge is public. Keyed by
-   * author rather than by design, so one publisher with several cards on a
-   * page costs one entry. Optional: an older deployment omits it and nothing
-   * is badged.
-   */
-  supporterAuthorIds?: string[];
-  /**
-   * Slots in the server's index, so the whole thing can be requested as
-   * concurrent windows. Optional: an older deployment omits it and the fetch
-   * falls back to paging sequentially.
-   */
-  indexSlots?: unknown;
-}
-
 /** Seed the per-card supporter flag from a page's author-keyed sidecar. */
 function supporterAuthorSet(page: CommunityListPage): Set<string> {
   return new Set(page.supporterAuthorIds ?? []);
-}
-
-function isListPage(value: unknown): value is CommunityListPage {
-  return (
-    isRecord(value) &&
-    Array.isArray(value.items) &&
-    value.items.every(isCommunityCard) &&
-    (value.nextCursor === null || typeof value.nextCursor === 'string') &&
-    (value.likedIds === undefined ||
-      (Array.isArray(value.likedIds) && value.likedIds.every((id) => typeof id === 'string'))) &&
-    (value.supporterAuthorIds === undefined ||
-      (Array.isArray(value.supporterAuthorIds) &&
-        value.supporterAuthorIds.every((id) => typeof id === 'string'))) &&
-    // indexSlots is deliberately not validated here. It is an optimisation
-    // hint, and a corrupt hint must not reject a page of real designs; it is
-    // read through readIndexSlots, which treats anything unusable as absent.
-    true
-  );
 }
 
 function isDeleteResponse(value: unknown): value is { success: true } {
@@ -296,26 +164,6 @@ export async function communityFetch(input: string, init: RequestInit): Promise<
   // forced sign-out event would clear the sync outbox and flip every tab
   // anonymous.
   return apiFetch(input, { ...init, suppressForcedSignOut: true });
-}
-
-/**
- * The server switches the client cannot infer. `community_showcase` is a
- * per-user Labs flag over the UI; these are deployment kill switches, and
- * nothing local reflects them.
- */
-export interface CommunityCapabilities {
-  publishEnabled: boolean;
-  printsEnabled: boolean;
-  requireDescription: boolean;
-}
-
-function isCapabilities(value: unknown): value is CommunityCapabilities {
-  return (
-    isRecord(value) &&
-    typeof value.publishEnabled === 'boolean' &&
-    typeof value.printsEnabled === 'boolean' &&
-    typeof value.requireDescription === 'boolean'
-  );
 }
 
 /**

--- a/src/features/community/api/clientGuards.ts
+++ b/src/features/community/api/clientGuards.ts
@@ -1,0 +1,168 @@
+import type {
+  CommunityCard,
+  CommunityCategory,
+  CommunityDesign,
+  CommunityFeatureReason,
+  CommunityHiddenReason,
+} from '@/shared/types/community';
+import { COMMUNITY_CATEGORIES, COMMUNITY_FEATURE_REASONS } from '@/shared/types/community';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
+import { isRecord } from '@/shared/utils/isRecord';
+
+export function isCommunityDesign(value: unknown): value is CommunityDesign {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === 'string' &&
+    typeof value.authorPublicId === 'string' &&
+    typeof value.authorName === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.description === 'string' &&
+    isKnownCategory(value.category) &&
+    Array.isArray(value.techniques) &&
+    value.techniques.every(isKnownTechnique) &&
+    (isRecord(value.params) ||
+      (value.kind === 'assembly' && isRecord(value.envelope) && isRecord(value.structure))) &&
+    isRecord(value.metrics) &&
+    (value.lineage === null || isRecord(value.lineage)) &&
+    Array.isArray(value.thumbnails) &&
+    typeof value.meshUrl === 'string' &&
+    typeof value.createdAt === 'number' &&
+    typeof value.updatedAt === 'number' &&
+    (value.status === 'live' || value.status === 'hidden' || value.status === 'removed')
+  );
+}
+
+export function isDesignResponse(value: unknown): value is { design: CommunityDesign } {
+  return isRecord(value) && isCommunityDesign(value.design);
+}
+
+export function isDetailResponse(value: unknown): value is {
+  design: CommunityDesign;
+  isOwner?: boolean;
+  counts?: unknown;
+  likedByMe?: unknown;
+  authorIsSupporter?: unknown;
+  hiddenReason?: unknown;
+  hiddenReasonCategory?: unknown;
+} {
+  return isDesignResponse(value) && (!('isOwner' in value) || typeof value.isOwner === 'boolean');
+}
+
+const KNOWN_TECHNIQUES: readonly string[] = Object.keys(TECHNIQUE_CONFIG);
+
+export function isKnownCategory(value: unknown): value is CommunityCategory {
+  return typeof value === 'string' && (COMMUNITY_CATEGORIES as readonly string[]).includes(value);
+}
+
+export function isKnownTechnique(value: unknown): boolean {
+  return typeof value === 'string' && KNOWN_TECHNIQUES.includes(value);
+}
+
+export function isKnownFeatureReason(value: unknown): value is CommunityFeatureReason {
+  return (
+    typeof value === 'string' && (COMMUNITY_FEATURE_REASONS as readonly string[]).includes(value)
+  );
+}
+
+export function isCommunityCard(value: unknown): value is CommunityCard {
+  if (!isRecord(value)) return false;
+  const counts: unknown = value.counts;
+  const metrics: unknown = value.metrics;
+  return (
+    typeof value.id === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.authorName === 'string' &&
+    typeof value.authorPublicId === 'string' &&
+    isKnownCategory(value.category) &&
+    Array.isArray(value.techniques) &&
+    value.techniques.every(isKnownTechnique) &&
+    isRecord(metrics) &&
+    typeof metrics.width === 'number' &&
+    typeof metrics.depth === 'number' &&
+    typeof metrics.height === 'number' &&
+    typeof metrics.gridUnitMm === 'number' &&
+    typeof value.thumbnailUrl === 'string' &&
+    typeof value.isRemix === 'boolean' &&
+    (value.parentId === undefined || typeof value.parentId === 'string') &&
+    typeof value.featured === 'boolean' &&
+    // A reason outside the union fails the whole card rather than flowing
+    // through as a typed value the UI will index into a label map.
+    (value.featureReason === undefined || isKnownFeatureReason(value.featureReason)) &&
+    isRecord(counts) &&
+    typeof counts.likes === 'number' &&
+    typeof counts.remixes === 'number' &&
+    typeof counts.exports === 'number' &&
+    isOptionalNumber(counts.opens) &&
+    isOptionalNumber(counts.views) &&
+    typeof value.createdAt === 'number' &&
+    typeof value.updatedAt === 'number' &&
+    (value.status === 'live' || value.status === 'hidden' || value.status === 'removed') &&
+    (value.hiddenReason === undefined || parseHiddenReason(value.hiddenReason) !== null)
+  );
+}
+
+export interface CommunityListPage {
+  items: CommunityCard[];
+  nextCursor: string | null;
+  /** Ids on this page the session user has liked; empty for anonymous callers. */
+  likedIds?: string[];
+  /**
+   * Author public ids on this page whose supporter badge is public. Keyed by
+   * author rather than by design, so one publisher with several cards on a
+   * page costs one entry. Optional: an older deployment omits it and nothing
+   * is badged.
+   */
+  supporterAuthorIds?: string[];
+  /**
+   * Slots in the server's index, so the whole thing can be requested as
+   * concurrent windows. Optional: an older deployment omits it and the fetch
+   * falls back to paging sequentially.
+   */
+  indexSlots?: unknown;
+}
+
+export function isListPage(value: unknown): value is CommunityListPage {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.items) &&
+    value.items.every(isCommunityCard) &&
+    (value.nextCursor === null || typeof value.nextCursor === 'string') &&
+    (value.likedIds === undefined ||
+      (Array.isArray(value.likedIds) && value.likedIds.every((id) => typeof id === 'string'))) &&
+    (value.supporterAuthorIds === undefined ||
+      (Array.isArray(value.supporterAuthorIds) &&
+        value.supporterAuthorIds.every((id) => typeof id === 'string'))) &&
+    // indexSlots is deliberately not validated here. It is an optimisation
+    // hint, and a corrupt hint must not reject a page of real designs; it is
+    // read through readIndexSlots, which treats anything unusable as absent.
+    true
+  );
+}
+
+/**
+ * The server switches the client cannot infer. `community_showcase` is a
+ * per-user Labs flag over the UI; these are deployment kill switches, and
+ * nothing local reflects them.
+ */
+export interface CommunityCapabilities {
+  publishEnabled: boolean;
+  printsEnabled: boolean;
+  requireDescription: boolean;
+}
+
+export function isCapabilities(value: unknown): value is CommunityCapabilities {
+  return (
+    isRecord(value) &&
+    typeof value.publishEnabled === 'boolean' &&
+    typeof value.printsEnabled === 'boolean' &&
+    typeof value.requireDescription === 'boolean'
+  );
+}
+
+export function isOptionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === 'number';
+}
+
+export function parseHiddenReason(value: unknown): CommunityHiddenReason | null {
+  return value === 'reports' || value === 'denylist' || value === 'moderation' ? value : null;
+}

--- a/src/features/community/store/browseFilters.ts
+++ b/src/features/community/store/browseFilters.ts
@@ -1,0 +1,299 @@
+import type {
+  CommunityCard,
+  CommunityCategory,
+  CommunityIndexSort,
+} from '@/shared/types/community';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+import { cardDimensionUnits } from '../components/CommunityCard/cardDims';
+import { gapFitVerdict } from '../utils/gapFit';
+
+/**
+ * `name` rides along with the filtering `id` so the clearable chip can label
+ * itself without a card lookup; it is '' on a cold `?author=` deep link until
+ * the loaded index resolves the display name.
+ */
+export interface BrowseAuthorFilter {
+  readonly id: string;
+  readonly name: string;
+}
+
+/**
+ * Client-only sort union: 'best-fit' never crosses the wire (the fetch layer
+ * always requests 'newest'), so it must not widen the server-mirrored
+ * CommunityIndexSort type.
+ */
+export type BrowseSort = CommunityIndexSort | 'best-fit';
+
+/**
+ * Ambient dimension bounds set by an external entry point (the layout
+ * editor's "find bins that fit" flow), in grid/height units. Not part of
+ * `filters`: it is not toolbar-editable and survives clearFilters().
+ */
+export interface FitsGapContext {
+  readonly widthMax: number;
+  readonly depthMax: number;
+  readonly maxHeight: number | null;
+  /**
+   * The layout's mm-per-unit scales, mirrored from the gapFit handoff:
+   * placement hard-rejects scale mismatches, so the gap filter must exclude
+   * cards the placement path could never place.
+   */
+  readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
+  readonly heightUnitMm: number;
+}
+
+export interface BrowseFilters {
+  readonly searchText: string;
+  readonly category: CommunityCategory | null;
+  readonly technique: ExampleTechnique | null;
+  readonly sort: BrowseSort;
+  readonly author: BrowseAuthorFilter | null;
+  readonly likedOnly: boolean;
+  readonly recentOnly: boolean;
+  readonly featuredOnly: boolean;
+  /** Grid units at half-grid steps; bounds are inclusive. `null` = unset. */
+  readonly widthMin: number | null;
+  readonly widthMax: number | null;
+  readonly depthMin: number | null;
+  readonly depthMax: number | null;
+  /** Height units at half steps; inclusive upper bound only. `null` = unset. */
+  readonly maxHeight: number | null;
+  /**
+   * Not a predicate over the public `items` like the other filters: the
+   * public index hard-excludes hidden designs, so while active the gallery
+   * sources its cards from mineStore (the `mine=1` list) instead.
+   */
+  readonly mineOnly: boolean;
+}
+
+export const INITIAL_BROWSE_FILTERS: BrowseFilters = {
+  searchText: '',
+  category: null,
+  technique: null,
+  sort: 'newest',
+  author: null,
+  likedOnly: false,
+  recentOnly: false,
+  featuredOnly: false,
+  widthMin: null,
+  widthMax: null,
+  depthMin: null,
+  depthMax: null,
+  maxHeight: null,
+  mineOnly: false,
+};
+
+export function hasDimensionConstraints(filters: BrowseFilters): boolean {
+  return (
+    filters.widthMin !== null ||
+    filters.widthMax !== null ||
+    filters.depthMin !== null ||
+    filters.depthMax !== null ||
+    filters.maxHeight !== null
+  );
+}
+
+export function hasActiveBrowseFilters(filters: BrowseFilters): boolean {
+  return (
+    filters.searchText !== INITIAL_BROWSE_FILTERS.searchText ||
+    filters.category !== INITIAL_BROWSE_FILTERS.category ||
+    filters.technique !== INITIAL_BROWSE_FILTERS.technique ||
+    filters.sort !== INITIAL_BROWSE_FILTERS.sort ||
+    filters.author !== null ||
+    filters.likedOnly ||
+    filters.recentOnly ||
+    filters.featuredOnly ||
+    filters.mineOnly ||
+    hasDimensionConstraints(filters)
+  );
+}
+
+function matchesSearch(card: CommunityCard, searchText: string, extraHaystack: string): boolean {
+  const query = searchText.trim().toLowerCase();
+  if (query === '') return true;
+  const haystack = `${card.name} ${card.authorName} ${extraHaystack}`.toLowerCase();
+  return query.split(/\s+/).every((term) => haystack.includes(term));
+}
+
+interface BestFitBounds {
+  readonly widthMax: number | null;
+  readonly depthMax: number | null;
+}
+
+const NO_BOUNDS: BestFitBounds = { widthMax: null, depthMax: null };
+
+// With no target box to normalize against (height-only constraint), raw
+// footprint area still yields a well-defined largest-first order.
+function coverageScore(card: CommunityCard, bounds: BestFitBounds): number {
+  const { width, depth } = cardDimensionUnits(card.metrics);
+  const area = width * depth;
+  if (bounds.widthMax === null || bounds.depthMax === null) return area;
+  return area / (bounds.widthMax * bounds.depthMax);
+}
+
+// Mirrors the server's compareCards tie-breaking (api/community.ts): count
+// sorts fall back to recency on ties, so local re-sorts match server order.
+function compareCards(
+  a: CommunityCard,
+  b: CommunityCard,
+  sort: BrowseSort,
+  bounds: BestFitBounds = NO_BOUNDS
+): number {
+  if (sort === 'best-fit') {
+    const diff = coverageScore(b, bounds) - coverageScore(a, bounds);
+    if (diff !== 0) return diff;
+  }
+  if (sort === 'likes' && b.counts.likes !== a.counts.likes) {
+    return b.counts.likes - a.counts.likes;
+  }
+  if (sort === 'remixes' && b.counts.remixes !== a.counts.remixes) {
+    return b.counts.remixes - a.counts.remixes;
+  }
+  return b.createdAt - a.createdAt;
+}
+
+interface MatchContext {
+  readonly matches: (card: CommunityCard) => boolean;
+  /** Non-null only while the recently-viewed filter is active; also drives its ordering. */
+  readonly recentRank: Map<string, number> | null;
+  readonly bounds: BestFitBounds;
+}
+
+function buildMatchContext(
+  filters: BrowseFilters,
+  searchLabels: ((card: CommunityCard) => string) | undefined,
+  recentIds: readonly string[],
+  fitsGapContext: FitsGapContext | null
+): MatchContext {
+  const recentRank = filters.recentOnly ? new Map(recentIds.map((id, index) => [id, index])) : null;
+  // An explicit toolbar bound always wins over the ambient gap context: it is
+  // the more specific, more recent signal.
+  const effectiveWidthMax = filters.widthMax ?? fitsGapContext?.widthMax ?? null;
+  const effectiveDepthMax = filters.depthMax ?? fitsGapContext?.depthMax ?? null;
+  const effectiveMaxHeight = filters.maxHeight ?? fitsGapContext?.maxHeight ?? null;
+  // An explicit toolbar bound overrides the corresponding gap dimension but
+  // keeps the rest of the context (notably the grid scale), so the verdict
+  // stays a single comparison rather than two competing ones.
+  const effectiveGap =
+    fitsGapContext === null
+      ? null
+      : {
+          ...fitsGapContext,
+          widthMax: filters.widthMax ?? fitsGapContext.widthMax,
+          depthMax: filters.depthMax ?? fitsGapContext.depthMax,
+          maxHeight: filters.maxHeight ?? fitsGapContext.maxHeight,
+        };
+  const fitsFootprintMax = (width: number, depth: number): boolean =>
+    (effectiveWidthMax === null || width <= effectiveWidthMax) &&
+    (effectiveDepthMax === null || depth <= effectiveDepthMax);
+  const matches = (card: CommunityCard): boolean => {
+    const dims = cardDimensionUnits(card.metrics);
+    // With a gap context the verdict comes from gapFitVerdict, the same
+    // function the detail view renders, so filtering a card out of the grid
+    // and telling someone "this will not fit" can never disagree. It covers
+    // rotation (placement probes both orientations) and the scale match that
+    // placement hard-rejects on.
+    const gapVerdict = effectiveGap === null ? null : gapFitVerdict(card.metrics, effectiveGap);
+    const footprintOk =
+      gapVerdict !== null
+        ? gapVerdict === 'fits' || gapVerdict === 'fits-rotated'
+        : fitsFootprintMax(dims.width, dims.depth);
+    const scaleOk = gapVerdict === null || gapVerdict !== 'scale-mismatch';
+    return (
+      scaleOk &&
+      (filters.category === null || card.category === filters.category) &&
+      (filters.technique === null || card.techniques.includes(filters.technique)) &&
+      (filters.author === null || card.authorPublicId === filters.author.id) &&
+      (!filters.likedOnly || card.likedByMe === true) &&
+      (!filters.featuredOnly || card.featured) &&
+      (filters.widthMin === null || dims.width >= filters.widthMin) &&
+      (filters.depthMin === null || dims.depth >= filters.depthMin) &&
+      footprintOk &&
+      (effectiveMaxHeight === null || dims.height <= effectiveMaxHeight) &&
+      (recentRank === null || recentRank.has(card.id)) &&
+      matchesSearch(card, filters.searchText, searchLabels?.(card) ?? '')
+    );
+  };
+  return {
+    matches,
+    recentRank,
+    bounds: { widthMax: effectiveWidthMax, depthMax: effectiveDepthMax },
+  };
+}
+
+/**
+ * The grid's own membership test, exposed so facet counts are computed with
+ * the exact predicate that decides what the grid shows. A second, parallel
+ * implementation would eventually promise a count the grid does not deliver.
+ *
+ * `mineOnly` is deliberately absent: it swaps the card source rather than
+ * filtering the public index (see BrowseFilters).
+ */
+export function createCardMatcher(
+  filters: BrowseFilters,
+  searchLabels?: (card: CommunityCard) => string,
+  recentIds: readonly string[] = [],
+  fitsGapContext: FitsGapContext | null = null
+): (card: CommunityCard) => boolean {
+  return buildMatchContext(filters, searchLabels, recentIds, fitsGapContext).matches;
+}
+
+export function filterAndSortCards(
+  items: readonly CommunityCard[],
+  filters: BrowseFilters,
+  searchLabels?: (card: CommunityCard) => string,
+  recentIds: readonly string[] = [],
+  fitsGapContext: FitsGapContext | null = null
+): CommunityCard[] {
+  const { matches, recentRank, bounds } = buildMatchContext(
+    filters,
+    searchLabels,
+    recentIds,
+    fitsGapContext
+  );
+  const matched = items.filter(matches);
+  if (recentRank !== null) {
+    // Most-recent-first is the point of the recently-viewed chip, so it
+    // overrides the sort control while active.
+    return matched.sort((a, b) => (recentRank.get(a.id) ?? 0) - (recentRank.get(b.id) ?? 0));
+  }
+  return matched.sort((a, b) => compareCards(a, b, filters.sort, bounds));
+}
+
+// Best-fit only has something to score against while a dimension constraint
+// (toolbar or gap context) is active; when the last one clears, silently
+// keeping the best-fit order would be an unexplained, unlabeled sort.
+export function withBestFitFallback(
+  filters: BrowseFilters,
+  fitsGapContext: FitsGapContext | null
+): BrowseFilters {
+  if (filters.sort !== 'best-fit') return filters;
+  if (hasDimensionConstraints(filters) || fitsGapContext !== null) return filters;
+  return { ...filters, sort: 'newest' };
+}
+
+/**
+ * Value equality over the filters. `author` is the only non-primitive, and it
+ * is compared by id and name rather than by reference: the URL rebuilds it on
+ * every decode, so a reference check would report a change on every replay.
+ */
+export function sameBrowseFilters(a: BrowseFilters, b: BrowseFilters): boolean {
+  return (
+    a.searchText === b.searchText &&
+    a.category === b.category &&
+    a.technique === b.technique &&
+    a.sort === b.sort &&
+    a.likedOnly === b.likedOnly &&
+    a.recentOnly === b.recentOnly &&
+    a.featuredOnly === b.featuredOnly &&
+    a.mineOnly === b.mineOnly &&
+    a.widthMin === b.widthMin &&
+    a.widthMax === b.widthMax &&
+    a.depthMin === b.depthMin &&
+    a.depthMax === b.depthMax &&
+    a.maxHeight === b.maxHeight &&
+    a.author?.id === b.author?.id &&
+    a.author?.name === b.author?.name
+  );
+}

--- a/src/features/community/store/browseStore.ts
+++ b/src/features/community/store/browseStore.ts
@@ -1,123 +1,36 @@
+import { INITIAL_BROWSE_FILTERS, withBestFitFallback, sameBrowseFilters } from './browseFilters';
+import type {
+  BrowseAuthorFilter,
+  BrowseSort,
+  FitsGapContext,
+  BrowseFilters,
+} from './browseFilters';
+export {
+  INITIAL_BROWSE_FILTERS,
+  hasDimensionConstraints,
+  hasActiveBrowseFilters,
+  createCardMatcher,
+  filterAndSortCards,
+  sameBrowseFilters,
+} from './browseFilters';
+export type {
+  BrowseAuthorFilter,
+  BrowseSort,
+  FitsGapContext,
+  BrowseFilters,
+} from './browseFilters';
 import { create } from 'zustand';
 import { isOk } from '@/core/result';
-import type {
-  CommunityCard,
-  CommunityCategory,
-  CommunityIndexSort,
-} from '@/shared/types/community';
+import type { CommunityCard, CommunityCategory } from '@/shared/types/community';
 import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
 import type { CommunityClientError } from '../api/client';
 import { fetchCommunityIndex } from '../api/client';
-import { cardDimensionUnits } from '../components/CommunityCard/cardDims';
-import { gapFitVerdict } from '../utils/gapFit';
 
 export const BROWSE_INDEX_STALE_MS = 5 * 60 * 1000;
 
 export const GALLERY_PAGE_SIZE = 24;
 
 export type BrowseLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
-
-/**
- * `name` rides along with the filtering `id` so the clearable chip can label
- * itself without a card lookup; it is '' on a cold `?author=` deep link until
- * the loaded index resolves the display name.
- */
-export interface BrowseAuthorFilter {
-  readonly id: string;
-  readonly name: string;
-}
-
-/**
- * Client-only sort union: 'best-fit' never crosses the wire (the fetch layer
- * always requests 'newest'), so it must not widen the server-mirrored
- * CommunityIndexSort type.
- */
-export type BrowseSort = CommunityIndexSort | 'best-fit';
-
-/**
- * Ambient dimension bounds set by an external entry point (the layout
- * editor's "find bins that fit" flow), in grid/height units. Not part of
- * `filters`: it is not toolbar-editable and survives clearFilters().
- */
-export interface FitsGapContext {
-  readonly widthMax: number;
-  readonly depthMax: number;
-  readonly maxHeight: number | null;
-  /**
-   * The layout's mm-per-unit scales, mirrored from the gapFit handoff:
-   * placement hard-rejects scale mismatches, so the gap filter must exclude
-   * cards the placement path could never place.
-   */
-  readonly gridUnitMm: number;
-  readonly gridUnitMmY: number;
-  readonly heightUnitMm: number;
-}
-
-export interface BrowseFilters {
-  readonly searchText: string;
-  readonly category: CommunityCategory | null;
-  readonly technique: ExampleTechnique | null;
-  readonly sort: BrowseSort;
-  readonly author: BrowseAuthorFilter | null;
-  readonly likedOnly: boolean;
-  readonly recentOnly: boolean;
-  readonly featuredOnly: boolean;
-  /** Grid units at half-grid steps; bounds are inclusive. `null` = unset. */
-  readonly widthMin: number | null;
-  readonly widthMax: number | null;
-  readonly depthMin: number | null;
-  readonly depthMax: number | null;
-  /** Height units at half steps; inclusive upper bound only. `null` = unset. */
-  readonly maxHeight: number | null;
-  /**
-   * Not a predicate over the public `items` like the other filters: the
-   * public index hard-excludes hidden designs, so while active the gallery
-   * sources its cards from mineStore (the `mine=1` list) instead.
-   */
-  readonly mineOnly: boolean;
-}
-
-export const INITIAL_BROWSE_FILTERS: BrowseFilters = {
-  searchText: '',
-  category: null,
-  technique: null,
-  sort: 'newest',
-  author: null,
-  likedOnly: false,
-  recentOnly: false,
-  featuredOnly: false,
-  widthMin: null,
-  widthMax: null,
-  depthMin: null,
-  depthMax: null,
-  maxHeight: null,
-  mineOnly: false,
-};
-
-export function hasDimensionConstraints(filters: BrowseFilters): boolean {
-  return (
-    filters.widthMin !== null ||
-    filters.widthMax !== null ||
-    filters.depthMin !== null ||
-    filters.depthMax !== null ||
-    filters.maxHeight !== null
-  );
-}
-
-export function hasActiveBrowseFilters(filters: BrowseFilters): boolean {
-  return (
-    filters.searchText !== INITIAL_BROWSE_FILTERS.searchText ||
-    filters.category !== INITIAL_BROWSE_FILTERS.category ||
-    filters.technique !== INITIAL_BROWSE_FILTERS.technique ||
-    filters.sort !== INITIAL_BROWSE_FILTERS.sort ||
-    filters.author !== null ||
-    filters.likedOnly ||
-    filters.recentOnly ||
-    filters.featuredOnly ||
-    filters.mineOnly ||
-    hasDimensionConstraints(filters)
-  );
-}
 
 interface BrowseState {
   status: BrowseLoadStatus;
@@ -202,197 +115,8 @@ export const INITIAL_BROWSE_STATE: BrowseState = {
   requestId: 0,
 };
 
-function matchesSearch(card: CommunityCard, searchText: string, extraHaystack: string): boolean {
-  const query = searchText.trim().toLowerCase();
-  if (query === '') return true;
-  const haystack = `${card.name} ${card.authorName} ${extraHaystack}`.toLowerCase();
-  return query.split(/\s+/).every((term) => haystack.includes(term));
-}
-
-interface BestFitBounds {
-  readonly widthMax: number | null;
-  readonly depthMax: number | null;
-}
-
-const NO_BOUNDS: BestFitBounds = { widthMax: null, depthMax: null };
-
-// With no target box to normalize against (height-only constraint), raw
-// footprint area still yields a well-defined largest-first order.
-function coverageScore(card: CommunityCard, bounds: BestFitBounds): number {
-  const { width, depth } = cardDimensionUnits(card.metrics);
-  const area = width * depth;
-  if (bounds.widthMax === null || bounds.depthMax === null) return area;
-  return area / (bounds.widthMax * bounds.depthMax);
-}
-
-// Mirrors the server's compareCards tie-breaking (api/community.ts): count
-// sorts fall back to recency on ties, so local re-sorts match server order.
-function compareCards(
-  a: CommunityCard,
-  b: CommunityCard,
-  sort: BrowseSort,
-  bounds: BestFitBounds = NO_BOUNDS
-): number {
-  if (sort === 'best-fit') {
-    const diff = coverageScore(b, bounds) - coverageScore(a, bounds);
-    if (diff !== 0) return diff;
-  }
-  if (sort === 'likes' && b.counts.likes !== a.counts.likes) {
-    return b.counts.likes - a.counts.likes;
-  }
-  if (sort === 'remixes' && b.counts.remixes !== a.counts.remixes) {
-    return b.counts.remixes - a.counts.remixes;
-  }
-  return b.createdAt - a.createdAt;
-}
-
-interface MatchContext {
-  readonly matches: (card: CommunityCard) => boolean;
-  /** Non-null only while the recently-viewed filter is active; also drives its ordering. */
-  readonly recentRank: Map<string, number> | null;
-  readonly bounds: BestFitBounds;
-}
-
-function buildMatchContext(
-  filters: BrowseFilters,
-  searchLabels: ((card: CommunityCard) => string) | undefined,
-  recentIds: readonly string[],
-  fitsGapContext: FitsGapContext | null
-): MatchContext {
-  const recentRank = filters.recentOnly ? new Map(recentIds.map((id, index) => [id, index])) : null;
-  // An explicit toolbar bound always wins over the ambient gap context: it is
-  // the more specific, more recent signal.
-  const effectiveWidthMax = filters.widthMax ?? fitsGapContext?.widthMax ?? null;
-  const effectiveDepthMax = filters.depthMax ?? fitsGapContext?.depthMax ?? null;
-  const effectiveMaxHeight = filters.maxHeight ?? fitsGapContext?.maxHeight ?? null;
-  // An explicit toolbar bound overrides the corresponding gap dimension but
-  // keeps the rest of the context (notably the grid scale), so the verdict
-  // stays a single comparison rather than two competing ones.
-  const effectiveGap =
-    fitsGapContext === null
-      ? null
-      : {
-          ...fitsGapContext,
-          widthMax: filters.widthMax ?? fitsGapContext.widthMax,
-          depthMax: filters.depthMax ?? fitsGapContext.depthMax,
-          maxHeight: filters.maxHeight ?? fitsGapContext.maxHeight,
-        };
-  const fitsFootprintMax = (width: number, depth: number): boolean =>
-    (effectiveWidthMax === null || width <= effectiveWidthMax) &&
-    (effectiveDepthMax === null || depth <= effectiveDepthMax);
-  const matches = (card: CommunityCard): boolean => {
-    const dims = cardDimensionUnits(card.metrics);
-    // With a gap context the verdict comes from gapFitVerdict, the same
-    // function the detail view renders, so filtering a card out of the grid
-    // and telling someone "this will not fit" can never disagree. It covers
-    // rotation (placement probes both orientations) and the scale match that
-    // placement hard-rejects on.
-    const gapVerdict = effectiveGap === null ? null : gapFitVerdict(card.metrics, effectiveGap);
-    const footprintOk =
-      gapVerdict !== null
-        ? gapVerdict === 'fits' || gapVerdict === 'fits-rotated'
-        : fitsFootprintMax(dims.width, dims.depth);
-    const scaleOk = gapVerdict === null || gapVerdict !== 'scale-mismatch';
-    return (
-      scaleOk &&
-      (filters.category === null || card.category === filters.category) &&
-      (filters.technique === null || card.techniques.includes(filters.technique)) &&
-      (filters.author === null || card.authorPublicId === filters.author.id) &&
-      (!filters.likedOnly || card.likedByMe === true) &&
-      (!filters.featuredOnly || card.featured) &&
-      (filters.widthMin === null || dims.width >= filters.widthMin) &&
-      (filters.depthMin === null || dims.depth >= filters.depthMin) &&
-      footprintOk &&
-      (effectiveMaxHeight === null || dims.height <= effectiveMaxHeight) &&
-      (recentRank === null || recentRank.has(card.id)) &&
-      matchesSearch(card, filters.searchText, searchLabels?.(card) ?? '')
-    );
-  };
-  return {
-    matches,
-    recentRank,
-    bounds: { widthMax: effectiveWidthMax, depthMax: effectiveDepthMax },
-  };
-}
-
-/**
- * The grid's own membership test, exposed so facet counts are computed with
- * the exact predicate that decides what the grid shows. A second, parallel
- * implementation would eventually promise a count the grid does not deliver.
- *
- * `mineOnly` is deliberately absent: it swaps the card source rather than
- * filtering the public index (see BrowseFilters).
- */
-export function createCardMatcher(
-  filters: BrowseFilters,
-  searchLabels?: (card: CommunityCard) => string,
-  recentIds: readonly string[] = [],
-  fitsGapContext: FitsGapContext | null = null
-): (card: CommunityCard) => boolean {
-  return buildMatchContext(filters, searchLabels, recentIds, fitsGapContext).matches;
-}
-
-export function filterAndSortCards(
-  items: readonly CommunityCard[],
-  filters: BrowseFilters,
-  searchLabels?: (card: CommunityCard) => string,
-  recentIds: readonly string[] = [],
-  fitsGapContext: FitsGapContext | null = null
-): CommunityCard[] {
-  const { matches, recentRank, bounds } = buildMatchContext(
-    filters,
-    searchLabels,
-    recentIds,
-    fitsGapContext
-  );
-  const matched = items.filter(matches);
-  if (recentRank !== null) {
-    // Most-recent-first is the point of the recently-viewed chip, so it
-    // overrides the sort control while active.
-    return matched.sort((a, b) => (recentRank.get(a.id) ?? 0) - (recentRank.get(b.id) ?? 0));
-  }
-  return matched.sort((a, b) => compareCards(a, b, filters.sort, bounds));
-}
-
 export function isIndexStale(fetchedAt: number | null, now: number): boolean {
   return fetchedAt === null || now - fetchedAt >= BROWSE_INDEX_STALE_MS;
-}
-
-// Best-fit only has something to score against while a dimension constraint
-// (toolbar or gap context) is active; when the last one clears, silently
-// keeping the best-fit order would be an unexplained, unlabeled sort.
-function withBestFitFallback(
-  filters: BrowseFilters,
-  fitsGapContext: FitsGapContext | null
-): BrowseFilters {
-  if (filters.sort !== 'best-fit') return filters;
-  if (hasDimensionConstraints(filters) || fitsGapContext !== null) return filters;
-  return { ...filters, sort: 'newest' };
-}
-
-/**
- * Value equality over the filters. `author` is the only non-primitive, and it
- * is compared by id and name rather than by reference: the URL rebuilds it on
- * every decode, so a reference check would report a change on every replay.
- */
-export function sameBrowseFilters(a: BrowseFilters, b: BrowseFilters): boolean {
-  return (
-    a.searchText === b.searchText &&
-    a.category === b.category &&
-    a.technique === b.technique &&
-    a.sort === b.sort &&
-    a.likedOnly === b.likedOnly &&
-    a.recentOnly === b.recentOnly &&
-    a.featuredOnly === b.featuredOnly &&
-    a.mineOnly === b.mineOnly &&
-    a.widthMin === b.widthMin &&
-    a.widthMax === b.widthMax &&
-    a.depthMin === b.depthMin &&
-    a.depthMax === b.depthMax &&
-    a.maxHeight === b.maxHeight &&
-    a.author?.id === b.author?.id &&
-    a.author?.name === b.author?.name
-  );
 }
 
 function withDimensionPatch(

--- a/src/features/community/utils/gapFit.ts
+++ b/src/features/community/utils/gapFit.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CommunityDesignMetrics } from '@/shared/types/community';
-import type { FitsGapContext } from '../store/browseStore';
+import type { FitsGapContext } from '../store/browseFilters';
 import { cardDimensionUnits } from '../components/CommunityCard/cardDims';
 
 export type GapFitVerdict =

--- a/src/features/supporters/components/SupportersPage/SupportersFlourishes.test.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersFlourishes.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CtaBurst, RotatingMessage, Sparkline } from './SupportersFlourishes';
+
+describe('Sparkline', () => {
+  it('plots one point per bucket and marks the last one', () => {
+    const { container } = render(
+      <Sparkline
+        buckets={[
+          { key: 'a', count: 1 },
+          { key: 'b', count: 3 },
+          { key: 'c', count: 2 },
+        ]}
+        color="#abc"
+      />
+    );
+    const line = container.querySelector('polyline');
+    expect(line?.getAttribute('points')?.split(' ')).toHaveLength(3);
+    expect(container.querySelector('circle')).not.toBeNull();
+  });
+});
+
+describe('RotatingMessage', () => {
+  it('shows the first message with its attribution and nothing for an empty list', () => {
+    const { container, rerender } = render(
+      <RotatingMessage
+        items={[{ message: 'thanks!', name: 'Sam' }]}
+        reducedMotion
+        attribution={(name) => `from ${name}`}
+      />
+    );
+    expect(screen.getByText('thanks!')).toBeInTheDocument();
+    expect(screen.getByText('from Sam')).toBeInTheDocument();
+    rerender(<RotatingMessage items={[]} reducedMotion attribution={(n) => n} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('CtaBurst', () => {
+  it('finishes immediately when no 2D canvas is available', () => {
+    const onDone = vi.fn();
+    render(<CtaBurst origin={{ x: 0, y: 0 }} accent="#f00" seed={1} onDone={onDone} />);
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/supporters/components/SupportersPage/SupportersFlourishes.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersFlourishes.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import type { SupportBucket } from '../../utils/supportersData';
+
+/** How long each rotating message holds before the next. */
+const MESSAGE_ROTATE_MS = 6000;
+
+/** Self-contained particle burst on a full-screen canvas; no-ops without 2D canvas. */
+export function CtaBurst({
+  origin,
+  accent,
+  seed,
+  onDone,
+}: {
+  origin: { x: number; y: number };
+  accent: string;
+  seed: number;
+  onDone: () => void;
+}) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) {
+      onDone();
+      return;
+    }
+    // Scale the backing store for crisp particles on high-DPI displays.
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = window.innerWidth * dpr;
+    canvas.height = window.innerHeight * dpr;
+    ctx.scale(dpr, dpr);
+    const particles = Array.from({ length: 18 }, (_, i) => {
+      const a = (i / 18) * Math.PI * 2 + seed;
+      const speed = 3 + (i % 5);
+      return {
+        x: origin.x,
+        y: origin.y,
+        vx: Math.cos(a) * speed,
+        vy: Math.sin(a) * speed - 2,
+        life: 1,
+        rot: a,
+      };
+    });
+    let raf = 0;
+    const tick = () => {
+      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+      let alive = false;
+      for (const p of particles) {
+        p.vy += 0.12;
+        p.x += p.vx;
+        p.y += p.vy;
+        p.life -= 0.02;
+        p.rot += 0.1;
+        if (p.life > 0) {
+          alive = true;
+          ctx.save();
+          ctx.globalAlpha = Math.max(0, p.life);
+          ctx.translate(p.x, p.y);
+          ctx.rotate(p.rot);
+          ctx.fillStyle = accent;
+          ctx.fillRect(-4, -4, 8, 8);
+          ctx.restore();
+        }
+      }
+      if (alive) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        onDone();
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [origin, accent, seed, onDone]);
+
+  return (
+    <canvas
+      ref={ref}
+      className="pointer-events-none fixed inset-0 z-30 h-full w-full"
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Muted line chart of new supporters per month. The SVG itself is aria-hidden
+ * (the shapes carry no meaning to a screen reader); the labeled `<figure>`
+ * wrapper in the page is what conveys the chart to assistive tech.
+ */
+export function Sparkline({ buckets, color }: { buckets: SupportBucket[]; color: string }) {
+  const width = 104;
+  const height = 30;
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+  const step = buckets.length > 1 ? width / (buckets.length - 1) : 0;
+  const points = buckets.map((b, i) => {
+    const x = i * step;
+    const y = height - (b.count / max) * (height - 5) - 3;
+    return { x, y };
+  });
+  const line = points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const last = points[points.length - 1] ?? { x: width, y: height };
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      fill="none"
+      aria-hidden="true"
+    >
+      {/* Soft area under the line so a sparse series still reads as a chart. */}
+      <polygon points={`0,${height} ${line} ${width},${height}`} fill={color} opacity={0.12} />
+      <polyline
+        points={line}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.75}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        opacity={0.95}
+      />
+      <circle cx={last.x} cy={last.y} r={2.4} fill={color} />
+    </svg>
+  );
+}
+
+/**
+ * Cycles slowly through supporters' public messages near the CTA, so the warmth
+ * on the wall is visible without hunting for a bin to click. Holds still under
+ * reduced motion.
+ */
+export function RotatingMessage({
+  items,
+  reducedMotion,
+  attribution,
+}: {
+  items: { message: string; name: string | null }[];
+  reducedMotion: boolean;
+  attribution: (name: string) => string;
+}) {
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    if (reducedMotion || items.length <= 1) return;
+    const id = setInterval(() => setIndex((i) => (i + 1) % items.length), MESSAGE_ROTATE_MS);
+    return () => clearInterval(id);
+  }, [items.length, reducedMotion]);
+
+  if (items.length === 0) return null;
+  const item = items[index % items.length];
+  return (
+    <p key={index} className="max-w-md text-sm italic opacity-70 motion-safe:animate-fade-in">
+      <span>{item.message}</span>
+      {item.name && <span className="opacity-60"> {attribution(item.name)}</span>}
+    </p>
+  );
+}

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -16,7 +16,6 @@ import {
   getSupporterCount,
   joinedThisMonth,
   supportHistogram,
-  type SupportBucket,
   type SupporterBin,
 } from '../../utils/supportersData';
 import { useSupportersData } from '../../hooks/useSupportersData';
@@ -25,180 +24,13 @@ import type { SupporterProfilePatch } from '../../api/supporterClient';
 import { getSupportersPalette } from '../../scene/palette';
 import { SupportersScene, type FlyToRequest } from '../SupportersScene';
 import { SupporterPanel } from '../SupporterPanel';
+import { useCountUp } from './useCountUp';
+import { CtaBurst, RotatingMessage, Sparkline } from './SupportersFlourishes';
 
 /** Months of history the sparkline plots. */
 const SPARKLINE_MONTHS = 6;
 /** The sparkline only earns its space once support spans a few distinct months. */
 const SPARKLINE_MIN_ACTIVE_MONTHS = 3;
-/** How long each rotating message holds before the next. */
-const MESSAGE_ROTATE_MS = 6000;
-
-function useCountUp(target: number, animate: boolean): number {
-  const [animated, setAnimated] = useState(0);
-  useEffect(() => {
-    if (!animate) return;
-    let raf = 0;
-    let startTs = 0;
-    const step = (ts: number) => {
-      if (!startTs) startTs = ts;
-      const t = Math.min((ts - startTs) / 1600, 1);
-      setAnimated(Math.round(target * (1 - Math.pow(1 - t, 3))));
-      if (t < 1) raf = requestAnimationFrame(step);
-    };
-    raf = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(raf);
-  }, [target, animate]);
-  return animate ? animated : target;
-}
-
-/** Self-contained particle burst on a full-screen canvas; no-ops without 2D canvas. */
-function CtaBurst({
-  origin,
-  accent,
-  seed,
-  onDone,
-}: {
-  origin: { x: number; y: number };
-  accent: string;
-  seed: number;
-  onDone: () => void;
-}) {
-  const ref = useRef<HTMLCanvasElement>(null);
-  useEffect(() => {
-    const canvas = ref.current;
-    const ctx = canvas?.getContext('2d');
-    if (!canvas || !ctx) {
-      onDone();
-      return;
-    }
-    // Scale the backing store for crisp particles on high-DPI displays.
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    canvas.width = window.innerWidth * dpr;
-    canvas.height = window.innerHeight * dpr;
-    ctx.scale(dpr, dpr);
-    const particles = Array.from({ length: 18 }, (_, i) => {
-      const a = (i / 18) * Math.PI * 2 + seed;
-      const speed = 3 + (i % 5);
-      return {
-        x: origin.x,
-        y: origin.y,
-        vx: Math.cos(a) * speed,
-        vy: Math.sin(a) * speed - 2,
-        life: 1,
-        rot: a,
-      };
-    });
-    let raf = 0;
-    const tick = () => {
-      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
-      let alive = false;
-      for (const p of particles) {
-        p.vy += 0.12;
-        p.x += p.vx;
-        p.y += p.vy;
-        p.life -= 0.02;
-        p.rot += 0.1;
-        if (p.life > 0) {
-          alive = true;
-          ctx.save();
-          ctx.globalAlpha = Math.max(0, p.life);
-          ctx.translate(p.x, p.y);
-          ctx.rotate(p.rot);
-          ctx.fillStyle = accent;
-          ctx.fillRect(-4, -4, 8, 8);
-          ctx.restore();
-        }
-      }
-      if (alive) {
-        raf = requestAnimationFrame(tick);
-      } else {
-        onDone();
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [origin, accent, seed, onDone]);
-
-  return (
-    <canvas
-      ref={ref}
-      className="pointer-events-none fixed inset-0 z-30 h-full w-full"
-      aria-hidden="true"
-    />
-  );
-}
-
-/**
- * Muted line chart of new supporters per month. The SVG itself is aria-hidden
- * (the shapes carry no meaning to a screen reader); the labeled `<figure>`
- * wrapper in the page is what conveys the chart to assistive tech.
- */
-function Sparkline({ buckets, color }: { buckets: SupportBucket[]; color: string }) {
-  const width = 104;
-  const height = 30;
-  const max = Math.max(1, ...buckets.map((b) => b.count));
-  const step = buckets.length > 1 ? width / (buckets.length - 1) : 0;
-  const points = buckets.map((b, i) => {
-    const x = i * step;
-    const y = height - (b.count / max) * (height - 5) - 3;
-    return { x, y };
-  });
-  const line = points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
-  const last = points[points.length - 1] ?? { x: width, y: height };
-  return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      fill="none"
-      aria-hidden="true"
-    >
-      {/* Soft area under the line so a sparse series still reads as a chart. */}
-      <polygon points={`0,${height} ${line} ${width},${height}`} fill={color} opacity={0.12} />
-      <polyline
-        points={line}
-        fill="none"
-        stroke={color}
-        strokeWidth={1.75}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        opacity={0.95}
-      />
-      <circle cx={last.x} cy={last.y} r={2.4} fill={color} />
-    </svg>
-  );
-}
-
-/**
- * Cycles slowly through supporters' public messages near the CTA, so the warmth
- * on the wall is visible without hunting for a bin to click. Holds still under
- * reduced motion.
- */
-function RotatingMessage({
-  items,
-  reducedMotion,
-  attribution,
-}: {
-  items: { message: string; name: string | null }[];
-  reducedMotion: boolean;
-  attribution: (name: string) => string;
-}) {
-  const [index, setIndex] = useState(0);
-  useEffect(() => {
-    if (reducedMotion || items.length <= 1) return;
-    const id = setInterval(() => setIndex((i) => (i + 1) % items.length), MESSAGE_ROTATE_MS);
-    return () => clearInterval(id);
-  }, [items.length, reducedMotion]);
-
-  if (items.length === 0) return null;
-  const item = items[index % items.length];
-  return (
-    <p key={index} className="max-w-md text-sm italic opacity-70 motion-safe:animate-fade-in">
-      <span>{item.message}</span>
-      {item.name && <span className="opacity-60"> {attribution(item.name)}</span>}
-    </p>
-  );
-}
 
 /**
  * Immersive standalone /supporters experience: an orbitable WebGL baseplate

--- a/src/features/supporters/components/SupportersPage/useCountUp.ts
+++ b/src/features/supporters/components/SupportersPage/useCountUp.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useCountUp(target: number, animate: boolean): number {
+  const [animated, setAnimated] = useState(0);
+  useEffect(() => {
+    if (!animate) return;
+    let raf = 0;
+    let startTs = 0;
+    const step = (ts: number) => {
+      if (!startTs) startTs = ts;
+      const t = Math.min((ts - startTs) / 1600, 1);
+      setAnimated(Math.round(target * (1 - Math.pow(1 - t, 3))));
+      if (t < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [target, animate]);
+  return animate ? animated : target;
+}

--- a/src/shell/layoutExport/layoutExportFiles.ts
+++ b/src/shell/layoutExport/layoutExportFiles.ts
@@ -1,0 +1,108 @@
+import type {
+  CombinedExportResult,
+  ExportFormat,
+  GenerationBridge,
+} from '@/shared/generation/bridge';
+import type { ZipBinaryFile } from '@/shared/generation/zipExport';
+import type { ExportFileFormat } from '@/shared/types/bin';
+import type { BinParams } from '@/features/bin-designer';
+import { withSocketNozzle } from '@/shared/generation/socketNozzle';
+// Deep imports (not the barrel): this code only runs inside the lazy
+// layout-export chunk, and the bin-designer barrel is eagerly loaded by App.
+import { buildBinDownloadPayload } from '@/features/bin-designer/utils/binDownloadHelpers';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { LayoutExportable, LayoutSplitPlan } from './planLayoutBinExport';
+
+export function baseNameOf(path: string): string {
+  return (path.split('/').pop() ?? path).replace(/\.[^.]+$/, '');
+}
+
+/**
+ * Flatten a combined export (body + lid + dividers) into ZIP files. STL emits a
+ * file per piece (`<base>.stl` for the body, `<base>_<part>.stl` for the rest);
+ * 3MF packs everything into one multi-object file and STEP into one compound —
+ * reusing the bin designer's packaging so colours/orientation match.
+ */
+/**
+ * Format a part file can take. A whole-layout 3MF export is a PROJECT file, so
+ * 3MF never reaches the per-part writers; naming that in the type keeps a dead
+ * per-part 3MF branch from creeping back in.
+ */
+type PartFileFormat = Exclude<ExportFileFormat, '3mf'>;
+
+export async function combinedFiles(
+  result: CombinedExportResult,
+  format: PartFileFormat,
+  basePath: string,
+  params: BinParams
+): Promise<ZipBinaryFile[]> {
+  if (format === 'stl') {
+    const baseNoExt = basePath.replace(/\.[^.]+$/, '');
+    return result.pieces.map((p) => ({
+      path: p.label === 'bin' ? `${baseNoExt}.stl` : `${baseNoExt}_${p.label}.stl`,
+      data: p.data,
+    }));
+  }
+
+  const { blob } = buildBinDownloadPayload(format, result, params, baseNameOf(basePath), null);
+  return [{ path: basePath, data: await blob.arrayBuffer() }];
+}
+
+/**
+ * Cut one oversized bin into bed-sized pieces and flatten them into ZIP files.
+ *
+ * Every piece becomes its own file — including under 3MF, unlike
+ * `combinedFiles`. The pieces are separate prints that get joined afterwards,
+ * so packing them into one multi-object 3MF would stack parts on the plate.
+ * Companion parts (lid, dividers) come from a second, combined pass because the
+ * split export emits body pieces only.
+ *
+ * Pieces go in their own `bins/<design>/` folder rather than sharing `bins/`
+ * with a `_<label>` suffix. Names are deduped before suffixes exist, so a flat
+ * `<base>_A1.stl` could collide with another design that generates exactly that
+ * name — and `packageFilesAsZip` keys by path, so the loser would vanish from
+ * the archive silently. A folder can't collide with a sibling file name, and it
+ * also groups the parts a user prints as one job.
+ */
+export async function splitFiles(
+  bridge: GenerationBridge,
+  exportable: LayoutExportable,
+  split: LayoutSplitPlan,
+  format: ExportFileFormat,
+  printSettings: { layerHeightMm: number; infillPercent: number; nozzleSizeMm: number },
+  workerFormat: ExportFormat
+): Promise<ZipBinaryFile[]> {
+  const params = withSocketNozzle(exportable.params, printSettings.nozzleSizeMm);
+  const connectorConfig = {
+    ...(exportable.params.splitConnectors ?? DEFAULT_SPLIT_CONNECTOR_CONFIG),
+    nozzleSizeMm: printSettings.nozzleSizeMm,
+  };
+  const result = await bridge.exportSplitBin(params, split.cutPlanesX, split.cutPlanesY, {
+    splitConnectorConfig: connectorConfig,
+    format: workerFormat,
+  });
+
+  const baseNoExt = exportable.path.replace(/\.[^.]+$/, '');
+  // Split and combined pieces carry different metadata (grid col/row vs none);
+  // packaging only needs the bytes and the label.
+  const pieces: { data: ArrayBuffer; label: string }[] = result.pieces.map((p) => ({
+    data: p.data,
+    label: p.label,
+  }));
+
+  if (exportable.companions.length > 0) {
+    // `separatePieces` matters under STEP: the default compound assembly
+    // bundles the bin in with its companions, and the body is already covered
+    // by the split pieces above.
+    const combined = await bridge.exportCombined(params, workerFormat, { separatePieces: true });
+    // The body is already covered by the split pieces — take only the extras.
+    for (const p of combined.pieces) {
+      if (p.label !== 'bin') pieces.push({ data: p.data, label: p.label });
+    }
+  }
+
+  return pieces.map((piece) => ({
+    path: `${baseNoExt}/${piece.label}.${format}`,
+    data: piece.data,
+  }));
+}

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -20,8 +20,7 @@ import { useTranslation } from '@/i18n';
 import { trackEvent, trackToolConverted } from '@/shared/analytics/posthog';
 import { getErrorMessage } from '@/shared/utils/errors';
 import { bridgeManager, workerPoolManager } from '@/shared/generation/bridge';
-import type { GenerationBridge } from '@/shared/generation/bridge';
-import type { ExportFormat, CombinedExportResult } from '@/shared/generation/bridge';
+import type { ExportFormat } from '@/shared/generation/bridge';
 import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 // Deep import (not the barrel): this code only runs inside the lazy
 // layout-export chunk (same rationale as planLabelPlateExport's deep imports).
@@ -40,19 +39,14 @@ import {
   BaseplateBedOverageError,
 } from '@/features/baseplate/utils/buildBaseplateExportPieces';
 import { loadDesign } from '@/features/bin-designer';
-import type { BinParams } from '@/features/bin-designer';
 // Deep import (not the barrel): the bin-designer barrel is eagerly loaded by App;
 // this packaging only runs inside the lazy layout-export chunk.
-import {
-  buildBinDownloadPayload,
-  buildMultiObject3MFObjects,
-} from '@/features/bin-designer/utils/binDownloadHelpers';
+import { buildMultiObject3MFObjects } from '@/features/bin-designer/utils/binDownloadHelpers';
 import { buildThreeMFPrintSettings } from '@/shared/generation/stlTo3mf';
 import { getLinkedDesignIds } from '@/features/design-linking';
 import { planLayoutBinExport } from './planLayoutBinExport';
-import type { LoadedDesign, LayoutExportable, LayoutSplitPlan } from './planLayoutBinExport';
+import type { LoadedDesign } from './planLayoutBinExport';
 // Deep import (not the barrel): same lazy-chunk rationale as the helpers above.
-import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
 import { planLabelPlateExport } from './planLabelPlateExport';
 import { dedupeFileNames } from './dedupeFileNames';
 import { snapTextDepthToLayers } from '@/shared/constants/labelPlates';
@@ -60,6 +54,7 @@ import type { LabelPlateExportSpec } from '@/shared/generation/bridge';
 import { buildLayoutManifest } from './buildLayoutManifest';
 import type { ManifestLabelGroup } from './buildLayoutManifest';
 import { buildLayoutProjectFile, createProjectPartCollector } from './buildProjectFile';
+import { baseNameOf, combinedFiles, splitFiles } from './layoutExportFiles';
 
 type Progress = { current: number; total: number; label?: string } | null;
 
@@ -72,100 +67,6 @@ interface UseLayoutExportReturn {
     zipBaseName: string,
     fileNameConfig: ExportFileNameConfig
   ) => Promise<boolean>;
-}
-
-function baseNameOf(path: string): string {
-  return (path.split('/').pop() ?? path).replace(/\.[^.]+$/, '');
-}
-
-/**
- * Flatten a combined export (body + lid + dividers) into ZIP files. STL emits a
- * file per piece (`<base>.stl` for the body, `<base>_<part>.stl` for the rest);
- * 3MF packs everything into one multi-object file and STEP into one compound —
- * reusing the bin designer's packaging so colours/orientation match.
- */
-/**
- * Format a part file can take. A whole-layout 3MF export is a PROJECT file, so
- * 3MF never reaches the per-part writers; naming that in the type keeps a dead
- * per-part 3MF branch from creeping back in.
- */
-type PartFileFormat = Exclude<ExportFileFormat, '3mf'>;
-
-async function combinedFiles(
-  result: CombinedExportResult,
-  format: PartFileFormat,
-  basePath: string,
-  params: BinParams
-): Promise<ZipBinaryFile[]> {
-  if (format === 'stl') {
-    const baseNoExt = basePath.replace(/\.[^.]+$/, '');
-    return result.pieces.map((p) => ({
-      path: p.label === 'bin' ? `${baseNoExt}.stl` : `${baseNoExt}_${p.label}.stl`,
-      data: p.data,
-    }));
-  }
-
-  const { blob } = buildBinDownloadPayload(format, result, params, baseNameOf(basePath), null);
-  return [{ path: basePath, data: await blob.arrayBuffer() }];
-}
-
-/**
- * Cut one oversized bin into bed-sized pieces and flatten them into ZIP files.
- *
- * Every piece becomes its own file — including under 3MF, unlike
- * `combinedFiles`. The pieces are separate prints that get joined afterwards,
- * so packing them into one multi-object 3MF would stack parts on the plate.
- * Companion parts (lid, dividers) come from a second, combined pass because the
- * split export emits body pieces only.
- *
- * Pieces go in their own `bins/<design>/` folder rather than sharing `bins/`
- * with a `_<label>` suffix. Names are deduped before suffixes exist, so a flat
- * `<base>_A1.stl` could collide with another design that generates exactly that
- * name — and `packageFilesAsZip` keys by path, so the loser would vanish from
- * the archive silently. A folder can't collide with a sibling file name, and it
- * also groups the parts a user prints as one job.
- */
-async function splitFiles(
-  bridge: GenerationBridge,
-  exportable: LayoutExportable,
-  split: LayoutSplitPlan,
-  format: ExportFileFormat,
-  printSettings: { layerHeightMm: number; infillPercent: number; nozzleSizeMm: number },
-  workerFormat: ExportFormat
-): Promise<ZipBinaryFile[]> {
-  const params = withSocketNozzle(exportable.params, printSettings.nozzleSizeMm);
-  const connectorConfig = {
-    ...(exportable.params.splitConnectors ?? DEFAULT_SPLIT_CONNECTOR_CONFIG),
-    nozzleSizeMm: printSettings.nozzleSizeMm,
-  };
-  const result = await bridge.exportSplitBin(params, split.cutPlanesX, split.cutPlanesY, {
-    splitConnectorConfig: connectorConfig,
-    format: workerFormat,
-  });
-
-  const baseNoExt = exportable.path.replace(/\.[^.]+$/, '');
-  // Split and combined pieces carry different metadata (grid col/row vs none);
-  // packaging only needs the bytes and the label.
-  const pieces: { data: ArrayBuffer; label: string }[] = result.pieces.map((p) => ({
-    data: p.data,
-    label: p.label,
-  }));
-
-  if (exportable.companions.length > 0) {
-    // `separatePieces` matters under STEP: the default compound assembly
-    // bundles the bin in with its companions, and the body is already covered
-    // by the split pieces above.
-    const combined = await bridge.exportCombined(params, workerFormat, { separatePieces: true });
-    // The body is already covered by the split pieces — take only the extras.
-    for (const p of combined.pieces) {
-      if (p.label !== 'bin') pieces.push({ data: p.data, label: p.label });
-    }
-  }
-
-  return pieces.map((piece) => ({
-    path: `${baseNoExt}/${piece.label}.${format}`,
-    data: piece.data,
-  }));
 }
 
 export function useLayoutExport(): UseLayoutExportReturn {


### PR DESCRIPTION
First batch of the `max-lines` backlog: the seven files nearest the 500-line limit that had a cohesive unit to lift out. Each extraction moves a group of declarations into a sibling module; the original file re-exports any public names, so no importer changes except one type import that now points at the new home. No behaviour changes.

| File | Was | Moved out | Now |
| --- | --- | --- | --- |
| `bin-designer/utils/binDownloadHelpers.ts` | 501 | `formatPieceDisplayName`, `buildReportIssueUrl` to `binDownloadNaming.ts` | ~400 |
| `community/store/browseStore.ts` | 501 | the filter model and pure matching/sorting (`BrowseFilters`, `FitsGapContext`, `INITIAL_BROWSE_FILTERS`, `filterAndSortCards`, `sameBrowseFilters`, and the helpers behind them) to `browseFilters.ts` | ~250 |
| `api/community/prints.ts` | 517 | `PrintResponse` and `toPrintResponse` to `api/lib/communityPrintResponse.ts` | ~470 |
| `community/api/client.ts` | 524 | the response type guards (`isCommunityDesign`, `isCommunityCard`, `isListPage`, `isCapabilities` and their helpers, plus `CommunityListPage` and `CommunityCapabilities`) to `clientGuards.ts` | ~390 |
| `shell/layoutExport/useLayoutExport.ts` | 535 | `combinedFiles`, `splitFiles`, `baseNameOf` to `layoutExportFiles.ts` | ~450 |
| `supporters/.../SupportersPage.tsx` | 523 | `useCountUp` to its own hook; `CtaBurst`, `Sparkline`, `RotatingMessage` to `SupportersFlourishes.tsx` | ~350 |
| `bin-designer/.../DividerTiltSubsection.tsx` | 517 | the list view and its row to `DividerTiltList.tsx` | ~420 |

Counts are the rule's own (blank lines and comments excluded).

`gapFit.ts` now imports `FitsGapContext` from `browseFilters`, which also removes the last runtime edge between the browse store and the gap-fit utility. The community print response module lives under `api/lib` rather than beside the handler, because every file under `api/community/` is deployed as a route.

The two new components (`SupportersFlourishes`, `DividerTiltList`) have sibling tests as the structure gate requires; the moved helpers stay covered by their original files' suites through the re-exports.

**Verification**

- Root and api typechecks, lint (including `max-lines` on all seven), module boundaries, design-system, component-structure and doc-drift gates pass.
- Vitest, unit and dom projects, over every touched folder: 110 files, 1548 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

