### PR TITLE
refactor: move the lid fine-tuning and label-tab groups into sibling components

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabShapeControls.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabShapeControls.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LabelTabShapeControls } from './LabelTabShapeControls';
+import { useLabelTabsSection } from './useLabelTabsSection';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+
+function Harness() {
+  const { state, handlers, t } = useLabelTabsSection();
+  return (
+    <LabelTabShapeControls
+      state={state}
+      handlers={handlers}
+      t={t}
+      title="Tab shape & size"
+      summary=""
+      expanded
+      onExpandedChange={() => {}}
+    />
+  );
+}
+
+describe('LabelTabShapeControls', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
+      },
+      ui: { ...DEFAULT_UI_STATE },
+    });
+  });
+
+  it('offers the support styles and writes the chosen one to the design', () => {
+    render(<Harness />);
+    const group = screen.getByRole('group', { name: 'Support' });
+    fireEvent.click(screen.getByRole('button', { name: 'Solid' }));
+    expect(group).toBeInTheDocument();
+    expect(useDesignerStore.getState().params.label.support).toBe('solid');
+  });
+});

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabShapeControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabShapeControls.tsx
@@ -1,0 +1,230 @@
+/** The collapsed "tab shape & size" group: support style, tab dimensions and the label lip. */
+
+import { CheckboxRow } from '@/design-system';
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
+import { Button, Stepper, InfoIcon, Collapsible } from '@/design-system';
+import { DESIGNER_CONSTRAINTS } from '../../../constants';
+import type { LabelTabSupport } from '../../../types';
+import type { useLabelTabsSection } from './useLabelTabsSection';
+import type { ReactNode } from 'react';
+import type { useTranslation } from '@/i18n';
+
+const SUPPORT_OPTIONS: LabelTabSupport[] = ['bracket', 'solid', 'fillet'];
+
+interface LabelTabShapeControlsProps {
+  state: ReturnType<typeof useLabelTabsSection>['state'];
+  handlers: ReturnType<typeof useLabelTabsSection>['handlers'];
+  t: ReturnType<typeof useTranslation>;
+  title: string;
+  summary: string;
+  expanded: boolean;
+  onExpandedChange: (open: boolean) => void;
+  badge?: ReactNode;
+}
+
+export function LabelTabShapeControls({
+  state,
+  handlers,
+  t,
+  title,
+  summary,
+  expanded,
+  onExpandedChange,
+  badge,
+}: LabelTabShapeControlsProps) {
+  return (
+    <Collapsible
+      title={title}
+      summary={summary}
+      expanded={expanded}
+      onExpandedChange={onExpandedChange}
+      size="sm"
+      badge={badge}
+    >
+      <div className="space-y-3">
+        {/* Support */}
+        <div>
+          <span className="mb-1 block text-label text-content-tertiary">
+            {t('binDesigner.tabSupport')}
+          </span>
+          <div
+            role="group"
+            aria-label={t('binDesigner.tabSupport')}
+            className={SEGMENT_GROUP_CLASS}
+          >
+            {SUPPORT_OPTIONS.map((option) => (
+              <Button
+                key={option}
+                type="button"
+                variant="ghost"
+                touchTarget={false}
+                onClick={() => handlers.setTabSupport(option)}
+                aria-pressed={state.label.support === option}
+                className={`flex-1 ${getSegmentClass(state.label.support === option)}`}
+              >
+                {t(`binDesigner.tabSupport.${option}`)}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.tabWidth')}
+            </span>
+            <Stepper
+              value={state.label.width}
+              onChange={handlers.setTabWidth}
+              onStep={(delta) =>
+                handlers.setTabWidth(
+                  Math.min(
+                    DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
+                    Math.max(
+                      DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
+                      state.label.width + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP
+                    )
+                  )
+                )
+              }
+              min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH}
+              max={DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH}
+              step={DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP}
+              size="md"
+              aria-label={t('binDesigner.labelTabs.widthAria')}
+            />
+          </div>
+          <div className="min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.tabDepth')}
+            </span>
+            <Stepper
+              value={state.label.depth}
+              onChange={handlers.setTabDepth}
+              onStep={(delta) =>
+                handlers.setTabDepth(
+                  Math.min(
+                    state.tabDepthMax,
+                    Math.max(
+                      state.tabDepthMin,
+                      state.label.depth + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_DEPTH_STEP
+                    )
+                  )
+                )
+              }
+              min={state.tabDepthMin}
+              max={state.tabDepthMax}
+              step={DESIGNER_CONSTRAINTS.LABEL_TAB_DEPTH_STEP}
+              size="md"
+              aria-label={t('binDesigner.labelTabs.depthAria')}
+            />
+          </div>
+          <div className="min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.tabHeight')}
+            </span>
+            <Stepper
+              value={state.tabHeightMm}
+              onChange={handlers.setTabHeight}
+              onStep={(delta) =>
+                handlers.setTabHeight(
+                  Math.min(
+                    state.tabHeightMax,
+                    Math.max(
+                      state.tabHeightMin,
+                      state.tabHeightMm + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP
+                    )
+                  )
+                )
+              }
+              min={state.tabHeightMin}
+              max={state.tabHeightMax}
+              step={DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP}
+              size="md"
+              aria-label={t('binDesigner.labelTabs.heightAria')}
+            />
+          </div>
+          <div className="min-w-0">
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.tabInset')}
+            </span>
+            <Stepper
+              value={state.label.inset ?? 0}
+              onChange={handlers.setTabInset}
+              onStep={(delta) =>
+                handlers.setTabInset(
+                  Math.min(
+                    state.tabInsetMax,
+                    Math.max(
+                      DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_INSET,
+                      (state.label.inset ?? 0) + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_INSET_STEP
+                    )
+                  )
+                )
+              }
+              min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_INSET}
+              max={state.tabInsetMax}
+              step={DESIGNER_CONSTRAINTS.LABEL_TAB_INSET_STEP}
+              size="md"
+              aria-label={t('binDesigner.labelTabs.insetAria')}
+            />
+          </div>
+        </div>
+        {/* Label lip: raised rim to retain loose labels (#2971).
+              Text-mode only — socket plates retain themselves. */}
+        {state.lipAvailable && (
+          <div className="mt-3 border-t border-border-subtle pt-3">
+            <CheckboxRow
+              label={t('binDesigner.tabLip')}
+              checked={state.lipEnabled}
+              onChange={handlers.toggleLabelLip}
+            />
+            <p className="mt-0.5 pl-7 text-label leading-snug text-content-tertiary">
+              {t('binDesigner.tabLipHint')}
+            </p>
+            {state.lipEnabled && (
+              <div className="mt-2 min-w-0 pl-7">
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  {t('binDesigner.tabLipHeight')}
+                </span>
+                <Stepper
+                  value={state.lipHeightMm}
+                  onChange={handlers.setLabelLipHeight}
+                  onStep={(delta) =>
+                    handlers.setLabelLipHeight(
+                      Math.min(
+                        state.lipMax,
+                        Math.max(state.lipMin, state.lipHeightMm + delta * state.lipStep)
+                      )
+                    )
+                  }
+                  min={state.lipMin}
+                  max={state.lipMax}
+                  step={state.lipStep}
+                  size="md"
+                  aria-label={t('binDesigner.labelTabs.lipHeightAria')}
+                />
+              </div>
+            )}
+            {state.lipWontFit && (
+              <div className="mt-1 flex items-start gap-2 pl-7 text-xs text-warning">
+                <InfoIcon size="xs" className="mt-0.5 shrink-0" />
+                <span className="flex-1">{t('binDesigner.tabLipTooTallWarning')}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  touchTarget={false}
+                  onClick={handlers.autoFixLip}
+                  className="shrink-0 px-0 font-medium text-accent hover:bg-transparent hover:text-accent/80"
+                >
+                  {t('binDesigner.tabAutoFix')}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </Collapsible>
+  );
+}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabTextStyleControls.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabTextStyleControls.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LabelTabTextStyleControls } from './LabelTabTextStyleControls';
+import { useLabelTabsSection } from './useLabelTabsSection';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+
+function Harness() {
+  const { state, handlers, t } = useLabelTabsSection();
+  return (
+    <LabelTabTextStyleControls
+      state={state}
+      handlers={handlers}
+      t={t}
+      title="Engraved text"
+      summary=""
+      expanded
+      onExpandedChange={() => {}}
+    />
+  );
+}
+
+describe('LabelTabTextStyleControls', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
+      },
+      ui: { ...DEFAULT_UI_STATE },
+    });
+  });
+
+  it('offers the finishes and writes the chosen one to the text defaults', () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Emboss' }));
+    expect(useDesignerStore.getState().params.textDefaults.mode).toBe('emboss');
+  });
+});

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabTextStyleControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabTextStyleControls.tsx
@@ -1,0 +1,151 @@
+/** The collapsed "engraved text" group: finish, font, depth and the shared size control. */
+
+import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
+import { Button, Select, Stepper, InfoIcon, Collapsible } from '@/design-system';
+import { LabelSizeControl } from '../../controls';
+import type { SelectOption } from '@/design-system';
+import type { TextFontFamily, TextMode } from '../../../types';
+import { jumpToDesignerControl } from '@/features/bin-designer/settingsManifest';
+import { DependencyHint } from '../shared';
+import type { useLabelTabsSection } from './useLabelTabsSection';
+import type { useTranslation } from '@/i18n';
+
+const MODE_OPTIONS: TextMode[] = ['engrave', 'emboss', 'through-cut'];
+const FONT_OPTIONS: readonly TextFontFamily[] = [
+  'atkinson',
+  'jetbrains-mono',
+  'allerta-stencil',
+] as const;
+/** Per-mode bounds for the engrave/emboss depth stepper. Through-cut ignores
+ *  `depth` (cuts through the full shelf), so the picker is hidden in that
+ *  mode rather than disabled. */
+const TEXT_DEPTH_MIN = 0.2;
+const TEXT_DEPTH_MAX = 5;
+const TEXT_DEPTH_STEP = 0.1;
+
+interface LabelTabTextStyleControlsProps {
+  state: ReturnType<typeof useLabelTabsSection>['state'];
+  handlers: ReturnType<typeof useLabelTabsSection>['handlers'];
+  t: ReturnType<typeof useTranslation>;
+  title: string;
+  summary: string;
+  expanded: boolean;
+  onExpandedChange: (open: boolean) => void;
+}
+
+export function LabelTabTextStyleControls({
+  state,
+  handlers,
+  t,
+  title,
+  summary,
+  expanded,
+  onExpandedChange,
+}: LabelTabTextStyleControlsProps) {
+  return (
+    <Collapsible
+      title={title}
+      summary={summary}
+      expanded={expanded}
+      onExpandedChange={onExpandedChange}
+      size="sm"
+    >
+      <div className="space-y-2">
+        {/* Mode picker */}
+        <div>
+          <span className="mb-1 block text-xs text-content-tertiary">
+            {t('binDesigner.textMode')}
+          </span>
+          <div role="group" aria-label={t('binDesigner.textMode')} className={SEGMENT_GROUP_CLASS}>
+            {MODE_OPTIONS.map((option) => (
+              <Button
+                key={option}
+                type="button"
+                variant="ghost"
+                touchTarget={false}
+                onClick={() => handlers.setTextMode(option)}
+                aria-pressed={state.textDefaults.mode === option}
+                className={`flex-1 ${getSegmentClass(state.textDefaults.mode === option)}`}
+              >
+                {t(`binDesigner.textMode.${option}`)}
+              </Button>
+            ))}
+          </div>
+          {state.textDefaults.mode === 'through-cut' && (
+            <p className="mt-1 flex items-start gap-1 text-xs text-content-tertiary">
+              <InfoIcon size="xs" className="mt-0.5 shrink-0" />
+              <span>{t('binDesigner.textMode.throughCutStencilNote')}</span>
+            </p>
+          )}
+        </div>
+
+        {/* Font + (conditional) depth, side by side when both visible */}
+        <div className="flex items-end gap-2">
+          <div className="min-w-0 flex-1">
+            <span className="mb-1 block text-xs text-content-tertiary">
+              {t('binDesigner.textFont')}
+            </span>
+            <Select
+              size="sm"
+              fullWidth
+              // Through-cut forces Allerta Stencil at render time; show
+              // that as the value so the disabled state isn't misleading.
+              // The user's font preference is preserved in
+              // `textDefaults.font` and restored on switching back.
+              value={
+                state.textDefaults.mode === 'through-cut'
+                  ? 'allerta-stencil'
+                  : state.textDefaults.font
+              }
+              onChange={(e) => handlers.setTextFont(e.target.value as TextFontFamily)}
+              disabled={state.textDefaults.mode === 'through-cut'}
+              aria-label={t('binDesigner.textFont')}
+              options={FONT_OPTIONS.map((f): SelectOption => ({
+                id: f,
+                name: t(`binDesigner.type.font.${f}`),
+              }))}
+            />
+          </div>
+          {state.textDefaults.mode !== 'through-cut' && (
+            <div className="min-w-0 flex-1">
+              <span className="mb-1 block text-xs text-content-tertiary">
+                {t('binDesigner.textDepth')}
+              </span>
+              <Stepper
+                value={state.textDefaults.depth}
+                onChange={handlers.setTextDepth}
+                onStep={(delta) =>
+                  handlers.setTextDepth(
+                    Math.min(
+                      TEXT_DEPTH_MAX,
+                      Math.max(TEXT_DEPTH_MIN, state.textDefaults.depth + delta * TEXT_DEPTH_STEP)
+                    )
+                  )
+                }
+                min={TEXT_DEPTH_MIN}
+                max={TEXT_DEPTH_MAX}
+                step={TEXT_DEPTH_STEP}
+                size="md"
+                aria-label={t('binDesigner.textDepth')}
+              />
+            </div>
+          )}
+        </div>
+        <LabelSizeControl
+          className="mt-3"
+          labelClassName="text-xs text-content-tertiary"
+          value={state.label.textStyle?.fontSizeOverride}
+          onChange={handlers.setTextSize}
+          min={state.textDefaults.minFontSize}
+          max={state.textDefaults.maxFontSize}
+          explainShared
+        />
+        <DependencyHint
+          reason={t('binDesigner.tabText.sharedTypeNote')}
+          actionLabel={t('binDesigner.tabText.editTypography')}
+          onAction={() => jumpToDesignerControl('bd-type')}
+        />
+      </div>
+    </Collapsible>
+  );
+}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -7,29 +7,18 @@
  * the text and little else.
  */
 
-import { CheckboxRow } from '@/design-system';
 import { useCallback, useState } from 'react';
 import { FeatureToggle } from '../FeatureToggle';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
-import { Button, Select, Stepper, InfoIcon, Collapsible } from '@/design-system';
-import { LabelSizeControl } from '../../controls';
-import type { SelectOption } from '@/design-system';
+import { Button, Stepper, InfoIcon, Collapsible } from '@/design-system';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
-import type {
-  LabelTabAlignment,
-  LabelTabEdges,
-  LabelTabSupport,
-  TextFontFamily,
-  TextMode,
-} from '../../../types';
+import type { LabelTabAlignment, LabelTabEdges } from '../../../types';
 import {
   LABEL_PLATE_FIT_OFFSET_MAX,
   LABEL_PLATE_FIT_OFFSET_MIN,
   LABEL_PLATE_FIT_OFFSET_STEP,
 } from '@/shared/constants/labelPlates';
 import type { LabelSocketStyle } from '@/shared/constants/labelPlates';
-import { jumpToDesignerControl } from '@/features/bin-designer/settingsManifest';
-import { DependencyHint } from '../shared';
 import { LabelTextList } from './LabelTextList';
 import { LabelSectionWarnings } from './LabelSectionWarnings';
 import { LabelColorControls } from './LabelColorControls';
@@ -38,26 +27,13 @@ import { LabelFitSampleButton } from './LabelFitSampleButton';
 import { useLabelTabsSection } from './useLabelTabsSection';
 import type { LabelWarningGroup } from './useLabelTabsSection';
 import type { LabelTabMode } from '../../../types';
+import { LabelTabShapeControls } from './LabelTabShapeControls';
+import { LabelTabTextStyleControls } from './LabelTabTextStyleControls';
 
 const ALIGNMENT_OPTIONS: LabelTabAlignment[] = ['left', 'center', 'right'];
-const SUPPORT_OPTIONS: LabelTabSupport[] = ['bracket', 'solid', 'fillet'];
 const EDGES_OPTIONS: LabelTabEdges[] = ['back', 'front', 'both'];
-const MODE_OPTIONS: TextMode[] = ['engrave', 'emboss', 'through-cut'];
 const TAB_MODE_OPTIONS: LabelTabMode[] = ['text', 'socket'];
 const SOCKET_STYLE_OPTIONS: readonly LabelSocketStyle[] = ['clickIn', 'slideChannel'];
-
-const FONT_OPTIONS: readonly TextFontFamily[] = [
-  'atkinson',
-  'jetbrains-mono',
-  'allerta-stencil',
-] as const;
-
-/** Per-mode bounds for the engrave/emboss depth stepper. Through-cut ignores
- *  `depth` (cuts through the full shelf), so the picker is hidden in that
- *  mode rather than disabled. */
-const TEXT_DEPTH_MIN = 0.2;
-const TEXT_DEPTH_MAX = 5;
-const TEXT_DEPTH_STEP = 0.1;
 
 /** Collapsible groups below the label text. Every one starts closed: the text
  *  IS the section, and these are how it gets shaped. */
@@ -391,315 +367,29 @@ export function LabelTabsSection() {
             </div>
           </Collapsible>
 
-          <Collapsible
+          <LabelTabShapeControls
+            state={state}
+            handlers={handlers}
+            t={t}
             title={groupTitles.shape}
             summary={dimensionsReadout}
             expanded={expandedGroups.has('shape')}
             onExpandedChange={(open) => setGroupExpanded('shape', open)}
-            size="sm"
             badge={warningBadge('shape')}
-          >
-            <div className="space-y-3">
-              {/* Support */}
-              <div>
-                <span className="mb-1 block text-label text-content-tertiary">
-                  {t('binDesigner.tabSupport')}
-                </span>
-                <div
-                  role="group"
-                  aria-label={t('binDesigner.tabSupport')}
-                  className={SEGMENT_GROUP_CLASS}
-                >
-                  {SUPPORT_OPTIONS.map((option) => (
-                    <Button
-                      key={option}
-                      type="button"
-                      variant="ghost"
-                      touchTarget={false}
-                      onClick={() => handlers.setTabSupport(option)}
-                      aria-pressed={state.label.support === option}
-                      className={`flex-1 ${getSegmentClass(state.label.support === option)}`}
-                    >
-                      {t(`binDesigner.tabSupport.${option}`)}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-2">
-                <div className="min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.tabWidth')}
-                  </span>
-                  <Stepper
-                    value={state.label.width}
-                    onChange={handlers.setTabWidth}
-                    onStep={(delta) =>
-                      handlers.setTabWidth(
-                        Math.min(
-                          DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
-                          Math.max(
-                            DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
-                            state.label.width + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP
-                          )
-                        )
-                      )
-                    }
-                    min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH}
-                    max={DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH}
-                    step={DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP}
-                    size="md"
-                    aria-label={t('binDesigner.labelTabs.widthAria')}
-                  />
-                </div>
-                <div className="min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.tabDepth')}
-                  </span>
-                  <Stepper
-                    value={state.label.depth}
-                    onChange={handlers.setTabDepth}
-                    onStep={(delta) =>
-                      handlers.setTabDepth(
-                        Math.min(
-                          state.tabDepthMax,
-                          Math.max(
-                            state.tabDepthMin,
-                            state.label.depth + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_DEPTH_STEP
-                          )
-                        )
-                      )
-                    }
-                    min={state.tabDepthMin}
-                    max={state.tabDepthMax}
-                    step={DESIGNER_CONSTRAINTS.LABEL_TAB_DEPTH_STEP}
-                    size="md"
-                    aria-label={t('binDesigner.labelTabs.depthAria')}
-                  />
-                </div>
-                <div className="min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.tabHeight')}
-                  </span>
-                  <Stepper
-                    value={state.tabHeightMm}
-                    onChange={handlers.setTabHeight}
-                    onStep={(delta) =>
-                      handlers.setTabHeight(
-                        Math.min(
-                          state.tabHeightMax,
-                          Math.max(
-                            state.tabHeightMin,
-                            state.tabHeightMm + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP
-                          )
-                        )
-                      )
-                    }
-                    min={state.tabHeightMin}
-                    max={state.tabHeightMax}
-                    step={DESIGNER_CONSTRAINTS.LABEL_TAB_HEIGHT_STEP}
-                    size="md"
-                    aria-label={t('binDesigner.labelTabs.heightAria')}
-                  />
-                </div>
-                <div className="min-w-0">
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.tabInset')}
-                  </span>
-                  <Stepper
-                    value={state.label.inset ?? 0}
-                    onChange={handlers.setTabInset}
-                    onStep={(delta) =>
-                      handlers.setTabInset(
-                        Math.min(
-                          state.tabInsetMax,
-                          Math.max(
-                            DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_INSET,
-                            (state.label.inset ?? 0) +
-                              delta * DESIGNER_CONSTRAINTS.LABEL_TAB_INSET_STEP
-                          )
-                        )
-                      )
-                    }
-                    min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_INSET}
-                    max={state.tabInsetMax}
-                    step={DESIGNER_CONSTRAINTS.LABEL_TAB_INSET_STEP}
-                    size="md"
-                    aria-label={t('binDesigner.labelTabs.insetAria')}
-                  />
-                </div>
-              </div>
-              {/* Label lip: raised rim to retain loose labels (#2971).
-                    Text-mode only — socket plates retain themselves. */}
-              {state.lipAvailable && (
-                <div className="mt-3 border-t border-border-subtle pt-3">
-                  <CheckboxRow
-                    label={t('binDesigner.tabLip')}
-                    checked={state.lipEnabled}
-                    onChange={handlers.toggleLabelLip}
-                  />
-                  <p className="mt-0.5 pl-7 text-label leading-snug text-content-tertiary">
-                    {t('binDesigner.tabLipHint')}
-                  </p>
-                  {state.lipEnabled && (
-                    <div className="mt-2 min-w-0 pl-7">
-                      <span className="mb-1 block text-xs text-content-tertiary">
-                        {t('binDesigner.tabLipHeight')}
-                      </span>
-                      <Stepper
-                        value={state.lipHeightMm}
-                        onChange={handlers.setLabelLipHeight}
-                        onStep={(delta) =>
-                          handlers.setLabelLipHeight(
-                            Math.min(
-                              state.lipMax,
-                              Math.max(state.lipMin, state.lipHeightMm + delta * state.lipStep)
-                            )
-                          )
-                        }
-                        min={state.lipMin}
-                        max={state.lipMax}
-                        step={state.lipStep}
-                        size="md"
-                        aria-label={t('binDesigner.labelTabs.lipHeightAria')}
-                      />
-                    </div>
-                  )}
-                  {state.lipWontFit && (
-                    <div className="mt-1 flex items-start gap-2 pl-7 text-xs text-warning">
-                      <InfoIcon size="xs" className="mt-0.5 shrink-0" />
-                      <span className="flex-1">{t('binDesigner.tabLipTooTallWarning')}</span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        touchTarget={false}
-                        onClick={handlers.autoFixLip}
-                        className="shrink-0 px-0 font-medium text-accent hover:bg-transparent hover:text-accent/80"
-                      >
-                        {t('binDesigner.tabAutoFix')}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          </Collapsible>
+          />
 
           {/* Engraving styles the printed-in text; irrelevant when the tab
               face carries a socket instead. */}
           {!state.isSocketMode && (
-            <Collapsible
+            <LabelTabTextStyleControls
+              state={state}
+              handlers={handlers}
+              t={t}
               title={groupTitles.text}
               summary={textStyleReadout}
               expanded={expandedGroups.has('text')}
               onExpandedChange={(open) => setGroupExpanded('text', open)}
-              size="sm"
-            >
-              <div className="space-y-2">
-                {/* Mode picker */}
-                <div>
-                  <span className="mb-1 block text-xs text-content-tertiary">
-                    {t('binDesigner.textMode')}
-                  </span>
-                  <div
-                    role="group"
-                    aria-label={t('binDesigner.textMode')}
-                    className={SEGMENT_GROUP_CLASS}
-                  >
-                    {MODE_OPTIONS.map((option) => (
-                      <Button
-                        key={option}
-                        type="button"
-                        variant="ghost"
-                        touchTarget={false}
-                        onClick={() => handlers.setTextMode(option)}
-                        aria-pressed={state.textDefaults.mode === option}
-                        className={`flex-1 ${getSegmentClass(state.textDefaults.mode === option)}`}
-                      >
-                        {t(`binDesigner.textMode.${option}`)}
-                      </Button>
-                    ))}
-                  </div>
-                  {state.textDefaults.mode === 'through-cut' && (
-                    <p className="mt-1 flex items-start gap-1 text-xs text-content-tertiary">
-                      <InfoIcon size="xs" className="mt-0.5 shrink-0" />
-                      <span>{t('binDesigner.textMode.throughCutStencilNote')}</span>
-                    </p>
-                  )}
-                </div>
-
-                {/* Font + (conditional) depth, side by side when both visible */}
-                <div className="flex items-end gap-2">
-                  <div className="min-w-0 flex-1">
-                    <span className="mb-1 block text-xs text-content-tertiary">
-                      {t('binDesigner.textFont')}
-                    </span>
-                    <Select
-                      size="sm"
-                      fullWidth
-                      // Through-cut forces Allerta Stencil at render time; show
-                      // that as the value so the disabled state isn't misleading.
-                      // The user's font preference is preserved in
-                      // `textDefaults.font` and restored on switching back.
-                      value={
-                        state.textDefaults.mode === 'through-cut'
-                          ? 'allerta-stencil'
-                          : state.textDefaults.font
-                      }
-                      onChange={(e) => handlers.setTextFont(e.target.value as TextFontFamily)}
-                      disabled={state.textDefaults.mode === 'through-cut'}
-                      aria-label={t('binDesigner.textFont')}
-                      options={FONT_OPTIONS.map((f): SelectOption => ({
-                        id: f,
-                        name: t(`binDesigner.type.font.${f}`),
-                      }))}
-                    />
-                  </div>
-                  {state.textDefaults.mode !== 'through-cut' && (
-                    <div className="min-w-0 flex-1">
-                      <span className="mb-1 block text-xs text-content-tertiary">
-                        {t('binDesigner.textDepth')}
-                      </span>
-                      <Stepper
-                        value={state.textDefaults.depth}
-                        onChange={handlers.setTextDepth}
-                        onStep={(delta) =>
-                          handlers.setTextDepth(
-                            Math.min(
-                              TEXT_DEPTH_MAX,
-                              Math.max(
-                                TEXT_DEPTH_MIN,
-                                state.textDefaults.depth + delta * TEXT_DEPTH_STEP
-                              )
-                            )
-                          )
-                        }
-                        min={TEXT_DEPTH_MIN}
-                        max={TEXT_DEPTH_MAX}
-                        step={TEXT_DEPTH_STEP}
-                        size="md"
-                        aria-label={t('binDesigner.textDepth')}
-                      />
-                    </div>
-                  )}
-                </div>
-                <LabelSizeControl
-                  className="mt-3"
-                  labelClassName="text-xs text-content-tertiary"
-                  value={state.label.textStyle?.fontSizeOverride}
-                  onChange={handlers.setTextSize}
-                  min={state.textDefaults.minFontSize}
-                  max={state.textDefaults.maxFontSize}
-                  explainShared
-                />
-                <DependencyHint
-                  reason={t('binDesigner.tabText.sharedTypeNote')}
-                  actionLabel={t('binDesigner.tabText.editTypography')}
-                  onAction={() => jumpToDesignerControl('bd-type')}
-                />
-              </div>
-            </Collapsible>
+            />
           )}
 
           <Collapsible

--- a/src/features/bin-designer/components/panel/LidSection/LidAdvancedFields.test.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidAdvancedFields.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LidAdvancedFields } from './LidAdvancedFields';
+import { useLidSection } from './useLidSection';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+
+function Harness() {
+  const { state, handlers, t } = useLidSection();
+  return <LidAdvancedFields state={state} handlers={handlers} t={t} />;
+}
+
+function seed(lid: Partial<typeof DEFAULT_BIN_PARAMS.lid> = {}) {
+  useDesignerStore.setState({
+    params: { ...DEFAULT_BIN_PARAMS, lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true, ...lid } },
+    ui: { ...DEFAULT_UI_STATE },
+  });
+}
+
+describe('LidAdvancedFields', () => {
+  beforeEach(() => {
+    seed();
+  });
+
+  it('reveals the plate thickness and seam relief behind the fine-tuning disclosure', () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: /fine tuning/i }));
+    expect(screen.getByLabelText('Lid top plate thickness in millimeters')).toBeInTheDocument();
+    expect(screen.getByText('Relieve interior at the lid seam')).toBeInTheDocument();
+  });
+
+  it('shows the magnet fields only for a magnetic lid', () => {
+    const { unmount } = render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: /fine tuning/i }));
+    expect(screen.queryByLabelText('Retention magnet diameter in millimeters')).toBeNull();
+    unmount();
+
+    seed({ attachment: 'magnetic' });
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: /fine tuning/i }));
+    expect(screen.getByLabelText('Retention magnet diameter in millimeters')).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/LidSection/LidAdvancedFields.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidAdvancedFields.tsx
@@ -1,0 +1,270 @@
+/** The lid's millimetre fine-tuning disclosure: plate thickness, mode-specific clearances, seam relief, tray dims. */
+
+import { useState } from 'react';
+import { Collapsible } from '@/design-system';
+import { SnappingSlider } from '../../controls/SnappingSlider';
+import { StepperField } from '../shared/StepperField';
+import { Hint, Readout } from '../shared';
+import type { useTranslation } from '@/i18n';
+import { FeatureToggle } from '../FeatureToggle';
+import type { useLidSection } from './useLidSection';
+
+type Translator = ReturnType<typeof useTranslation>;
+
+export function LidAdvancedFields({
+  state,
+  handlers,
+  t,
+}: {
+  state: ReturnType<typeof useLidSection>['state'];
+  handlers: ReturnType<typeof useLidSection>['handlers'];
+  t: Translator;
+}) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Which mode-specific knobs the Advanced disclosure holds depends on the
+  // current mode; the floor-plate thickness applies to every lid, so the
+  // disclosure is always present now and never renders empty.
+  const showMagnetAdvanced = state.attachment === 'magnetic';
+  const showCoverageAdvanced = state.attachment === 'clickRails' && state.anyRail;
+  // A sliding lid has no top surface to recess, no cavity to deepen and no seam
+  // to relieve, so those three sections are hidden rather than shown inert. The
+  // stored values survive — `resolveLidInputs` forces the geometry off without
+  // touching the config — so switching attachment back restores them.
+  const showTrayAdvanced = state.topSurface === 'tray' && !state.isSlide;
+
+  // On a tray lid the geometry holds the floor at LID_TRAY_FLOOR even if the
+  // design stored something thinner, so the field reads back from the resolver
+  // rather than the raw param — otherwise it would sit directly above the
+  // breakdown showing a number the part does not use.
+  const shownThickness = state.trayBreakdown ? state.trayBreakdown.floorMm : state.topThicknessMm;
+
+  return (
+    <Collapsible
+      title={t('binDesigner.lid.advanced')}
+      size="sm"
+      expanded={advancedOpen}
+      onExpandedChange={setAdvancedOpen}
+    >
+      <div className="space-y-3 pt-2">
+        <div className="space-y-1">
+          <StepperField
+            label={
+              state.trayBreakdown
+                ? t('binDesigner.lid.trayFloorThickness')
+                : t('binDesigner.lid.topThickness')
+            }
+            unit="mm"
+            value={shownThickness}
+            onChange={handlers.setTopThickness}
+            // Step from the SHOWN value, not the stored one. They differ
+            // on a tray lid whose design stored less than the geometry
+            // uses, and stepping from the stored value made the first
+            // click compute a number that clamped straight back to what
+            // was already displayed — a control that looked dead.
+            onStep={(delta) =>
+              handlers.setTopThickness(shownThickness + delta * state.topThicknessStep)
+            }
+            min={state.topThicknessMin}
+            max={state.topThicknessMax}
+            step={state.topThicknessStep}
+            size="md"
+            aria-label={
+              state.trayBreakdown
+                ? t('binDesigner.lid.trayFloorThicknessAria')
+                : t('binDesigner.lid.topThicknessAria')
+            }
+            commitMode="deferred"
+          />
+          {/* A tray splits the plate into recess + floor, and the field
+              sets the floor — without the arithmetic spelled out, the
+              overall thickness looks unrelated to what was typed (#3072). */}
+          {state.trayBreakdown && (
+            <dl className="text-content-tertiary space-y-0.5 text-xs">
+              <div className="flex justify-between gap-2">
+                <dt>{t('binDesigner.lid.trayBreakdownRecess')}</dt>
+                <dd className="tabular-nums">{state.trayBreakdown.recessMm.toFixed(1)} mm</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt>{t('binDesigner.lid.trayBreakdownFloor')}</dt>
+                <dd className="tabular-nums">{state.trayBreakdown.floorMm.toFixed(1)} mm</dd>
+              </div>
+              <div className="text-content-secondary flex justify-between gap-2 font-medium">
+                <dt>{t('binDesigner.lid.trayBreakdownOverall')}</dt>
+                <dd className="tabular-nums">{state.trayBreakdown.overallMm.toFixed(1)} mm</dd>
+              </div>
+            </dl>
+          )}
+          <Hint>
+            {state.trayBreakdown
+              ? t('binDesigner.lid.trayFloorThicknessHint')
+              : state.topThicknessEffective > state.topThicknessMm
+                ? t('binDesigner.lid.topThicknessRaisedHint', {
+                    thickness: state.topThicknessEffective.toFixed(1),
+                  })
+                : t('binDesigner.lid.topThicknessHint')}
+          </Hint>
+        </div>
+
+        {state.isHinge && (
+          <div className="space-y-1">
+            <StepperField
+              label={t('binDesigner.lid.hinge.fitClearance')}
+              unit="mm"
+              value={state.hinge.fitClearanceMm}
+              onChange={handlers.setHingeFit}
+              onStep={(delta) =>
+                handlers.setHingeFit(state.hinge.fitClearanceMm + delta * state.hingeFitStep)
+              }
+              min={state.hingeFitMin}
+              max={state.hingeFitMax}
+              step={state.hingeFitStep}
+              size="md"
+              aria-label={t('binDesigner.lid.hinge.fitClearanceAria')}
+              commitMode="deferred"
+            />
+            <Hint>{t('binDesigner.lid.hinge.fitClearanceHint')}</Hint>
+          </div>
+        )}
+
+        {state.isSlide && (
+          <div className="space-y-1">
+            <StepperField
+              label={t('binDesigner.lid.slide.clearance')}
+              unit="mm"
+              value={state.slide.clearanceMm}
+              onChange={handlers.setSlideClearance}
+              onStep={(delta) =>
+                handlers.setSlideClearance(
+                  state.slide.clearanceMm + delta * state.slideClearanceStep
+                )
+              }
+              min={state.slideClearanceMin}
+              max={state.slideClearanceMax}
+              step={state.slideClearanceStep}
+              size="md"
+              aria-label={t('binDesigner.lid.slide.clearanceAria')}
+              commitMode="deferred"
+            />
+            <Hint>{t('binDesigner.lid.slide.clearanceHint')}</Hint>
+          </div>
+        )}
+
+        {showMagnetAdvanced && (
+          <div className="space-y-2">
+            <StepperField
+              label={t('binDesigner.lid.retentionMagnetDiameter')}
+              unit="mm"
+              value={state.retentionMagnetDiameter}
+              onChange={handlers.setRetentionMagnetDiameter}
+              onStep={(delta) =>
+                handlers.setRetentionMagnetDiameter(
+                  state.retentionMagnetDiameter + delta * state.retentionMagnetStep
+                )
+              }
+              min={state.retentionMagnetDiameterMin}
+              max={state.retentionMagnetDiameterMax}
+              step={state.retentionMagnetStep}
+              size="md"
+              aria-label={t('binDesigner.lid.retentionMagnetDiameterAria')}
+              commitMode="deferred"
+            />
+            <StepperField
+              label={t('binDesigner.lid.retentionMagnetDepth')}
+              unit="mm"
+              value={state.retentionMagnetDepth}
+              onChange={handlers.setRetentionMagnetDepth}
+              onStep={(delta) =>
+                handlers.setRetentionMagnetDepth(
+                  state.retentionMagnetDepth + delta * state.retentionMagnetStep
+                )
+              }
+              min={state.retentionMagnetDepthMin}
+              max={state.retentionMagnetDepthMax}
+              step={state.retentionMagnetStep}
+              size="md"
+              aria-label={t('binDesigner.lid.retentionMagnetDepthAria')}
+              commitMode="deferred"
+            />
+            <div className="space-y-1">
+              <StepperField
+                label={t('binDesigner.lid.retentionEdgeMagnets')}
+                value={state.retentionMagnetEdgeMagnets}
+                onChange={handlers.setRetentionMagnetEdgeMagnets}
+                onStep={(delta) =>
+                  handlers.setRetentionMagnetEdgeMagnets(
+                    state.retentionMagnetEdgeMagnets + delta * state.retentionMagnetEdgeStep
+                  )
+                }
+                min={state.retentionMagnetEdgeMin}
+                max={state.retentionMagnetEdgeMax}
+                step={state.retentionMagnetEdgeStep}
+                size="md"
+                aria-label={t('binDesigner.lid.retentionEdgeMagnetsAria')}
+                commitMode="deferred"
+              />
+              <Hint>{t('binDesigner.lid.retentionEdgeMagnetsHint')}</Hint>
+            </div>
+          </div>
+        )}
+
+        {showCoverageAdvanced && (
+          <div className="space-y-1">
+            <SnappingSlider
+              label={t('binDesigner.lid.clickRailCoverage')}
+              value={state.clickRailCoverage}
+              onChange={handlers.setClickRailCoverage}
+              options={state.railCoverageOptions}
+              unit="%"
+            />
+            <Readout>{state.railsReadout}</Readout>
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <FeatureToggle
+            label={t('binDesigner.lid.relieveInterior')}
+            checked={state.relieveInterior}
+            onChange={handlers.toggleRelieveInterior}
+          />
+          <Hint>
+            {state.relieveInterior
+              ? t('binDesigner.lid.relieveInteriorHint')
+              : t('binDesigner.lid.relieveInteriorOffHint')}
+          </Hint>
+        </div>
+
+        {showTrayAdvanced && (
+          <div className="space-y-2">
+            <StepperField
+              label={t('binDesigner.lid.trayDepth')}
+              unit="mm"
+              value={state.tray.depthMm}
+              onChange={handlers.setTrayDepth}
+              onStep={(delta) => handlers.setTrayDepth(state.tray.depthMm + delta * state.trayStep)}
+              min={state.trayDepthMin}
+              max={state.trayDepthMax}
+              step={state.trayStep}
+              size="md"
+              aria-label={t('binDesigner.lid.trayDepthAria')}
+              commitMode="deferred"
+            />
+            <StepperField
+              label={t('binDesigner.lid.trayWall')}
+              unit="mm"
+              value={state.tray.wallMm}
+              onChange={handlers.setTrayWall}
+              onStep={(delta) => handlers.setTrayWall(state.tray.wallMm + delta * state.trayStep)}
+              min={state.trayWallMin}
+              max={state.trayWallMax}
+              step={state.trayStep}
+              size="md"
+              aria-label={t('binDesigner.lid.trayWallAria')}
+              commitMode="deferred"
+            />
+          </div>
+        )}
+      </div>
+    </Collapsible>
+  );
+}

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -16,9 +16,7 @@
  * nothing, so `topThicknessMm` is a user knob.
  */
 
-import { useState } from 'react';
-import { Button, SegmentedControl, Collapsible } from '@/design-system';
-import { SnappingSlider } from '../../controls/SnappingSlider';
+import { Button, SegmentedControl } from '@/design-system';
 import { LidGripControls } from '../LidGripControls';
 import { SlideControls } from '../SlideControls';
 import { HingeControls } from '../HingeControls';
@@ -43,6 +41,7 @@ import type { useTranslation } from '@/i18n';
 import { CompartmentTextInput } from '../LabelTabsSection/CompartmentTextInput';
 import { FeatureToggle } from '../FeatureToggle';
 import { useLidSection, LID_TOP_SURFACES } from './useLidSection';
+import { LidAdvancedFields } from './LidAdvancedFields';
 
 /** Mode options for the lid-text picker, in the shared textMode order. */
 const TEXT_MODE_OPTIONS: readonly TextMode[] = ['engrave', 'emboss', 'through-cut'] as const;
@@ -135,24 +134,6 @@ function RailSides({
 
 export function LidSection() {
   const { state, handlers, t } = useLidSection();
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-
-  // Which mode-specific knobs the Advanced disclosure holds depends on the
-  // current mode; the floor-plate thickness applies to every lid, so the
-  // disclosure is always present now and never renders empty.
-  const showMagnetAdvanced = state.attachment === 'magnetic';
-  const showCoverageAdvanced = state.attachment === 'clickRails' && state.anyRail;
-  // A sliding lid has no top surface to recess, no cavity to deepen and no seam
-  // to relieve, so those three sections are hidden rather than shown inert. The
-  // stored values survive — `resolveLidInputs` forces the geometry off without
-  // touching the config — so switching attachment back restores them.
-  const showTrayAdvanced = state.topSurface === 'tray' && !state.isSlide;
-
-  // On a tray lid the geometry holds the floor at LID_TRAY_FLOOR even if the
-  // design stored something thinner, so the field reads back from the resolver
-  // rather than the raw param — otherwise it would sit directly above the
-  // breakdown showing a number the part does not use.
-  const shownThickness = state.trayBreakdown ? state.trayBreakdown.floorMm : state.topThicknessMm;
 
   return (
     <div className="space-y-4">
@@ -409,238 +390,7 @@ export function LidSection() {
           </div>
 
           {/* ── Advanced (millimetre fine-tuning) ────────────────────── */}
-          <Collapsible
-            title={t('binDesigner.lid.advanced')}
-            size="sm"
-            expanded={advancedOpen}
-            onExpandedChange={setAdvancedOpen}
-          >
-            <div className="space-y-3 pt-2">
-              <div className="space-y-1">
-                <StepperField
-                  label={
-                    state.trayBreakdown
-                      ? t('binDesigner.lid.trayFloorThickness')
-                      : t('binDesigner.lid.topThickness')
-                  }
-                  unit="mm"
-                  value={shownThickness}
-                  onChange={handlers.setTopThickness}
-                  // Step from the SHOWN value, not the stored one. They differ
-                  // on a tray lid whose design stored less than the geometry
-                  // uses, and stepping from the stored value made the first
-                  // click compute a number that clamped straight back to what
-                  // was already displayed — a control that looked dead.
-                  onStep={(delta) =>
-                    handlers.setTopThickness(shownThickness + delta * state.topThicknessStep)
-                  }
-                  min={state.topThicknessMin}
-                  max={state.topThicknessMax}
-                  step={state.topThicknessStep}
-                  size="md"
-                  aria-label={
-                    state.trayBreakdown
-                      ? t('binDesigner.lid.trayFloorThicknessAria')
-                      : t('binDesigner.lid.topThicknessAria')
-                  }
-                  commitMode="deferred"
-                />
-                {/* A tray splits the plate into recess + floor, and the field
-                    sets the floor — without the arithmetic spelled out, the
-                    overall thickness looks unrelated to what was typed (#3072). */}
-                {state.trayBreakdown && (
-                  <dl className="text-content-tertiary space-y-0.5 text-xs">
-                    <div className="flex justify-between gap-2">
-                      <dt>{t('binDesigner.lid.trayBreakdownRecess')}</dt>
-                      <dd className="tabular-nums">{state.trayBreakdown.recessMm.toFixed(1)} mm</dd>
-                    </div>
-                    <div className="flex justify-between gap-2">
-                      <dt>{t('binDesigner.lid.trayBreakdownFloor')}</dt>
-                      <dd className="tabular-nums">{state.trayBreakdown.floorMm.toFixed(1)} mm</dd>
-                    </div>
-                    <div className="text-content-secondary flex justify-between gap-2 font-medium">
-                      <dt>{t('binDesigner.lid.trayBreakdownOverall')}</dt>
-                      <dd className="tabular-nums">
-                        {state.trayBreakdown.overallMm.toFixed(1)} mm
-                      </dd>
-                    </div>
-                  </dl>
-                )}
-                <Hint>
-                  {state.trayBreakdown
-                    ? t('binDesigner.lid.trayFloorThicknessHint')
-                    : state.topThicknessEffective > state.topThicknessMm
-                      ? t('binDesigner.lid.topThicknessRaisedHint', {
-                          thickness: state.topThicknessEffective.toFixed(1),
-                        })
-                      : t('binDesigner.lid.topThicknessHint')}
-                </Hint>
-              </div>
-
-              {state.isHinge && (
-                <div className="space-y-1">
-                  <StepperField
-                    label={t('binDesigner.lid.hinge.fitClearance')}
-                    unit="mm"
-                    value={state.hinge.fitClearanceMm}
-                    onChange={handlers.setHingeFit}
-                    onStep={(delta) =>
-                      handlers.setHingeFit(state.hinge.fitClearanceMm + delta * state.hingeFitStep)
-                    }
-                    min={state.hingeFitMin}
-                    max={state.hingeFitMax}
-                    step={state.hingeFitStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.hinge.fitClearanceAria')}
-                    commitMode="deferred"
-                  />
-                  <Hint>{t('binDesigner.lid.hinge.fitClearanceHint')}</Hint>
-                </div>
-              )}
-
-              {state.isSlide && (
-                <div className="space-y-1">
-                  <StepperField
-                    label={t('binDesigner.lid.slide.clearance')}
-                    unit="mm"
-                    value={state.slide.clearanceMm}
-                    onChange={handlers.setSlideClearance}
-                    onStep={(delta) =>
-                      handlers.setSlideClearance(
-                        state.slide.clearanceMm + delta * state.slideClearanceStep
-                      )
-                    }
-                    min={state.slideClearanceMin}
-                    max={state.slideClearanceMax}
-                    step={state.slideClearanceStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.slide.clearanceAria')}
-                    commitMode="deferred"
-                  />
-                  <Hint>{t('binDesigner.lid.slide.clearanceHint')}</Hint>
-                </div>
-              )}
-
-              {showMagnetAdvanced && (
-                <div className="space-y-2">
-                  <StepperField
-                    label={t('binDesigner.lid.retentionMagnetDiameter')}
-                    unit="mm"
-                    value={state.retentionMagnetDiameter}
-                    onChange={handlers.setRetentionMagnetDiameter}
-                    onStep={(delta) =>
-                      handlers.setRetentionMagnetDiameter(
-                        state.retentionMagnetDiameter + delta * state.retentionMagnetStep
-                      )
-                    }
-                    min={state.retentionMagnetDiameterMin}
-                    max={state.retentionMagnetDiameterMax}
-                    step={state.retentionMagnetStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.retentionMagnetDiameterAria')}
-                    commitMode="deferred"
-                  />
-                  <StepperField
-                    label={t('binDesigner.lid.retentionMagnetDepth')}
-                    unit="mm"
-                    value={state.retentionMagnetDepth}
-                    onChange={handlers.setRetentionMagnetDepth}
-                    onStep={(delta) =>
-                      handlers.setRetentionMagnetDepth(
-                        state.retentionMagnetDepth + delta * state.retentionMagnetStep
-                      )
-                    }
-                    min={state.retentionMagnetDepthMin}
-                    max={state.retentionMagnetDepthMax}
-                    step={state.retentionMagnetStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.retentionMagnetDepthAria')}
-                    commitMode="deferred"
-                  />
-                  <div className="space-y-1">
-                    <StepperField
-                      label={t('binDesigner.lid.retentionEdgeMagnets')}
-                      value={state.retentionMagnetEdgeMagnets}
-                      onChange={handlers.setRetentionMagnetEdgeMagnets}
-                      onStep={(delta) =>
-                        handlers.setRetentionMagnetEdgeMagnets(
-                          state.retentionMagnetEdgeMagnets + delta * state.retentionMagnetEdgeStep
-                        )
-                      }
-                      min={state.retentionMagnetEdgeMin}
-                      max={state.retentionMagnetEdgeMax}
-                      step={state.retentionMagnetEdgeStep}
-                      size="md"
-                      aria-label={t('binDesigner.lid.retentionEdgeMagnetsAria')}
-                      commitMode="deferred"
-                    />
-                    <Hint>{t('binDesigner.lid.retentionEdgeMagnetsHint')}</Hint>
-                  </div>
-                </div>
-              )}
-
-              {showCoverageAdvanced && (
-                <div className="space-y-1">
-                  <SnappingSlider
-                    label={t('binDesigner.lid.clickRailCoverage')}
-                    value={state.clickRailCoverage}
-                    onChange={handlers.setClickRailCoverage}
-                    options={state.railCoverageOptions}
-                    unit="%"
-                  />
-                  <Readout>{state.railsReadout}</Readout>
-                </div>
-              )}
-
-              <div className="space-y-1">
-                <FeatureToggle
-                  label={t('binDesigner.lid.relieveInterior')}
-                  checked={state.relieveInterior}
-                  onChange={handlers.toggleRelieveInterior}
-                />
-                <Hint>
-                  {state.relieveInterior
-                    ? t('binDesigner.lid.relieveInteriorHint')
-                    : t('binDesigner.lid.relieveInteriorOffHint')}
-                </Hint>
-              </div>
-
-              {showTrayAdvanced && (
-                <div className="space-y-2">
-                  <StepperField
-                    label={t('binDesigner.lid.trayDepth')}
-                    unit="mm"
-                    value={state.tray.depthMm}
-                    onChange={handlers.setTrayDepth}
-                    onStep={(delta) =>
-                      handlers.setTrayDepth(state.tray.depthMm + delta * state.trayStep)
-                    }
-                    min={state.trayDepthMin}
-                    max={state.trayDepthMax}
-                    step={state.trayStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.trayDepthAria')}
-                    commitMode="deferred"
-                  />
-                  <StepperField
-                    label={t('binDesigner.lid.trayWall')}
-                    unit="mm"
-                    value={state.tray.wallMm}
-                    onChange={handlers.setTrayWall}
-                    onStep={(delta) =>
-                      handlers.setTrayWall(state.tray.wallMm + delta * state.trayStep)
-                    }
-                    min={state.trayWallMin}
-                    max={state.trayWallMax}
-                    step={state.trayStep}
-                    size="md"
-                    aria-label={t('binDesigner.lid.trayWallAria')}
-                    commitMode="deferred"
-                  />
-                </div>
-              )}
-            </div>
-          </Collapsible>
+          <LidAdvancedFields state={state} handlers={handlers} t={t} />
 
           <section
             data-help-target="bd-lid-grip"


### PR DESCRIPTION
Ninth batch of the `max-lines` sweep: the two designer panel sections that had grown past the limit. Each hands a collapsed group to a sibling component that takes the section hook's `state`, `handlers` and `t`, the same shape `LidGripControls` already uses, so the markup moves verbatim and the hooks are untouched.

**`LidSection.tsx`** (593 code lines, now 370)

- `LidAdvancedFields.tsx` takes the fine-tuning disclosure: plate thickness with the tray breakdown, hinge and slide clearances, magnet fields, click-rail coverage, seam relief and tray dimensions. The disclosure's open state and the four mode-derived flags it reads move with it.

**`LabelTabsSection.tsx`** (654, now 361)

- `LabelTabShapeControls.tsx` takes the "tab shape & size" group: support style, the four dimension steppers and the label lip.
- `LabelTabTextStyleControls.tsx` takes the "engraved text" group: finish, font, depth and the shared size control.
- Both receive the collapsible's title, summary, expansion state and badge as props, so the section still owns which group is open and how a warning jumps to it. The option tables and depth bounds each group alone used move with it.

**Tests**

- Each new component gets a sibling test that renders it through the real section hook against a seeded designer store: the lid fields reveal the thickness field and show the magnet fields only for a magnetic lid; the shape group writes the chosen support to the design; the text group writes the chosen finish to the text defaults.

**Verification**

- Typecheck, ESLint and the pre-commit gates pass.
- Vitest over both section folders: 13 files, 209 tests.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

