### PR TITLE
refactor: compose the assembly and cutout slices from smaller action factories

### DIFF
--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -13,15 +13,8 @@ import { SHARE_CONSTRAINTS } from './shareConstraints.js';
 import type { ValidExpiration, ValidationError } from './shareConstraints.js';
 export { SHARE_CONSTRAINTS } from './shareConstraints.js';
 export type { ValidExpiration, ValidationError } from './shareConstraints.js';
-export {
-  DESIGN_ID_MAX_LENGTH,
-  RESERVED_PROPERTY_KEYS,
-  validateSharedDesigns,
-  isSharedDesignsError,
-} from './sharedDesignsValidation.js';
+export { validateSharedDesigns, isSharedDesignsError } from './sharedDesignsValidation.js';
 export type { SharedDesignShape, SharedDesignsResult } from './sharedDesignsValidation.js';
-export { isValidDrawer, sanitizeDrawer } from './drawerValidation.js';
-export type { DrawerShape } from './drawerValidation.js';
 
 interface LayerShape {
   id: string;

--- a/src/features/bin-designer/store/slices/cutoutGroupActions.ts
+++ b/src/features/bin-designer/store/slices/cutoutGroupActions.ts
@@ -1,0 +1,286 @@
+/**
+ * Cutout group actions: form and dissolve boolean groups, move units between
+ * them, peel a group apart and edit a group's name or op. `set` is the
+ * slice's wrapped setter, so an emptied lid array still collapses to absent.
+ */
+
+import type { Cutout, GroupOp } from '../../types';
+import { DEFAULT_GROUP_OP, DEFAULT_CUTOUT_COLOR_SCOPE, MAX_GROUP_NAME_LENGTH } from '../../types';
+import {
+  adoptedGroupArray,
+  dissolveSingletonGroups,
+  pushHistoryEntry,
+  withCutoutArray,
+} from '../helpers';
+import { generateLayoutId } from '@/shared/utils/uuid';
+import {
+  canNestDeeper,
+  groupChain,
+  insertGroupAt,
+  isBooleanGroup,
+  maxChainLength,
+  parentGroups,
+  removeGroup,
+  sameChain,
+  unitTag,
+  unitTagGroupId,
+  unitTags,
+  withGroupChain,
+} from '../../utils/cutoutHierarchy';
+import { cutoutOwner, gcCutoutGroupNames, planUnitLandings } from './cutoutSliceHelpers';
+import type { Set } from './cutoutSliceHelpers';
+
+export function createCutoutGroupActions(set: Set) {
+  return {
+    groupCutouts: (cutoutIds: readonly string[], op?: GroupOp, context: readonly string[] = []) => {
+      if (cutoutIds.length < 2) return;
+      set((state) => {
+        const owner = cutoutOwner(state);
+        // Nothing may be created inside a boolean group. Its members are exactly
+        // what its op fuses, so a group formed among them would silently reduce
+        // that set — the one nesting move that could change existing geometry.
+        if (context.length > 0 && isBooleanGroup(owner.cutouts, context[context.length - 1])) {
+          return;
+        }
+        // Which things the selection reaches at this level. A group counts once
+        // however many of its members are selected, so "two shapes of one group"
+        // is one unit and correctly does nothing.
+        const units = unitTags(
+          owner.cutouts.filter((c) => cutoutIds.includes(c.id)),
+          context
+        );
+        if (units.size < 2) return;
+
+        // A selection reaching only loose shapes still forms a boolean group,
+        // exactly as it did before nesting existed — that is what keeps Ctrl+G
+        // then a Pathfinder op working. The moment it reaches a group, wrapping
+        // is the only thing that preserves what is already there, so an explicit
+        // op (a Pathfinder button) is the only way back to the flat behavior.
+        if (op === undefined && [...units].some((tag) => unitTagGroupId(tag) !== null)) {
+          const members = owner.cutouts.filter((c) => {
+            const tag = unitTag(c, context);
+            return tag !== null && units.has(tag);
+          });
+          if (!canNestDeeper(members)) return;
+          const containerId = generateLayoutId();
+          const memberIds = new Set(members.map((c) => c.id));
+          pushHistoryEntry(state, { affectsGeometry: false });
+          owner.cutouts = owner.cutouts.map((c) =>
+            memberIds.has(c.id) ? insertGroupAt(c, containerId, context.length) : c
+          );
+          return;
+        }
+        // Reuse an existing groupId if any selected cutout already belongs to a group
+        const existingMember = owner.cutouts.find(
+          (c) => cutoutIds.includes(c.id) && c.groupId !== null
+        );
+        const existingGroupId = existingMember?.groupId ?? null;
+        const groupId = existingGroupId ?? generateLayoutId();
+        // When extending an existing group and the caller didn't override the op,
+        // inherit the group's current op so silent regroups keep their semantics.
+        const groupOp: GroupOp = op ?? existingMember?.groupOp ?? DEFAULT_GROUP_OP;
+        const idsToGroup = new Set(cutoutIds);
+        if (existingGroupId) {
+          for (const c of owner.cutouts) {
+            if (c.groupId === existingGroupId) idsToGroup.add(c.id);
+          }
+        }
+        // One repeat per group, adopted the same way the color below is.
+        const sharedArray = adoptedGroupArray(owner.cutouts, idsToGroup, existingGroupId);
+        // One color per group: adopt the group's existing color, else the first
+        // colored member, so a freshly grouped set can't hold mixed backings.
+        const colorSource =
+          (existingGroupId
+            ? owner.cutouts.find((c) => c.groupId === existingGroupId && c.color !== undefined)
+            : undefined) ??
+          owner.cutouts.find((c) => idsToGroup.has(c.id) && c.color !== undefined);
+        const colorPatch: Pick<Cutout, 'color' | 'colorScope'> | undefined = colorSource
+          ? {
+              color: colorSource.color,
+              colorScope: colorSource.colorScope ?? DEFAULT_CUTOUT_COLOR_SCOPE,
+            }
+          : undefined;
+        // Where the boolean group sits in the tree. An EXISTING group's own
+        // position wins — folding shapes into it must move them to it, not drag
+        // it out to wherever the caller was looking from.
+        const destParents = existingMember ? parentGroups(existingMember) : context;
+        const destChain = [...destParents, groupId];
+        // Re-grouping a set that already forms this exact group changes nothing,
+        // and an unconditional history push would spend an undo slot on it —
+        // reachable from Ctrl+G on a partial selection of one group.
+        const noChange = owner.cutouts.every(
+          (c) =>
+            !idsToGroup.has(c.id) ||
+            (c.groupId === groupId &&
+              (c.groupOp ?? DEFAULT_GROUP_OP) === groupOp &&
+              c.array === sharedArray &&
+              sameChain(groupChain(c), destChain) &&
+              (!colorPatch ||
+                (c.color === colorPatch.color &&
+                  (c.colorScope ?? DEFAULT_CUTOUT_COLOR_SCOPE) === colorPatch.colorScope)))
+        );
+        if (noChange) return;
+
+        pushHistoryEntry(state);
+        owner.cutouts = owner.cutouts.map((c) =>
+          idsToGroup.has(c.id)
+            ? withCutoutArray(
+                withGroupChain({ ...c, groupId, groupOp, ...colorPatch }, destChain),
+                sharedArray
+              )
+            : c
+        );
+        gcCutoutGroupNames(state);
+      });
+    },
+
+    ungroupCutouts: (cutoutIds: readonly string[]) => {
+      set((state) => {
+        pushHistoryEntry(state);
+        const owner = cutoutOwner(state);
+        const ungrouped = owner.cutouts.map((c) => {
+          if (!cutoutIds.includes(c.id)) return c;
+          const { groupOp: _omit, ...rest } = c;
+          return { ...rest, groupId: null };
+        });
+        // A group can be left with a single member after a partial ungroup;
+        // dissolve that singleton so the Pathfinder UI doesn't pretend a lone
+        // cutout still belongs to an active group.
+        owner.cutouts = dissolveSingletonGroups(ungrouped);
+        gcCutoutGroupNames(state);
+      });
+    },
+
+    /**
+     * Move whole units — group rows and shape rows from the shape list — under
+     * `destGroupId`, or to the top level when it is null.
+     *
+     * Takes {@link unitTag}s rather than cutout ids because the ids alone are
+     * ambiguous: the members of a dragged group and three loose shapes that
+     * happen to share a parent look identical as a flat id list, yet one has to
+     * keep its own group on landing and the other must not gain one.
+     */
+    moveUnitsIntoGroup: (tags: readonly string[], destGroupId: string | null) => {
+      if (tags.length === 0) return;
+      set((state) => {
+        const owner = cutoutOwner(state);
+        const movingGroups = tags.map(unitTagGroupId).filter((id): id is string => id !== null);
+        // A shape landing directly in a boolean group joins its boolean; every
+        // other landing keeps whatever the cutout already was.
+        const joinsBoolean =
+          destGroupId !== null && isBooleanGroup(owner.cutouts, destGroupId) ? destGroupId : null;
+
+        // A boolean group's members are exactly what its op fuses, so admitting
+        // a subgroup would change what it carves without touching its own rows.
+        if (joinsBoolean !== null && movingGroups.length > 0) return;
+
+        let destChain: readonly string[] = [];
+        if (destGroupId !== null) {
+          const anchor = owner.cutouts.find((c) => groupChain(c).includes(destGroupId));
+          if (!anchor) return;
+          const anchorChain = groupChain(anchor);
+          destChain = anchorChain.slice(0, anchorChain.indexOf(destGroupId) + 1);
+        }
+        // Landing a group inside itself, or anywhere in its own subtree, would
+        // cut that branch loose.
+        if (movingGroups.some((g) => destChain.includes(g))) return;
+
+        const landings = planUnitLandings(owner.cutouts, tags, destChain);
+        if (landings.size === 0) return;
+        // Per landing, not one flat cap: a shape that lands loose stores its
+        // whole chain in `parentGroups`, which the schema caps one lower.
+        const overDepth = [...landings.values()].some(
+          (l) => l.chain.length > maxChainLength({ groupId: l.keepsGroup ? 'kept' : null })
+        );
+        if (overDepth) return;
+
+        const unchanged = owner.cutouts.every((c) => {
+          const next = landings.get(c.id);
+          return (
+            next === undefined ||
+            (sameChain(groupChain(c), next.chain) && next.keepsGroup === (c.groupId !== null))
+          );
+        });
+        if (unchanged) return;
+
+        pushHistoryEntry(state, { affectsGeometry: joinsBoolean !== null });
+        const destOp =
+          joinsBoolean === null
+            ? DEFAULT_GROUP_OP
+            : (owner.cutouts.find((c) => c.groupId === joinsBoolean)?.groupOp ?? DEFAULT_GROUP_OP);
+        owner.cutouts = dissolveSingletonGroups(
+          owner.cutouts.map((c) => {
+            const landing = landings.get(c.id);
+            if (landing === undefined) return c;
+            if (landing.keepsGroup) return withGroupChain(c, landing.chain, true);
+            // `destChain` already ends with the destination group, so a shape
+            // joining a boolean group takes that chain as-is — appending the id
+            // again would list it twice and make it its own ancestor.
+            if (joinsBoolean !== null) {
+              return withGroupChain(
+                { ...c, groupId: joinsBoolean, groupOp: destOp },
+                landing.chain,
+                true
+              );
+            }
+            // Leaving a boolean group takes its op along: a stale one on a now
+            // loose shape would be adopted by whatever group it joins next.
+            const { groupOp: _omit, ...bare } = c;
+            return withGroupChain(bare, landing.chain, false);
+          })
+        );
+        gcCutoutGroupNames(state);
+      });
+    },
+
+    peelGroup: (groupId: string) => {
+      set((state) => {
+        const owner = cutoutOwner(state);
+        if (!owner.cutouts.some((c) => groupChain(c).includes(groupId))) return;
+        // Dissolving a container rearranges nothing the generator reads, but
+        // dissolving a boolean group turns one fused cut tool back into several,
+        // so only the latter is a geometry change.
+        pushHistoryEntry(state, { affectsGeometry: isBooleanGroup(owner.cutouts, groupId) });
+        const peeled = owner.cutouts.map((c) => {
+          if (!groupChain(c).includes(groupId)) return c;
+          // `groupOp` describes membership of the group being dissolved, so it
+          // has to go with it — a stale op on a now-loose shape would be adopted
+          // by whatever group the shape joins next.
+          const next = removeGroup(c, groupId);
+          if (c.groupId !== groupId) return next;
+          const { groupOp: _omit, ...rest } = next;
+          return rest;
+        });
+        owner.cutouts = dissolveSingletonGroups(peeled);
+        gcCutoutGroupNames(state);
+      });
+    },
+
+    setCutoutGroupName: (groupId: string, name: string) => {
+      set((state) => {
+        const trimmed = name.trim().slice(0, MAX_GROUP_NAME_LENGTH);
+        const names = state.params.cutoutGroupNames ?? {};
+        if ((names[groupId] ?? '') === trimmed) return;
+        // Editor metadata only — a rename must never rebuild the mesh.
+        pushHistoryEntry(state, { affectsGeometry: false });
+        const next = Object.fromEntries(Object.entries(names).filter(([id]) => id !== groupId));
+        if (trimmed !== '') next[groupId] = trimmed;
+        state.params.cutoutGroupNames = Object.keys(next).length > 0 ? next : undefined;
+      });
+    },
+
+    setGroupOp: (groupId: string, op: GroupOp) => {
+      set((state) => {
+        const owner = cutoutOwner(state);
+        const hasMatchingGroup = owner.cutouts.some(
+          (c) => c.groupId === groupId && (c.groupOp ?? DEFAULT_GROUP_OP) !== op
+        );
+        if (!hasMatchingGroup) return;
+        pushHistoryEntry(state);
+        owner.cutouts = owner.cutouts.map((c) =>
+          c.groupId === groupId ? { ...c, groupOp: op } : c
+        );
+      });
+    },
+  };
+}

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -12,18 +12,11 @@ import type {
   Cutout,
   CutoutArrayConfig,
   CutoutColorScope,
-  CutoutTarget,
   CutoutToggleProperties,
   ReorderDirection,
-  PathPoint,
   GroupOp,
 } from '../../types';
-import {
-  DEFAULT_GROUP_OP,
-  DEFAULT_CUTOUT_COLOR_SCOPE,
-  MAX_GROUP_NAME_LENGTH,
-  MAX_LID_CUTOUTS,
-} from '../../types';
+import { DEFAULT_GROUP_OP, DEFAULT_CUTOUT_COLOR_SCOPE } from '../../types';
 import { canArray } from '@/shared/utils/cutoutArray';
 import { withTextFootprint } from '@/shared/utils/cutoutLabel';
 import type { MeshAsset } from '@/shared/generation/meshAsset';
@@ -36,261 +29,30 @@ import {
   withCutoutArray,
 } from '../helpers';
 import { generateLayoutId } from '@/shared/utils/uuid';
-import { scalePathPoints, translatePathPoints } from '../../utils/pathTransforms';
+import { translatePathPoints } from '../../utils/pathTransforms';
 import {
-  canNestDeeper,
   groupChain,
-  insertGroupAt,
-  isBooleanGroup,
-  maxChainLength,
   parentGroups,
-  referencedGroupIds,
   remapGroupChain,
-  removeGroup,
   sameChain,
-  unitTag,
-  unitTagGroupId,
-  unitTagShapeId,
-  unitTags,
   withGroupChain,
 } from '../../utils/cutoutHierarchy';
-
-/**
- * The cutout array every action in this slice reads and writes, chosen by
- * `ui.cutoutTarget`.
- *
- * Returns the OWNER of the array (`params` or `params.lid`) rather than the array
- * itself, so a caller can both read `owner.cutouts` and assign to it — an immer
- * draft property assignment either way. That is what lets one editor serve the
- * bin's interior and the lid's plate without a target argument threaded through
- * twenty action signatures, and it means an action added later is retargetable by
- * construction instead of by remembering to be.
- *
- * Pair it with {@link cutoutList} for guards that run BEFORE any write: this one
- * materializes `lid.cutouts`, and an action that bails early would otherwise
- * leave `[]` behind on a lid that has none — enough to shift the design's
- * `communityParamsFingerprint` for a no-op.
- */
-function cutoutList(state: Draft<DesignerState>): readonly Cutout[] {
-  if (state.ui.cutoutTarget !== 'lid') return state.params.cutouts;
-  return state.params.lid.cutouts ?? [];
-}
-
-function cutoutOwner(state: Draft<DesignerState>): { cutouts: Cutout[] } {
-  if (state.ui.cutoutTarget !== 'lid') return state.params;
-  const lid = state.params.lid;
-  // `lid.cutouts` is absent rather than empty on a design that has none, so the
-  // fingerprint of every design published before the feature is unchanged (see the
-  // field's note). Materializing it here — inside a producer, so it is a real draft
-  // mutation — is what lets the actions below read and write it unconditionally.
-  // It only ever runs when a cutout action fires against the lid, which means the
-  // user opened its editor.
-  lid.cutouts ??= [];
-  return lid as { cutouts: Cutout[] };
-}
-
-// Points are absolute, handles are relative — scale around the old origin
-// first so the bounds end up flush with the new x/y, then translate.
-function applyPathTransform(c: Cutout, updates: Partial<Cutout>): PathPoint[] | undefined {
-  if (!c.path || c.path.length === 0 || updates.path) return undefined;
-  const newX = updates.x ?? c.x;
-  const newY = updates.y ?? c.y;
-  const newW = updates.width ?? c.width;
-  const newD = updates.depth ?? c.depth;
-  const scaleX = c.width !== 0 ? newW / c.width : 1;
-  const scaleY = c.depth !== 0 ? newD / c.depth : 1;
-  const scaled = scaleX !== 1 || scaleY !== 1;
-  const dx = newX - c.x;
-  const dy = newY - c.y;
-  const translated = dx !== 0 || dy !== 0;
-  if (!scaled && !translated) return undefined;
-  const scaledPoints = scaled ? scalePathPoints(c.path, scaleX, scaleY, c.x, c.y) : c.path;
-  return translated ? translatePathPoints(scaledPoints, dx, dy) : [...scaledPoints];
-}
-
-// Expand a target id set to include every member of any group those ids touch,
-// so a per-group property (color) is written to the whole group at once.
-function expandIdsToGroups(
-  cutouts: readonly Cutout[],
-  ids: readonly string[]
-): ReadonlySet<string> {
-  const idSet = new Set(ids);
-  const groupIds = new Set<string>();
-  for (const c of cutouts) {
-    if (idSet.has(c.id) && c.groupId !== null) groupIds.add(c.groupId);
-  }
-  if (groupIds.size > 0) {
-    for (const c of cutouts) {
-      if (c.groupId !== null && groupIds.has(c.groupId)) idSet.add(c.id);
-    }
-  }
-  return idSet;
-}
-
-/**
- * Drop mesh assets no cutout references anymore. Runs after every deletion
- * path so a deleted mesh cutout doesn't strand its (100KB+) asset in the
- * design; undo restores both together because history snapshots full params.
- */
-function gcMeshAssets(state: Draft<DesignerState>): void {
-  const assets = state.params.meshAssets;
-  if (!assets) return;
-  // `state.params.cutouts`, deliberately NOT `cutoutOwner(state)`: mesh imprints
-  // exist only on the bin's interior array (an imprint is subtracted after
-  // tessellation, in the bin's mesh frame, so a lid can never hold one). Counting
-  // references through the retargeted array would find none while the lid is the
-  // target and drop every asset the BIN still uses.
-  const referenced = new Set(
-    state.params.cutouts.map((c) => c.meshId).filter((id): id is string => id !== undefined)
-  );
-  const kept = Object.entries(assets).filter(([id]) => referenced.has(id));
-  if (kept.length === Object.keys(assets).length) return;
-  state.params.meshAssets = kept.length > 0 ? Object.fromEntries(kept) : undefined;
-}
-
-/**
- * Drop names for groups the design no longer has. Runs after every path that
- * can empty or dissolve a group, so a deleted assembly doesn't leave its name
- * behind to be re-adopted by a later group that happens to reuse the id.
- *
- * Reads BOTH cutout arrays, unlike {@link gcMeshAssets}: one name map serves
- * the bin and its lid, so counting references through `cutoutOwner` alone would
- * drop every name the other array still uses.
- */
-function gcCutoutGroupNames(state: Draft<DesignerState>): void {
-  const names = state.params.cutoutGroupNames;
-  if (!names) return;
-  const referenced = referencedGroupIds(state.params.cutouts, state.params.lid.cutouts ?? []);
-  const kept = Object.entries(names).filter(([id]) => referenced.has(id));
-  if (kept.length === Object.keys(names).length) return;
-  state.params.cutoutGroupNames = kept.length > 0 ? Object.fromEntries(kept) : undefined;
-}
-
-/**
- * How many more cutouts a target will accept.
- *
- * Only the LID is capped: `MAX_LID_CUTOUTS` bounds the boolean work against a
- * single plate, where nothing else does (the bin's array is bounded in practice
- * by the cavity a shape has to fit in). The client refuses past it rather than
- * letting the write through, because the server rejects an oversized payload and
- * `migrateLidCutouts` truncates one on load — so without this an honest design
- * would be silently cut down somewhere the user never sees (CLAUDE.md gotcha
- * #13b: a server cap that rejects needs a client cap that refuses).
- *
- * Exported because a batch has to size its work BEFORE it starts. `addCutout`
- * refusing one at a time is enough to hold the cap, but not enough for a
- * flatten, whose first step destroys the master's repeat config: it needs to
- * know it can finish before it begins. One definition rather than a copy in the
- * UI, since a cap and a second reading of it are exactly what drift apart.
- */
-export function remainingCutoutCapacity(
-  target: CutoutTarget,
-  lidCutouts: readonly Cutout[] | undefined
-): number {
-  if (target !== 'lid') return Infinity;
-  return Math.max(0, MAX_LID_CUTOUTS - (lidCutouts?.length ?? 0));
-}
-
-function remainingCapacity(state: Draft<DesignerState>): number {
-  return remainingCutoutCapacity(state.ui.cutoutTarget, state.params.lid.cutouts);
-}
-
-type Set = (fn: (state: Draft<DesignerState>) => void) => void;
-
-/**
- * Whether a toggle-property edit changes the generated part.
- *
- * Only `hidden` does: the worker drops hidden cutouts (`cutoutBuilder.ts`), so
- * toggling it changes the geometry. `locked` is editor state the worker
- * never reads.
- */
-function togglePropertyAffectsGeometry(partial: CutoutToggleProperties): boolean {
-  return partial.hidden !== undefined;
-}
-
-/**
- * Whether a z-order change reaches the geometry.
- *
- * `zIndex`'s only geometry consumer is boolean-op ordering inside a group
- * (`cutoutGroupOps.ts`), so a design with nothing grouped can reorder purely
- * visually and skip the worker.
- */
-function zOrderAffectsGeometry(state: Draft<DesignerState>): boolean {
-  return cutoutOwner(state).cutouts.some((c) => c.groupId !== null);
-}
-
-/**
- * Put a new cutout on its own layer at the top of the stack.
- *
- * Two purposes: a freshly drawn shape should land on top, and giving every
- * cutout a distinct `zIndex` keeps the renderer's stacking key strict. Two
- * shapes sharing a layer AND an area would otherwise have identical scene Z and
- * `renderOrder`, leaving the tie to be broken by raycast traversal order on one
- * side and object id on the other — which can disagree.
- *
- * An explicit `zIndex` on the incoming cutout is honoured (paste/duplicate
- * carry their own ordering).
- */
-function withTopZIndex(state: Draft<DesignerState>, cutout: Cutout): Cutout {
-  if (cutout.zIndex !== undefined) return cutout;
-  return { ...cutout, zIndex: nextTopZIndexIn(cutoutList(state)) };
-}
-
-/**
- * One past the highest occupied layer in `list`.
- *
- * Takes the list rather than the state so a caller writing to a specific array
- * ranks against THAT array. `addMeshCutout` is the one that needs it: its write
- * target is pinned to the bin, so ranking against the retargeted list would stamp
- * an imprint with the lid's next index — `0` on a lid with no cutouts, colliding
- * with every bin cutout at the default layer, which is the exact tie this helper
- * exists to prevent.
- */
-function nextTopZIndexIn(list: readonly Cutout[]): number {
-  return list.reduce((m, c) => Math.max(m, c.zIndex ?? 0), -1) + 1;
-}
-
-/** Where one moving cutout lands: its new ancestry, and whether it keeps its own group. */
-interface UnitLanding {
-  readonly chain: readonly string[];
-  readonly keepsGroup: boolean;
-}
-
-/**
- * Resolve dragged {@link unitTag}s into a per-cutout landing.
- *
- * A dragged GROUP arrives intact, so its members keep everything from that
- * group down. A dragged SHAPE row is one shape: it lands as a direct child and
- * leaves whatever boolean group it was in — which is reachable by dragging a
- * member out while drilled into its group.
- */
-function planUnitLandings(
-  cutouts: readonly Cutout[],
-  tags: readonly string[],
-  destChain: readonly string[]
-): Map<string, UnitLanding> {
-  const landings = new Map<string, UnitLanding>();
-  for (const tag of tags) {
-    const groupId = unitTagGroupId(tag);
-    if (groupId === null) {
-      const id = unitTagShapeId(tag);
-      if (id !== null && cutouts.some((c) => c.id === id)) {
-        landings.set(id, { chain: destChain, keepsGroup: false });
-      }
-      continue;
-    }
-    for (const member of cutouts) {
-      const chain = groupChain(member);
-      const at = chain.indexOf(groupId);
-      if (at === -1) continue;
-      landings.set(member.id, {
-        chain: [...destChain, ...chain.slice(at)],
-        keepsGroup: member.groupId !== null,
-      });
-    }
-  }
-  return landings;
-}
+import {
+  cutoutList,
+  cutoutOwner,
+  applyPathTransform,
+  expandIdsToGroups,
+  gcMeshAssets,
+  gcCutoutGroupNames,
+  remainingCapacity,
+  togglePropertyAffectsGeometry,
+  zOrderAffectsGeometry,
+  withTopZIndex,
+  nextTopZIndexIn,
+} from './cutoutSliceHelpers';
+import type { Set } from './cutoutSliceHelpers';
+import { createCutoutGroupActions } from './cutoutGroupActions';
+export { remainingCutoutCapacity } from './cutoutSliceHelpers';
 
 export function createCutoutSlice(rawSet: Set) {
   /**
@@ -752,257 +514,6 @@ export function createCutoutSlice(rawSet: Set) {
       });
     },
 
-    groupCutouts: (cutoutIds: readonly string[], op?: GroupOp, context: readonly string[] = []) => {
-      if (cutoutIds.length < 2) return;
-      set((state) => {
-        const owner = cutoutOwner(state);
-        // Nothing may be created inside a boolean group. Its members are exactly
-        // what its op fuses, so a group formed among them would silently reduce
-        // that set — the one nesting move that could change existing geometry.
-        if (context.length > 0 && isBooleanGroup(owner.cutouts, context[context.length - 1])) {
-          return;
-        }
-        // Which things the selection reaches at this level. A group counts once
-        // however many of its members are selected, so "two shapes of one group"
-        // is one unit and correctly does nothing.
-        const units = unitTags(
-          owner.cutouts.filter((c) => cutoutIds.includes(c.id)),
-          context
-        );
-        if (units.size < 2) return;
-
-        // A selection reaching only loose shapes still forms a boolean group,
-        // exactly as it did before nesting existed — that is what keeps Ctrl+G
-        // then a Pathfinder op working. The moment it reaches a group, wrapping
-        // is the only thing that preserves what is already there, so an explicit
-        // op (a Pathfinder button) is the only way back to the flat behavior.
-        if (op === undefined && [...units].some((tag) => unitTagGroupId(tag) !== null)) {
-          const members = owner.cutouts.filter((c) => {
-            const tag = unitTag(c, context);
-            return tag !== null && units.has(tag);
-          });
-          if (!canNestDeeper(members)) return;
-          const containerId = generateLayoutId();
-          const memberIds = new Set(members.map((c) => c.id));
-          pushHistoryEntry(state, { affectsGeometry: false });
-          owner.cutouts = owner.cutouts.map((c) =>
-            memberIds.has(c.id) ? insertGroupAt(c, containerId, context.length) : c
-          );
-          return;
-        }
-        // Reuse an existing groupId if any selected cutout already belongs to a group
-        const existingMember = owner.cutouts.find(
-          (c) => cutoutIds.includes(c.id) && c.groupId !== null
-        );
-        const existingGroupId = existingMember?.groupId ?? null;
-        const groupId = existingGroupId ?? generateLayoutId();
-        // When extending an existing group and the caller didn't override the op,
-        // inherit the group's current op so silent regroups keep their semantics.
-        const groupOp: GroupOp = op ?? existingMember?.groupOp ?? DEFAULT_GROUP_OP;
-        const idsToGroup = new Set(cutoutIds);
-        if (existingGroupId) {
-          for (const c of owner.cutouts) {
-            if (c.groupId === existingGroupId) idsToGroup.add(c.id);
-          }
-        }
-        // One repeat per group, adopted the same way the color below is.
-        const sharedArray = adoptedGroupArray(owner.cutouts, idsToGroup, existingGroupId);
-        // One color per group: adopt the group's existing color, else the first
-        // colored member, so a freshly grouped set can't hold mixed backings.
-        const colorSource =
-          (existingGroupId
-            ? owner.cutouts.find((c) => c.groupId === existingGroupId && c.color !== undefined)
-            : undefined) ??
-          owner.cutouts.find((c) => idsToGroup.has(c.id) && c.color !== undefined);
-        const colorPatch: Pick<Cutout, 'color' | 'colorScope'> | undefined = colorSource
-          ? {
-              color: colorSource.color,
-              colorScope: colorSource.colorScope ?? DEFAULT_CUTOUT_COLOR_SCOPE,
-            }
-          : undefined;
-        // Where the boolean group sits in the tree. An EXISTING group's own
-        // position wins — folding shapes into it must move them to it, not drag
-        // it out to wherever the caller was looking from.
-        const destParents = existingMember ? parentGroups(existingMember) : context;
-        const destChain = [...destParents, groupId];
-        // Re-grouping a set that already forms this exact group changes nothing,
-        // and an unconditional history push would spend an undo slot on it —
-        // reachable from Ctrl+G on a partial selection of one group.
-        const noChange = owner.cutouts.every(
-          (c) =>
-            !idsToGroup.has(c.id) ||
-            (c.groupId === groupId &&
-              (c.groupOp ?? DEFAULT_GROUP_OP) === groupOp &&
-              c.array === sharedArray &&
-              sameChain(groupChain(c), destChain) &&
-              (!colorPatch ||
-                (c.color === colorPatch.color &&
-                  (c.colorScope ?? DEFAULT_CUTOUT_COLOR_SCOPE) === colorPatch.colorScope)))
-        );
-        if (noChange) return;
-
-        pushHistoryEntry(state);
-        owner.cutouts = owner.cutouts.map((c) =>
-          idsToGroup.has(c.id)
-            ? withCutoutArray(
-                withGroupChain({ ...c, groupId, groupOp, ...colorPatch }, destChain),
-                sharedArray
-              )
-            : c
-        );
-        gcCutoutGroupNames(state);
-      });
-    },
-
-    ungroupCutouts: (cutoutIds: readonly string[]) => {
-      set((state) => {
-        pushHistoryEntry(state);
-        const owner = cutoutOwner(state);
-        const ungrouped = owner.cutouts.map((c) => {
-          if (!cutoutIds.includes(c.id)) return c;
-          const { groupOp: _omit, ...rest } = c;
-          return { ...rest, groupId: null };
-        });
-        // A group can be left with a single member after a partial ungroup;
-        // dissolve that singleton so the Pathfinder UI doesn't pretend a lone
-        // cutout still belongs to an active group.
-        owner.cutouts = dissolveSingletonGroups(ungrouped);
-        gcCutoutGroupNames(state);
-      });
-    },
-
-    /**
-     * Move whole units — group rows and shape rows from the shape list — under
-     * `destGroupId`, or to the top level when it is null.
-     *
-     * Takes {@link unitTag}s rather than cutout ids because the ids alone are
-     * ambiguous: the members of a dragged group and three loose shapes that
-     * happen to share a parent look identical as a flat id list, yet one has to
-     * keep its own group on landing and the other must not gain one.
-     */
-    moveUnitsIntoGroup: (tags: readonly string[], destGroupId: string | null) => {
-      if (tags.length === 0) return;
-      set((state) => {
-        const owner = cutoutOwner(state);
-        const movingGroups = tags.map(unitTagGroupId).filter((id): id is string => id !== null);
-        // A shape landing directly in a boolean group joins its boolean; every
-        // other landing keeps whatever the cutout already was.
-        const joinsBoolean =
-          destGroupId !== null && isBooleanGroup(owner.cutouts, destGroupId) ? destGroupId : null;
-
-        // A boolean group's members are exactly what its op fuses, so admitting
-        // a subgroup would change what it carves without touching its own rows.
-        if (joinsBoolean !== null && movingGroups.length > 0) return;
-
-        let destChain: readonly string[] = [];
-        if (destGroupId !== null) {
-          const anchor = owner.cutouts.find((c) => groupChain(c).includes(destGroupId));
-          if (!anchor) return;
-          const anchorChain = groupChain(anchor);
-          destChain = anchorChain.slice(0, anchorChain.indexOf(destGroupId) + 1);
-        }
-        // Landing a group inside itself, or anywhere in its own subtree, would
-        // cut that branch loose.
-        if (movingGroups.some((g) => destChain.includes(g))) return;
-
-        const landings = planUnitLandings(owner.cutouts, tags, destChain);
-        if (landings.size === 0) return;
-        // Per landing, not one flat cap: a shape that lands loose stores its
-        // whole chain in `parentGroups`, which the schema caps one lower.
-        const overDepth = [...landings.values()].some(
-          (l) => l.chain.length > maxChainLength({ groupId: l.keepsGroup ? 'kept' : null })
-        );
-        if (overDepth) return;
-
-        const unchanged = owner.cutouts.every((c) => {
-          const next = landings.get(c.id);
-          return (
-            next === undefined ||
-            (sameChain(groupChain(c), next.chain) && next.keepsGroup === (c.groupId !== null))
-          );
-        });
-        if (unchanged) return;
-
-        pushHistoryEntry(state, { affectsGeometry: joinsBoolean !== null });
-        const destOp =
-          joinsBoolean === null
-            ? DEFAULT_GROUP_OP
-            : (owner.cutouts.find((c) => c.groupId === joinsBoolean)?.groupOp ?? DEFAULT_GROUP_OP);
-        owner.cutouts = dissolveSingletonGroups(
-          owner.cutouts.map((c) => {
-            const landing = landings.get(c.id);
-            if (landing === undefined) return c;
-            if (landing.keepsGroup) return withGroupChain(c, landing.chain, true);
-            // `destChain` already ends with the destination group, so a shape
-            // joining a boolean group takes that chain as-is — appending the id
-            // again would list it twice and make it its own ancestor.
-            if (joinsBoolean !== null) {
-              return withGroupChain(
-                { ...c, groupId: joinsBoolean, groupOp: destOp },
-                landing.chain,
-                true
-              );
-            }
-            // Leaving a boolean group takes its op along: a stale one on a now
-            // loose shape would be adopted by whatever group it joins next.
-            const { groupOp: _omit, ...bare } = c;
-            return withGroupChain(bare, landing.chain, false);
-          })
-        );
-        gcCutoutGroupNames(state);
-      });
-    },
-
-    peelGroup: (groupId: string) => {
-      set((state) => {
-        const owner = cutoutOwner(state);
-        if (!owner.cutouts.some((c) => groupChain(c).includes(groupId))) return;
-        // Dissolving a container rearranges nothing the generator reads, but
-        // dissolving a boolean group turns one fused cut tool back into several,
-        // so only the latter is a geometry change.
-        pushHistoryEntry(state, { affectsGeometry: isBooleanGroup(owner.cutouts, groupId) });
-        const peeled = owner.cutouts.map((c) => {
-          if (!groupChain(c).includes(groupId)) return c;
-          // `groupOp` describes membership of the group being dissolved, so it
-          // has to go with it — a stale op on a now-loose shape would be adopted
-          // by whatever group the shape joins next.
-          const next = removeGroup(c, groupId);
-          if (c.groupId !== groupId) return next;
-          const { groupOp: _omit, ...rest } = next;
-          return rest;
-        });
-        owner.cutouts = dissolveSingletonGroups(peeled);
-        gcCutoutGroupNames(state);
-      });
-    },
-
-    setCutoutGroupName: (groupId: string, name: string) => {
-      set((state) => {
-        const trimmed = name.trim().slice(0, MAX_GROUP_NAME_LENGTH);
-        const names = state.params.cutoutGroupNames ?? {};
-        if ((names[groupId] ?? '') === trimmed) return;
-        // Editor metadata only — a rename must never rebuild the mesh.
-        pushHistoryEntry(state, { affectsGeometry: false });
-        const next = Object.fromEntries(Object.entries(names).filter(([id]) => id !== groupId));
-        if (trimmed !== '') next[groupId] = trimmed;
-        state.params.cutoutGroupNames = Object.keys(next).length > 0 ? next : undefined;
-      });
-    },
-
-    setGroupOp: (groupId: string, op: GroupOp) => {
-      set((state) => {
-        const owner = cutoutOwner(state);
-        const hasMatchingGroup = owner.cutouts.some(
-          (c) => c.groupId === groupId && (c.groupOp ?? DEFAULT_GROUP_OP) !== op
-        );
-        if (!hasMatchingGroup) return;
-        pushHistoryEntry(state);
-        owner.cutouts = owner.cutouts.map((c) =>
-          c.groupId === groupId ? { ...c, groupOp: op } : c
-        );
-      });
-    },
-
     setCutoutArray: (
       cutoutId: string,
       config: CutoutArrayConfig | undefined,
@@ -1091,5 +602,6 @@ export function createCutoutSlice(rawSet: Set) {
       // the guards above declined.
       return merged;
     },
+    ...createCutoutGroupActions(set),
   };
 }

--- a/src/features/bin-designer/store/slices/cutoutSliceHelpers.ts
+++ b/src/features/bin-designer/store/slices/cutoutSliceHelpers.ts
@@ -1,0 +1,258 @@
+/**
+ * Pure helpers behind the cutout slice: owner lookup, group expansion, asset
+ * and group-name garbage collection, z-order and unit-landing planning.
+ */
+
+import type { Draft } from 'immer';
+import type {
+  DesignerState,
+  Cutout,
+  CutoutTarget,
+  CutoutToggleProperties,
+  PathPoint,
+} from '../../types';
+import { MAX_LID_CUTOUTS } from '../../types';
+import { scalePathPoints, translatePathPoints } from '../../utils/pathTransforms';
+import {
+  groupChain,
+  referencedGroupIds,
+  unitTagGroupId,
+  unitTagShapeId,
+} from '../../utils/cutoutHierarchy';
+
+/**
+ * The cutout array every action in this slice reads and writes, chosen by
+ * `ui.cutoutTarget`.
+ *
+ * Returns the OWNER of the array (`params` or `params.lid`) rather than the array
+ * itself, so a caller can both read `owner.cutouts` and assign to it — an immer
+ * draft property assignment either way. That is what lets one editor serve the
+ * bin's interior and the lid's plate without a target argument threaded through
+ * twenty action signatures, and it means an action added later is retargetable by
+ * construction instead of by remembering to be.
+ *
+ * Pair it with {@link cutoutList} for guards that run BEFORE any write: this one
+ * materializes `lid.cutouts`, and an action that bails early would otherwise
+ * leave `[]` behind on a lid that has none — enough to shift the design's
+ * `communityParamsFingerprint` for a no-op.
+ */
+export function cutoutList(state: Draft<DesignerState>): readonly Cutout[] {
+  if (state.ui.cutoutTarget !== 'lid') return state.params.cutouts;
+  return state.params.lid.cutouts ?? [];
+}
+
+export function cutoutOwner(state: Draft<DesignerState>): { cutouts: Cutout[] } {
+  if (state.ui.cutoutTarget !== 'lid') return state.params;
+  const lid = state.params.lid;
+  // `lid.cutouts` is absent rather than empty on a design that has none, so the
+  // fingerprint of every design published before the feature is unchanged (see the
+  // field's note). Materializing it here — inside a producer, so it is a real draft
+  // mutation — is what lets the actions below read and write it unconditionally.
+  // It only ever runs when a cutout action fires against the lid, which means the
+  // user opened its editor.
+  lid.cutouts ??= [];
+  return lid as { cutouts: Cutout[] };
+}
+
+// Points are absolute, handles are relative — scale around the old origin
+// first so the bounds end up flush with the new x/y, then translate.
+export function applyPathTransform(c: Cutout, updates: Partial<Cutout>): PathPoint[] | undefined {
+  if (!c.path || c.path.length === 0 || updates.path) return undefined;
+  const newX = updates.x ?? c.x;
+  const newY = updates.y ?? c.y;
+  const newW = updates.width ?? c.width;
+  const newD = updates.depth ?? c.depth;
+  const scaleX = c.width !== 0 ? newW / c.width : 1;
+  const scaleY = c.depth !== 0 ? newD / c.depth : 1;
+  const scaled = scaleX !== 1 || scaleY !== 1;
+  const dx = newX - c.x;
+  const dy = newY - c.y;
+  const translated = dx !== 0 || dy !== 0;
+  if (!scaled && !translated) return undefined;
+  const scaledPoints = scaled ? scalePathPoints(c.path, scaleX, scaleY, c.x, c.y) : c.path;
+  return translated ? translatePathPoints(scaledPoints, dx, dy) : [...scaledPoints];
+}
+
+// Expand a target id set to include every member of any group those ids touch,
+// so a per-group property (color) is written to the whole group at once.
+export function expandIdsToGroups(
+  cutouts: readonly Cutout[],
+  ids: readonly string[]
+): ReadonlySet<string> {
+  const idSet = new Set(ids);
+  const groupIds = new Set<string>();
+  for (const c of cutouts) {
+    if (idSet.has(c.id) && c.groupId !== null) groupIds.add(c.groupId);
+  }
+  if (groupIds.size > 0) {
+    for (const c of cutouts) {
+      if (c.groupId !== null && groupIds.has(c.groupId)) idSet.add(c.id);
+    }
+  }
+  return idSet;
+}
+
+/**
+ * Drop mesh assets no cutout references anymore. Runs after every deletion
+ * path so a deleted mesh cutout doesn't strand its (100KB+) asset in the
+ * design; undo restores both together because history snapshots full params.
+ */
+export function gcMeshAssets(state: Draft<DesignerState>): void {
+  const assets = state.params.meshAssets;
+  if (!assets) return;
+  // `state.params.cutouts`, deliberately NOT `cutoutOwner(state)`: mesh imprints
+  // exist only on the bin's interior array (an imprint is subtracted after
+  // tessellation, in the bin's mesh frame, so a lid can never hold one). Counting
+  // references through the retargeted array would find none while the lid is the
+  // target and drop every asset the BIN still uses.
+  const referenced = new Set(
+    state.params.cutouts.map((c) => c.meshId).filter((id): id is string => id !== undefined)
+  );
+  const kept = Object.entries(assets).filter(([id]) => referenced.has(id));
+  if (kept.length === Object.keys(assets).length) return;
+  state.params.meshAssets = kept.length > 0 ? Object.fromEntries(kept) : undefined;
+}
+
+/**
+ * Drop names for groups the design no longer has. Runs after every path that
+ * can empty or dissolve a group, so a deleted assembly doesn't leave its name
+ * behind to be re-adopted by a later group that happens to reuse the id.
+ *
+ * Reads BOTH cutout arrays, unlike {@link gcMeshAssets}: one name map serves
+ * the bin and its lid, so counting references through `cutoutOwner` alone would
+ * drop every name the other array still uses.
+ */
+export function gcCutoutGroupNames(state: Draft<DesignerState>): void {
+  const names = state.params.cutoutGroupNames;
+  if (!names) return;
+  const referenced = referencedGroupIds(state.params.cutouts, state.params.lid.cutouts ?? []);
+  const kept = Object.entries(names).filter(([id]) => referenced.has(id));
+  if (kept.length === Object.keys(names).length) return;
+  state.params.cutoutGroupNames = kept.length > 0 ? Object.fromEntries(kept) : undefined;
+}
+
+/**
+ * How many more cutouts a target will accept.
+ *
+ * Only the LID is capped: `MAX_LID_CUTOUTS` bounds the boolean work against a
+ * single plate, where nothing else does (the bin's array is bounded in practice
+ * by the cavity a shape has to fit in). The client refuses past it rather than
+ * letting the write through, because the server rejects an oversized payload and
+ * `migrateLidCutouts` truncates one on load — so without this an honest design
+ * would be silently cut down somewhere the user never sees (CLAUDE.md gotcha
+ * #13b: a server cap that rejects needs a client cap that refuses).
+ *
+ * Exported because a batch has to size its work BEFORE it starts. `addCutout`
+ * refusing one at a time is enough to hold the cap, but not enough for a
+ * flatten, whose first step destroys the master's repeat config: it needs to
+ * know it can finish before it begins. One definition rather than a copy in the
+ * UI, since a cap and a second reading of it are exactly what drift apart.
+ */
+export function remainingCutoutCapacity(
+  target: CutoutTarget,
+  lidCutouts: readonly Cutout[] | undefined
+): number {
+  if (target !== 'lid') return Infinity;
+  return Math.max(0, MAX_LID_CUTOUTS - (lidCutouts?.length ?? 0));
+}
+
+export function remainingCapacity(state: Draft<DesignerState>): number {
+  return remainingCutoutCapacity(state.ui.cutoutTarget, state.params.lid.cutouts);
+}
+
+export type Set = (fn: (state: Draft<DesignerState>) => void) => void;
+
+/**
+ * Whether a toggle-property edit changes the generated part.
+ *
+ * Only `hidden` does: the worker drops hidden cutouts (`cutoutBuilder.ts`), so
+ * toggling it changes the geometry. `locked` is editor state the worker
+ * never reads.
+ */
+export function togglePropertyAffectsGeometry(partial: CutoutToggleProperties): boolean {
+  return partial.hidden !== undefined;
+}
+
+/**
+ * Whether a z-order change reaches the geometry.
+ *
+ * `zIndex`'s only geometry consumer is boolean-op ordering inside a group
+ * (`cutoutGroupOps.ts`), so a design with nothing grouped can reorder purely
+ * visually and skip the worker.
+ */
+export function zOrderAffectsGeometry(state: Draft<DesignerState>): boolean {
+  return cutoutOwner(state).cutouts.some((c) => c.groupId !== null);
+}
+
+/**
+ * Put a new cutout on its own layer at the top of the stack.
+ *
+ * Two purposes: a freshly drawn shape should land on top, and giving every
+ * cutout a distinct `zIndex` keeps the renderer's stacking key strict. Two
+ * shapes sharing a layer AND an area would otherwise have identical scene Z and
+ * `renderOrder`, leaving the tie to be broken by raycast traversal order on one
+ * side and object id on the other — which can disagree.
+ *
+ * An explicit `zIndex` on the incoming cutout is honoured (paste/duplicate
+ * carry their own ordering).
+ */
+export function withTopZIndex(state: Draft<DesignerState>, cutout: Cutout): Cutout {
+  if (cutout.zIndex !== undefined) return cutout;
+  return { ...cutout, zIndex: nextTopZIndexIn(cutoutList(state)) };
+}
+
+/**
+ * One past the highest occupied layer in `list`.
+ *
+ * Takes the list rather than the state so a caller writing to a specific array
+ * ranks against THAT array. `addMeshCutout` is the one that needs it: its write
+ * target is pinned to the bin, so ranking against the retargeted list would stamp
+ * an imprint with the lid's next index — `0` on a lid with no cutouts, colliding
+ * with every bin cutout at the default layer, which is the exact tie this helper
+ * exists to prevent.
+ */
+export function nextTopZIndexIn(list: readonly Cutout[]): number {
+  return list.reduce((m, c) => Math.max(m, c.zIndex ?? 0), -1) + 1;
+}
+
+/** Where one moving cutout lands: its new ancestry, and whether it keeps its own group. */
+interface UnitLanding {
+  readonly chain: readonly string[];
+  readonly keepsGroup: boolean;
+}
+
+/**
+ * Resolve dragged {@link unitTag}s into a per-cutout landing.
+ *
+ * A dragged GROUP arrives intact, so its members keep everything from that
+ * group down. A dragged SHAPE row is one shape: it lands as a direct child and
+ * leaves whatever boolean group it was in — which is reachable by dragging a
+ * member out while drilled into its group.
+ */
+export function planUnitLandings(
+  cutouts: readonly Cutout[],
+  tags: readonly string[],
+  destChain: readonly string[]
+): Map<string, UnitLanding> {
+  const landings = new Map<string, UnitLanding>();
+  for (const tag of tags) {
+    const groupId = unitTagGroupId(tag);
+    if (groupId === null) {
+      const id = unitTagShapeId(tag);
+      if (id !== null && cutouts.some((c) => c.id === id)) {
+        landings.set(id, { chain: destChain, keepsGroup: false });
+      }
+      continue;
+    }
+    for (const member of cutouts) {
+      const chain = groupChain(member);
+      const at = chain.indexOf(groupId);
+      if (at === -1) continue;
+      landings.set(member.id, {
+        chain: [...destChain, ...chain.slice(at)],
+        keepsGroup: member.groupId !== null,
+      });
+    }
+  }
+  return landings;
+}

--- a/src/features/bin-designer/store/slices/paramSlice/assemblyActionContext.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/assemblyActionContext.ts
@@ -1,0 +1,109 @@
+/**
+ * Closures every assembly action shares: the current part list, the one-entry
+ * commit, world placements by select id and the world-to-parent-local
+ * conversion the batch moves are built on.
+ */
+import { clampPartTransform } from '@/shared/items/assembly/descriptor';
+import type { AssemblyPartNode, PartTransform } from '@/shared/types/assembly';
+import { resolvePlacedParts, rotate2d, type PlacedPart } from '@/shared/types/assemblyPlacement';
+import {
+  findAssemblyPart,
+  withAssemblyPartUpdated,
+} from '@/features/bin-designer/utils/assemblyTree';
+import { pushHistoryEntry } from '@/features/bin-designer/store/helpers';
+import type { Set, Get } from './types';
+
+export function transformsEqual(a: PartTransform, b: PartTransform): boolean {
+  return a.x === b.x && a.y === b.y && a.seatZ === b.seatZ && a.rotZDeg === b.rotZDeg;
+}
+
+export function normalizeDeg(deg: number): number {
+  const wrapped = (((deg % 360) + 540) % 360) - 180;
+  return wrapped === -180 ? 180 : wrapped;
+}
+
+export const PASTE_OFFSET_MM = 8;
+
+export type AssemblyActionContext = ReturnType<typeof createAssemblyActionContext>;
+
+export function createAssemblyActionContext(set: Set, get: Get) {
+  const parts = (): AssemblyPartNode[] | null => {
+    const structure = get().structure;
+    return structure?.kind === 'assembly' ? structure.parts : null;
+  };
+
+  const commitParts = (next: AssemblyPartNode[]): void => {
+    set((state) => {
+      if (state.structure?.kind !== 'assembly') return;
+      pushHistoryEntry(state);
+      state.structure.parts = next;
+    });
+  };
+
+  /** World placements by select id — the same resolution the scene renders. */
+  const placedById = (): Map<string, PlacedPart> | null => {
+    const { structure, envelope } = get();
+    if (structure?.kind !== 'assembly' || !envelope) return null;
+    const extent = {
+      w: envelope.width * envelope.gridUnitMm,
+      d: envelope.depth * envelope.gridUnitMm,
+    };
+    const map = new Map<string, PlacedPart>();
+    for (const placed of resolvePlacedParts(structure, extent)) {
+      if (!map.has(placed.selectId)) map.set(placed.selectId, placed);
+    }
+    return map;
+  };
+
+  /** Convert a world-frame target into `placed`'s parent-local transform fields. */
+  const worldToLocal = (
+    placed: PlacedPart,
+    map: Map<string, PlacedPart>,
+    world: { x: number; y: number; rotZDeg?: number }
+  ): Partial<PartTransform> => {
+    const parent = placed.parentId === null ? null : (map.get(placed.parentId) ?? null);
+    const parentX = parent?.x ?? 0;
+    const parentY = parent?.y ?? 0;
+    const parentRot = parent?.rotZDeg ?? 0;
+    const local = rotate2d(world.x - parentX, world.y - parentY, -parentRot);
+    return {
+      x: local.x,
+      y: local.y,
+      ...(world.rotZDeg !== undefined ? { rotZDeg: normalizeDeg(world.rotZDeg - parentRot) } : {}),
+    };
+  };
+
+  /**
+   * Apply per-part world targets in one history entry. Entries whose id no
+   * longer resolves are skipped; a batch that changes nothing commits nothing.
+   */
+  const applyWorldTargets = (
+    targets: readonly { id: string; x: number; y: number; rotZDeg?: number }[]
+  ): void => {
+    const current = parts();
+    const map = placedById();
+    if (!current || !map) return;
+    let next: AssemblyPartNode[] = current;
+    let changed = false;
+    for (const target of targets) {
+      const placed = map.get(target.id);
+      const node = findAssemblyPart(next, target.id);
+      if (!placed || !node) continue;
+      const nextTransform = clampPartTransform({
+        ...node.transform,
+        ...worldToLocal(placed, map, target),
+      });
+      if (transformsEqual(nextTransform, node.transform)) continue;
+      const updated = withAssemblyPartUpdated(next, target.id, (n) => ({
+        ...n,
+        transform: nextTransform,
+      }));
+      if (!updated) continue;
+      next = updated;
+      changed = true;
+    }
+    if (changed) commitParts(next);
+  };
+
+  return { parts, commitParts, placedById, worldToLocal, applyWorldTargets };
+}

--- a/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
@@ -23,11 +23,9 @@ import type {
   PartLabel,
   PartTransform,
 } from '@/shared/types/assembly';
-import { resolvePlacedParts, rotate2d, type PlacedPart } from '@/shared/types/assemblyPlacement';
 import {
   cloneAssemblySubtree,
   collectAssemblyIds,
-  filterTopLevelAssemblyIds,
   findAssemblyParentId,
   findAssemblyPart,
   findAssemblySiblings,
@@ -39,116 +37,17 @@ import {
 import { pushHistoryEntry, setAssemblySelection } from '@/features/bin-designer/store/helpers';
 import type { Set, Get } from './types';
 import { generateUUID } from '@/shared/utils/uuid';
-
-function transformsEqual(a: PartTransform, b: PartTransform): boolean {
-  return a.x === b.x && a.y === b.y && a.seatZ === b.seatZ && a.rotZDeg === b.rotZDeg;
-}
-
-function normalizeDeg(deg: number): number {
-  const wrapped = (((deg % 360) + 540) % 360) - 180;
-  return wrapped === -180 ? 180 : wrapped;
-}
-
-/**
- * Group-op clipboard. Module-level like the pending mesh cache: node data
- * never needs to be reactive (the UI only needs the count, mirrored in
- * `ui.workshopClipboardCount`), and keeping frozen snapshots out of the
- * store means paste after any amount of editing still reads a stable copy.
- */
-interface WorkshopClipboardEntry {
-  readonly node: AssemblyPartNode;
-  readonly world: { x: number; y: number; rotZDeg: number };
-}
-let workshopClipboard: {
-  readonly entries: readonly WorkshopClipboardEntry[];
-  readonly centroid: { x: number; y: number };
-} | null = null;
-
-/** @internal test-only reset so suites don't leak copies into each other. */
-export function _resetWorkshopClipboard(): void {
-  workshopClipboard = null;
-}
-
-const PASTE_OFFSET_MM = 8;
+import {
+  createAssemblyActionContext,
+  transformsEqual,
+  PASTE_OFFSET_MM,
+} from './assemblyActionContext';
+import { createAssemblyBatchActions } from './assemblyBatchActions';
+export { _resetWorkshopClipboard } from './assemblyBatchActions';
 
 export function createAssemblyActions(set: Set, get: Get) {
-  const parts = (): AssemblyPartNode[] | null => {
-    const structure = get().structure;
-    return structure?.kind === 'assembly' ? structure.parts : null;
-  };
-
-  const commitParts = (next: AssemblyPartNode[]): void => {
-    set((state) => {
-      if (state.structure?.kind !== 'assembly') return;
-      pushHistoryEntry(state);
-      state.structure.parts = next;
-    });
-  };
-
-  /** World placements by select id — the same resolution the scene renders. */
-  const placedById = (): Map<string, PlacedPart> | null => {
-    const { structure, envelope } = get();
-    if (structure?.kind !== 'assembly' || !envelope) return null;
-    const extent = {
-      w: envelope.width * envelope.gridUnitMm,
-      d: envelope.depth * envelope.gridUnitMm,
-    };
-    const map = new Map<string, PlacedPart>();
-    for (const placed of resolvePlacedParts(structure, extent)) {
-      if (!map.has(placed.selectId)) map.set(placed.selectId, placed);
-    }
-    return map;
-  };
-
-  /** Convert a world-frame target into `placed`'s parent-local transform fields. */
-  const worldToLocal = (
-    placed: PlacedPart,
-    map: Map<string, PlacedPart>,
-    world: { x: number; y: number; rotZDeg?: number }
-  ): Partial<PartTransform> => {
-    const parent = placed.parentId === null ? null : (map.get(placed.parentId) ?? null);
-    const parentX = parent?.x ?? 0;
-    const parentY = parent?.y ?? 0;
-    const parentRot = parent?.rotZDeg ?? 0;
-    const local = rotate2d(world.x - parentX, world.y - parentY, -parentRot);
-    return {
-      x: local.x,
-      y: local.y,
-      ...(world.rotZDeg !== undefined ? { rotZDeg: normalizeDeg(world.rotZDeg - parentRot) } : {}),
-    };
-  };
-
-  /**
-   * Apply per-part world targets in one history entry. Entries whose id no
-   * longer resolves are skipped; a batch that changes nothing commits nothing.
-   */
-  const applyWorldTargets = (
-    targets: readonly { id: string; x: number; y: number; rotZDeg?: number }[]
-  ): void => {
-    const current = parts();
-    const map = placedById();
-    if (!current || !map) return;
-    let next: AssemblyPartNode[] = current;
-    let changed = false;
-    for (const target of targets) {
-      const placed = map.get(target.id);
-      const node = findAssemblyPart(next, target.id);
-      if (!placed || !node) continue;
-      const nextTransform = clampPartTransform({
-        ...node.transform,
-        ...worldToLocal(placed, map, target),
-      });
-      if (transformsEqual(nextTransform, node.transform)) continue;
-      const updated = withAssemblyPartUpdated(next, target.id, (n) => ({
-        ...n,
-        transform: nextTransform,
-      }));
-      if (!updated) continue;
-      next = updated;
-      changed = true;
-    }
-    if (changed) commitParts(next);
-  };
+  const ctx = createAssemblyActionContext(set, get);
+  const { parts, commitParts } = ctx;
 
   return {
     addAssemblyPart: (
@@ -388,259 +287,6 @@ export function createAssemblyActions(set: Set, get: Get) {
       return true;
     },
 
-    /**
-     * Set world placements for several parts at once (group drag/rotate).
-     * Targets are world-frame; descendants of another target ride along with
-     * their ancestor, so callers pass top-level ids only.
-     */
-    moveAssemblyPartsWorldTo: (
-      targets: readonly { id: string; x: number; y: number; rotZDeg?: number }[]
-    ): void => {
-      applyWorldTargets(targets);
-    },
-
-    /** Translate the selection's top-level parts by a world-frame delta. */
-    nudgeAssemblyPartsWorld: (ids: readonly string[], dx: number, dy: number): void => {
-      if (dx === 0 && dy === 0) return;
-      const current = parts();
-      const map = placedById();
-      if (!current || !map) return;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      applyWorldTargets(
-        top.flatMap((id) => {
-          const placed = map.get(id);
-          return placed ? [{ id, x: placed.x + dx, y: placed.y + dy }] : [];
-        })
-      );
-    },
-
-    /**
-     * Rotate the selection's top-level parts by `deltaDeg` about their world
-     * centroid — positions orbit the pivot, each part spins with them. A
-     * single part spins in place (its own anchor is the pivot).
-     */
-    rotateAssemblyPartsWorld: (ids: readonly string[], deltaDeg: number): void => {
-      const current = parts();
-      const map = placedById();
-      if (!current || !map || deltaDeg === 0) return;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      const placements = top.flatMap((id) => map.get(id) ?? []);
-      if (placements.length === 0) return;
-      const pivot = {
-        x: placements.reduce((sum, p) => sum + p.x, 0) / placements.length,
-        y: placements.reduce((sum, p) => sum + p.y, 0) / placements.length,
-      };
-      applyWorldTargets(
-        placements.map((placed) => {
-          const orbited = rotate2d(placed.x - pivot.x, placed.y - pivot.y, deltaDeg);
-          return {
-            id: placed.selectId,
-            x: pivot.x + orbited.x,
-            y: pivot.y + orbited.y,
-            rotZDeg: placed.rotZDeg + deltaDeg,
-          };
-        })
-      );
-    },
-
-    /**
-     * Align the selection's top-level parts to the anchor part's world
-     * coordinate on one axis. The anchor never moves.
-     */
-    alignAssemblyPartsWorld: (ids: readonly string[], axis: 'x' | 'y'): void => {
-      const current = parts();
-      const map = placedById();
-      if (!current || !map) return;
-      const anchorId = get().ui.selectedAssemblyPartId;
-      if (anchorId === null || !ids.includes(anchorId)) return;
-      const anchor = map.get(anchorId);
-      if (!anchor) return;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      if (top.length < 2) return;
-      applyWorldTargets(
-        top.flatMap((id) => {
-          const placed = map.get(id);
-          if (!placed || id === anchorId) return [];
-          return [
-            { id, x: axis === 'x' ? anchor.x : placed.x, y: axis === 'y' ? anchor.y : placed.y },
-          ];
-        })
-      );
-    },
-
-    /** Evenly space the selection's top-level parts between the two outermost. */
-    distributeAssemblyPartsWorld: (ids: readonly string[], axis: 'x' | 'y'): void => {
-      const current = parts();
-      const map = placedById();
-      if (!current || !map) return;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      const placements = top.flatMap((id) => map.get(id) ?? []);
-      if (placements.length < 3) return;
-      const sorted = [...placements].sort((a, b) => a[axis] - b[axis]);
-      const first = sorted.at(0);
-      const last = sorted.at(-1);
-      if (!first || !last) return;
-      const step = (last[axis] - first[axis]) / (sorted.length - 1);
-      applyWorldTargets(
-        sorted.slice(1, -1).map((placed, index) => ({
-          id: placed.selectId,
-          x: axis === 'x' ? first.x + step * (index + 1) : placed.x,
-          y: axis === 'y' ? first.y + step * (index + 1) : placed.y,
-        }))
-      );
-    },
-
-    /** Remove every selected subtree in one history entry. */
-    removeAssemblyParts: (ids: readonly string[]): void => {
-      const current = parts();
-      if (!current) return;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      if (top.length === 0) return;
-      const removedIds = new Set<string>();
-      let next: AssemblyPartNode[] = current;
-      for (const id of top) {
-        const node = findAssemblyPart(next, id);
-        if (!node) continue;
-        for (const removed of collectAssemblyIds([node])) removedIds.add(removed);
-        const without = withAssemblyPartRemoved(next, id);
-        if (without) next = without;
-      }
-      if (removedIds.size === 0) return;
-      set((state) => {
-        if (state.structure?.kind !== 'assembly') return;
-        pushHistoryEntry(state);
-        state.structure.parts = next;
-        setAssemblySelection(
-          state,
-          state.ui.selectedAssemblyPartIds.filter((selected) => !removedIds.has(selected)),
-          state.ui.selectedAssemblyPartId
-        );
-      });
-    },
-
-    /**
-     * Duplicate every selected subtree in one history entry and select the
-     * clones, so a follow-up drag moves the copies as a group. `offsetMm`
-     * shifts the clones aside (default) — alt-drag passes 0 so the clone
-     * starts under the pointer. Returns clone ids with their source ids so
-     * the caller can pick up the clone of the part it grabbed.
-     */
-    duplicateAssemblyParts: (
-      ids: readonly string[],
-      offsetMm: number = PASTE_OFFSET_MM
-    ): { id: string; sourceId: string }[] => {
-      const current = parts();
-      if (!current) return [];
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      if (top.length === 0) return [];
-      const anchorId = get().ui.selectedAssemblyPartId;
-      let next: AssemblyPartNode[] = current;
-      const clones: { id: string; sourceId: string }[] = [];
-      let cloneAnchor: string | null = null;
-      for (const id of top) {
-        const node = findAssemblyPart(next, id);
-        if (!node) continue;
-        const copy = cloneAssemblySubtree(node);
-        const offset = {
-          ...copy,
-          transform: clampPartTransform({
-            ...copy.transform,
-            x: copy.transform.x + offsetMm,
-          }),
-        } as AssemblyPartNode;
-        const parentId = findAssemblyParentId(next, id) ?? null;
-        const added = withAssemblyPartAdded(next, parentId, offset);
-        if (!added) continue;
-        next = added;
-        clones.push({ id: offset.id, sourceId: id });
-        if (id === anchorId) cloneAnchor = offset.id;
-      }
-      if (clones.length === 0) return [];
-      set((state) => {
-        if (state.structure?.kind !== 'assembly') return;
-        pushHistoryEntry(state);
-        state.structure.parts = next;
-        setAssemblySelection(
-          state,
-          clones.map((clone) => clone.id),
-          cloneAnchor
-        );
-      });
-      return clones;
-    },
-
-    /** Snapshot the selected subtrees (with world placement) for paste. */
-    copyAssemblyParts: (ids: readonly string[]): number => {
-      const current = parts();
-      const map = placedById();
-      if (!current || !map) return 0;
-      const top = filterTopLevelAssemblyIds(current, new Set(ids));
-      const entries: WorkshopClipboardEntry[] = top.flatMap((id) => {
-        const node = findAssemblyPart(current, id);
-        const placed = map.get(id);
-        if (!node || !placed) return [];
-        return [
-          {
-            node: structuredClone(node),
-            world: { x: placed.x, y: placed.y, rotZDeg: placed.rotZDeg },
-          },
-        ];
-      });
-      if (entries.length === 0) return 0;
-      workshopClipboard = {
-        entries,
-        centroid: {
-          x: entries.reduce((sum, e) => sum + e.world.x, 0) / entries.length,
-          y: entries.reduce((sum, e) => sum + e.world.y, 0) / entries.length,
-        },
-      };
-      set((state) => {
-        state.ui.workshopClipboardCount = entries.length;
-      });
-      return entries.length;
-    },
-
-    /**
-     * Paste the clipboard onto the base floor, keeping the copied
-     * arrangement, centered at `at` (default: beside the source). Pasted
-     * parts keep their copied world rotations and become the selection.
-     */
-    pasteAssemblyParts: (at?: { x: number; y: number }): string[] => {
-      const clipboard = workshopClipboard;
-      const current = parts();
-      if (!clipboard || !current) return [];
-      const target = at ?? {
-        x: clipboard.centroid.x + PASTE_OFFSET_MM,
-        y: clipboard.centroid.y + PASTE_OFFSET_MM,
-      };
-      let next: AssemblyPartNode[] = current;
-      const pastedIds: string[] = [];
-      for (const entry of clipboard.entries) {
-        const copy = cloneAssemblySubtree(entry.node);
-        const placedCopy = {
-          ...copy,
-          transform: clampPartTransform({
-            x: target.x + (entry.world.x - clipboard.centroid.x),
-            y: target.y + (entry.world.y - clipboard.centroid.y),
-            seatZ: 0,
-            rotZDeg: normalizeDeg(entry.world.rotZDeg),
-          }),
-        } as AssemblyPartNode;
-        const added = withAssemblyPartAdded(next, null, placedCopy);
-        if (!added) continue;
-        next = added;
-        pastedIds.push(placedCopy.id);
-      }
-      if (pastedIds.length === 0) return [];
-      set((state) => {
-        if (state.structure?.kind !== 'assembly') return;
-        pushHistoryEntry(state);
-        state.structure.parts = next;
-        setAssemblySelection(state, pastedIds);
-      });
-      return pastedIds;
-    },
-
     updateAssemblyBase: (partial: Partial<AssemblyBase>): void => {
       const structure = get().structure;
       if (structure?.kind !== 'assembly') return;
@@ -659,5 +305,6 @@ export function createAssemblyActions(set: Set, get: Get) {
         state.structure.base = nextBase;
       });
     },
+    ...createAssemblyBatchActions(set, get, ctx),
   };
 }

--- a/src/features/bin-designer/store/slices/paramSlice/assemblyBatchActions.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/assemblyBatchActions.ts
@@ -1,0 +1,298 @@
+/**
+ * Multi-part assembly actions: world-frame moves over a selection, remove,
+ * duplicate and the copy/paste clipboard. Each commits ONE history entry.
+ */
+import { clampPartTransform } from '@/shared/items/assembly/descriptor';
+import type { AssemblyPartNode } from '@/shared/types/assembly';
+import { rotate2d } from '@/shared/types/assemblyPlacement';
+import {
+  cloneAssemblySubtree,
+  collectAssemblyIds,
+  filterTopLevelAssemblyIds,
+  findAssemblyParentId,
+  findAssemblyPart,
+  withAssemblyPartAdded,
+  withAssemblyPartRemoved,
+} from '@/features/bin-designer/utils/assemblyTree';
+import { pushHistoryEntry, setAssemblySelection } from '@/features/bin-designer/store/helpers';
+import type { Set, Get } from './types';
+import { normalizeDeg, PASTE_OFFSET_MM } from './assemblyActionContext';
+import type { AssemblyActionContext } from './assemblyActionContext';
+
+/**
+ * Group-op clipboard. Module-level like the pending mesh cache: node data
+ * never needs to be reactive (the UI only needs the count, mirrored in
+ * `ui.workshopClipboardCount`), and keeping frozen snapshots out of the
+ * store means paste after any amount of editing still reads a stable copy.
+ */
+interface WorkshopClipboardEntry {
+  readonly node: AssemblyPartNode;
+  readonly world: { x: number; y: number; rotZDeg: number };
+}
+let workshopClipboard: {
+  readonly entries: readonly WorkshopClipboardEntry[];
+  readonly centroid: { x: number; y: number };
+} | null = null;
+/** @internal test-only reset so suites don't leak copies into each other. */
+export function _resetWorkshopClipboard(): void {
+  workshopClipboard = null;
+}
+
+export function createAssemblyBatchActions(set: Set, get: Get, ctx: AssemblyActionContext) {
+  const { parts, placedById, applyWorldTargets } = ctx;
+
+  return {
+    /**
+     * Set world placements for several parts at once (group drag/rotate).
+     * Targets are world-frame; descendants of another target ride along with
+     * their ancestor, so callers pass top-level ids only.
+     */
+    moveAssemblyPartsWorldTo: (
+      targets: readonly { id: string; x: number; y: number; rotZDeg?: number }[]
+    ): void => {
+      applyWorldTargets(targets);
+    },
+
+    /** Translate the selection's top-level parts by a world-frame delta. */
+    nudgeAssemblyPartsWorld: (ids: readonly string[], dx: number, dy: number): void => {
+      if (dx === 0 && dy === 0) return;
+      const current = parts();
+      const map = placedById();
+      if (!current || !map) return;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      applyWorldTargets(
+        top.flatMap((id) => {
+          const placed = map.get(id);
+          return placed ? [{ id, x: placed.x + dx, y: placed.y + dy }] : [];
+        })
+      );
+    },
+
+    /**
+     * Rotate the selection's top-level parts by `deltaDeg` about their world
+     * centroid — positions orbit the pivot, each part spins with them. A
+     * single part spins in place (its own anchor is the pivot).
+     */
+    rotateAssemblyPartsWorld: (ids: readonly string[], deltaDeg: number): void => {
+      const current = parts();
+      const map = placedById();
+      if (!current || !map || deltaDeg === 0) return;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      const placements = top.flatMap((id) => map.get(id) ?? []);
+      if (placements.length === 0) return;
+      const pivot = {
+        x: placements.reduce((sum, p) => sum + p.x, 0) / placements.length,
+        y: placements.reduce((sum, p) => sum + p.y, 0) / placements.length,
+      };
+      applyWorldTargets(
+        placements.map((placed) => {
+          const orbited = rotate2d(placed.x - pivot.x, placed.y - pivot.y, deltaDeg);
+          return {
+            id: placed.selectId,
+            x: pivot.x + orbited.x,
+            y: pivot.y + orbited.y,
+            rotZDeg: placed.rotZDeg + deltaDeg,
+          };
+        })
+      );
+    },
+
+    /**
+     * Align the selection's top-level parts to the anchor part's world
+     * coordinate on one axis. The anchor never moves.
+     */
+    alignAssemblyPartsWorld: (ids: readonly string[], axis: 'x' | 'y'): void => {
+      const current = parts();
+      const map = placedById();
+      if (!current || !map) return;
+      const anchorId = get().ui.selectedAssemblyPartId;
+      if (anchorId === null || !ids.includes(anchorId)) return;
+      const anchor = map.get(anchorId);
+      if (!anchor) return;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      if (top.length < 2) return;
+      applyWorldTargets(
+        top.flatMap((id) => {
+          const placed = map.get(id);
+          if (!placed || id === anchorId) return [];
+          return [
+            { id, x: axis === 'x' ? anchor.x : placed.x, y: axis === 'y' ? anchor.y : placed.y },
+          ];
+        })
+      );
+    },
+
+    /** Evenly space the selection's top-level parts between the two outermost. */
+    distributeAssemblyPartsWorld: (ids: readonly string[], axis: 'x' | 'y'): void => {
+      const current = parts();
+      const map = placedById();
+      if (!current || !map) return;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      const placements = top.flatMap((id) => map.get(id) ?? []);
+      if (placements.length < 3) return;
+      const sorted = [...placements].sort((a, b) => a[axis] - b[axis]);
+      const first = sorted.at(0);
+      const last = sorted.at(-1);
+      if (!first || !last) return;
+      const step = (last[axis] - first[axis]) / (sorted.length - 1);
+      applyWorldTargets(
+        sorted.slice(1, -1).map((placed, index) => ({
+          id: placed.selectId,
+          x: axis === 'x' ? first.x + step * (index + 1) : placed.x,
+          y: axis === 'y' ? first.y + step * (index + 1) : placed.y,
+        }))
+      );
+    },
+
+    /** Remove every selected subtree in one history entry. */
+    removeAssemblyParts: (ids: readonly string[]): void => {
+      const current = parts();
+      if (!current) return;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      if (top.length === 0) return;
+      const removedIds = new Set<string>();
+      let next: AssemblyPartNode[] = current;
+      for (const id of top) {
+        const node = findAssemblyPart(next, id);
+        if (!node) continue;
+        for (const removed of collectAssemblyIds([node])) removedIds.add(removed);
+        const without = withAssemblyPartRemoved(next, id);
+        if (without) next = without;
+      }
+      if (removedIds.size === 0) return;
+      set((state) => {
+        if (state.structure?.kind !== 'assembly') return;
+        pushHistoryEntry(state);
+        state.structure.parts = next;
+        setAssemblySelection(
+          state,
+          state.ui.selectedAssemblyPartIds.filter((selected) => !removedIds.has(selected)),
+          state.ui.selectedAssemblyPartId
+        );
+      });
+    },
+
+    /**
+     * Duplicate every selected subtree in one history entry and select the
+     * clones, so a follow-up drag moves the copies as a group. `offsetMm`
+     * shifts the clones aside (default) — alt-drag passes 0 so the clone
+     * starts under the pointer. Returns clone ids with their source ids so
+     * the caller can pick up the clone of the part it grabbed.
+     */
+    duplicateAssemblyParts: (
+      ids: readonly string[],
+      offsetMm: number = PASTE_OFFSET_MM
+    ): { id: string; sourceId: string }[] => {
+      const current = parts();
+      if (!current) return [];
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      if (top.length === 0) return [];
+      const anchorId = get().ui.selectedAssemblyPartId;
+      let next: AssemblyPartNode[] = current;
+      const clones: { id: string; sourceId: string }[] = [];
+      let cloneAnchor: string | null = null;
+      for (const id of top) {
+        const node = findAssemblyPart(next, id);
+        if (!node) continue;
+        const copy = cloneAssemblySubtree(node);
+        const offset = {
+          ...copy,
+          transform: clampPartTransform({
+            ...copy.transform,
+            x: copy.transform.x + offsetMm,
+          }),
+        } as AssemblyPartNode;
+        const parentId = findAssemblyParentId(next, id) ?? null;
+        const added = withAssemblyPartAdded(next, parentId, offset);
+        if (!added) continue;
+        next = added;
+        clones.push({ id: offset.id, sourceId: id });
+        if (id === anchorId) cloneAnchor = offset.id;
+      }
+      if (clones.length === 0) return [];
+      set((state) => {
+        if (state.structure?.kind !== 'assembly') return;
+        pushHistoryEntry(state);
+        state.structure.parts = next;
+        setAssemblySelection(
+          state,
+          clones.map((clone) => clone.id),
+          cloneAnchor
+        );
+      });
+      return clones;
+    },
+
+    /** Snapshot the selected subtrees (with world placement) for paste. */
+    copyAssemblyParts: (ids: readonly string[]): number => {
+      const current = parts();
+      const map = placedById();
+      if (!current || !map) return 0;
+      const top = filterTopLevelAssemblyIds(current, new Set(ids));
+      const entries: WorkshopClipboardEntry[] = top.flatMap((id) => {
+        const node = findAssemblyPart(current, id);
+        const placed = map.get(id);
+        if (!node || !placed) return [];
+        return [
+          {
+            node: structuredClone(node),
+            world: { x: placed.x, y: placed.y, rotZDeg: placed.rotZDeg },
+          },
+        ];
+      });
+      if (entries.length === 0) return 0;
+      workshopClipboard = {
+        entries,
+        centroid: {
+          x: entries.reduce((sum, e) => sum + e.world.x, 0) / entries.length,
+          y: entries.reduce((sum, e) => sum + e.world.y, 0) / entries.length,
+        },
+      };
+      set((state) => {
+        state.ui.workshopClipboardCount = entries.length;
+      });
+      return entries.length;
+    },
+
+    /**
+     * Paste the clipboard onto the base floor, keeping the copied
+     * arrangement, centered at `at` (default: beside the source). Pasted
+     * parts keep their copied world rotations and become the selection.
+     */
+    pasteAssemblyParts: (at?: { x: number; y: number }): string[] => {
+      const clipboard = workshopClipboard;
+      const current = parts();
+      if (!clipboard || !current) return [];
+      const target = at ?? {
+        x: clipboard.centroid.x + PASTE_OFFSET_MM,
+        y: clipboard.centroid.y + PASTE_OFFSET_MM,
+      };
+      let next: AssemblyPartNode[] = current;
+      const pastedIds: string[] = [];
+      for (const entry of clipboard.entries) {
+        const copy = cloneAssemblySubtree(entry.node);
+        const placedCopy = {
+          ...copy,
+          transform: clampPartTransform({
+            x: target.x + (entry.world.x - clipboard.centroid.x),
+            y: target.y + (entry.world.y - clipboard.centroid.y),
+            seatZ: 0,
+            rotZDeg: normalizeDeg(entry.world.rotZDeg),
+          }),
+        } as AssemblyPartNode;
+        const added = withAssemblyPartAdded(next, null, placedCopy);
+        if (!added) continue;
+        next = added;
+        pastedIds.push(placedCopy.id);
+      }
+      if (pastedIds.length === 0) return [];
+      set((state) => {
+        if (state.structure?.kind !== 'assembly') return;
+        pushHistoryEntry(state);
+        state.structure.parts = next;
+        setAssemblySelection(state, pastedIds);
+      });
+      return pastedIds;
+    },
+  };
+}

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -57,7 +57,6 @@ import {
   effectiveDividerHeight,
   totalDividerLength,
 } from './printPatternSavings';
-export { computeLabelTabVolume, rampAreaWithin, lipSupportArea } from './printLabelTabVolume';
 export interface PrintEstimate {
   /** Estimated material volume in mm³ */
   readonly volumeMm3: number;


### PR DESCRIPTION
Fourth batch of the `max-lines` sweep: the two designer store modules whose single factory function had grown past the limit. Each factory now composes a second one for the actions that form a group of their own, spread into the same slice object, so the store's public surface is unchanged.

**assemblyActions.ts** (577 lines)

- `assemblyActionContext.ts` holds the closures every action shares: current part list, one-entry commit, world placements by select id and the world-to-parent-local conversion. `transformsEqual`, `normalizeDeg` and `PASTE_OFFSET_MM` move with them.
- `assemblyBatchActions.ts` takes the multi-part actions: world-frame move, nudge, rotate, align and distribute over a selection, batch remove and duplicate, and the copy/paste clipboard (which stays module-level, with `_resetWorkshopClipboard` re-exported for the scenario tests).
- `createAssemblyActions` builds the context, keeps the single-part actions, and spreads `createAssemblyBatchActions(set, get, ctx)`.

**cutoutSlice.ts** (700 lines)

- `cutoutSliceHelpers.ts` takes the module-level helpers: owner lookup, group expansion, mesh-asset and group-name garbage collection, z-order helpers and unit-landing planning. `remainingCutoutCapacity` re-exports from the slice.
- `cutoutGroupActions.ts` takes the boolean-group actions: group, ungroup, move units between groups, peel, rename and set op. It receives the slice's wrapped `set`, so an emptied lid array still collapses to absent.

**Verification**

- Typecheck, ESLint and the pre-commit gates pass. Neither original file carries a `max-lines` warning.
- Vitest: the whole designer store folder, including the workshop and cutout scenario suites, 22 files, 587 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

