### PR TITLE
fix(migration): guard migrateWalls against non-object input and correct a docblock

### DIFF
--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -64,6 +64,10 @@ describe('migrateWalls', () => {
     expect(migrate(undefined)).toBe(defaults);
   });
 
+  it.each([null, 0, 12, 'walls', true])('returns the defaults for the non-object %j', (raw) => {
+    expect(migrate(raw as unknown as Parameters<typeof migrate>[0])).toBe(defaults);
+  });
+
   it('expands legacy numeric sides into WallCutout objects', () => {
     const result = migrate({ front: 12, back: 0 });
     expect(result.front.enabled).toBe(true);

--- a/src/features/bin-designer/constants/paramMigrationCutouts.ts
+++ b/src/features/bin-designer/constants/paramMigrationCutouts.ts
@@ -204,8 +204,9 @@ export function migrateCutoutGroupNames(
  * declines to repeat it, and rewriting one member's pattern onto the others
  * would move cuts in a design nothing in this app produced.
  *
- * Returns the input by reference when nothing needed changing, so a design that
- * was already consistent serializes byte-identically.
+ * When nothing needed changing the result is a fresh array holding the same
+ * cutout objects, so a design that was already consistent serializes
+ * byte-identically.
  */
 export function shareGroupArrays(cutouts: readonly Cutout[]): Cutout[] {
   const byGroup = new Map<string, Cutout[]>();

--- a/src/features/bin-designer/constants/paramMigrationWalls.ts
+++ b/src/features/bin-designer/constants/paramMigrationWalls.ts
@@ -5,6 +5,7 @@ import { DEFAULT_LID_CONFIG, LID_CLICK_RAIL_COVERAGE_OPTIONS } from '../types/li
 import type { LidClickRails } from '../types/lid';
 import { MAX_CUTOUT_CORNER_RADIUS } from '@/shared/utils/wallCutoutPosition';
 import { DESIGNER_CONSTRAINTS } from './gridfinity';
+import { isObj } from './paramMigrationHelpers';
 
 /** Legacy wall config where sides could be numbers instead of WallCutout objects. */
 export interface LegacyWallConfig {
@@ -45,7 +46,7 @@ export function migrateWalls(
   defaults: WallConfig,
   disabledCutout: WallCutout
 ): WallConfig {
-  if (rawWalls === undefined) return defaults;
+  if (!isObj(rawWalls)) return defaults;
   const raw = rawWalls as LegacyWallConfig;
 
   // Helper: infer enabled from non-zero values


### PR DESCRIPTION
Follow-up to the review of #4194.

- `migrateWalls` returned defaults for `undefined` but read properties off anything else, so a persisted `walls: null` or non-object would throw inside the migration. It now falls back to defaults for any non-object, using the same `isObj` guard the other steps use.
- The `shareGroupArrays` docblock said the input is returned by reference when nothing changes; the function returns a fresh array holding the same cutout objects. The doc now says that.

Verification: typecheck, ESLint, the pre-commit gates, and the `constants` folder suites including `paramMigration.test.ts`.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

