### PR TITLE
docs(generators): drop a dangling link and two stray comments from the split modules

### DIFF
--- a/src/features/baseplate/utils/splitMargins.ts
+++ b/src/features/baseplate/utils/splitMargins.ts
@@ -28,7 +28,8 @@ interface MarginLayout {
  * corners, extending over any perpendicular padding so they reach the true outer
  * corner); the perpendicular pair runs `short`, fitting between — and a short
  * end segment claims a corner only when its perpendicular long side is absent.
- * A side detaches only when its padding ≥ {@link MARGIN_MIN_DETACH_MM}.
+ * A side detaches only when its padding reaches `MARGIN_MIN_DETACH_MM` from
+ * `@/core/baseplateDefaults`.
  *
  * World positions are in the plate-centered, padding-free body frame (mm) so they
  * line up with how the preview/export place the body pieces.

--- a/src/features/generation/worker/generators/compartmentCavities.ts
+++ b/src/features/generation/worker/generators/compartmentCavities.ts
@@ -10,8 +10,6 @@ import { buildOverrideLookup, overrideKey } from '@/shared/types/bin';
 
 import { BOX_CORNER_RADIUS } from './generatorConstants';
 
-// Re-export for backwards compatibility with existing imports
-
 interface CavityCorners {
   bl: [number, number];
   br: [number, number];

--- a/src/features/generation/worker/generators/compartmentDividerSegments.ts
+++ b/src/features/generation/worker/generators/compartmentDividerSegments.ts
@@ -15,8 +15,6 @@ import {
 
 import { sketch } from './meshUtils';
 
-// Re-export for backwards compatibility with existing imports
-
 /** One divider wall segment: its top line, how far its foot leans off that
  *  line, and the interior it gets clipped to. */
 interface WallSegmentPlan {


### PR DESCRIPTION
Follow-up to the review of #4200.

- `splitMargins.ts`: the docblock linked `MARGIN_MIN_DETACH_MM`, which the module no longer imports; it now names the constant and where it lives in plain text.
- `compartmentCavities.ts`, `compartmentDividerSegments.ts`: a comment about re-exports travelled with the import header but described a statement that stayed behind. Removed.

Comments only; typecheck, ESLint and the pre-commit gates pass.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

