### PR TITLE
docs: put the cutout owner docblock on cutoutOwner

### DIFF
--- a/src/features/bin-designer/store/slices/cutoutSliceHelpers.ts
+++ b/src/features/bin-designer/store/slices/cutoutSliceHelpers.ts
@@ -21,6 +21,16 @@ import {
 } from '../../utils/cutoutHierarchy';
 
 /**
+ * Read-only view of the target's cutouts, for guards that run BEFORE any write.
+ * Unlike {@link cutoutOwner} it never materializes `lid.cutouts`, so an action
+ * that bails early leaves no `[]` behind on a lid that has none.
+ */
+export function cutoutList(state: Draft<DesignerState>): readonly Cutout[] {
+  if (state.ui.cutoutTarget !== 'lid') return state.params.cutouts;
+  return state.params.lid.cutouts ?? [];
+}
+
+/**
  * The cutout array every action in this slice reads and writes, chosen by
  * `ui.cutoutTarget`.
  *
@@ -36,11 +46,6 @@ import {
  * leave `[]` behind on a lid that has none — enough to shift the design's
  * `communityParamsFingerprint` for a no-op.
  */
-export function cutoutList(state: Draft<DesignerState>): readonly Cutout[] {
-  if (state.ui.cutoutTarget !== 'lid') return state.params.cutouts;
-  return state.params.lid.cutouts ?? [];
-}
-
 export function cutoutOwner(state: Draft<DesignerState>): { cutouts: Cutout[] } {
   if (state.ui.cutoutTarget !== 'lid') return state.params;
   const lid = state.params.lid;


### PR DESCRIPTION
Follow-up to #4192. The docblock that explains the owner lookup (why it returns `params` or `params.lid` rather than the array) sat above `cutoutList`, which returns the array. It now sits on `cutoutOwner`, and `cutoutList` gets a three-line note on what it is for: guards that must run before any write without materializing `lid.cutouts`.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

