### PR TITLE
refactor: finish the max-lines sweep with the detail dialog hook and three exemptions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,25 +1,41 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import jsxA11y from 'eslint-plugin-jsx-a11y'
-import { fixupPluginRules } from '@eslint/compat'
-import i18next from 'eslint-plugin-i18next'
-import boundaries from 'eslint-plugin-boundaries'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
-import noInitTimeImportedCall from './eslint-rules/no-init-time-imported-call.js'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import { fixupPluginRules } from '@eslint/compat';
+import i18next from 'eslint-plugin-i18next';
+import boundaries from 'eslint-plugin-boundaries';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import noInitTimeImportedCall from './eslint-rules/no-init-time-imported-call.js';
 
 // i18next@6.1.5 anchors each words.exclude entry as a raw `^…$` regex source, so
 // literal metacharacters (+, ., $, ~) must be escaped to match the intended text
 // and to avoid crashing the linter on bare quantifiers like "+".
-const literal = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const literal = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export default defineConfig([
   // `.worktrees` / `.claude/worktrees` hold git worktrees — each is a full copy
   // of the repo. Both are gitignored, but flat config does not read .gitignore,
   // so without these `eslint .` type-checks every checkout at once and OOMs.
-  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'brep-parts', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx', 'src/test/setup.ts', '.worktrees', '.claude/worktrees']),
+  globalIgnores([
+    'dist',
+    'coverage',
+    'e2e',
+    'scripts',
+    'benchmarks',
+    'reports',
+    'brep-parts',
+    'playwright.config.ts',
+    'playwright.smoke.config.ts',
+    'playwright-ct.config.ts',
+    'playwright',
+    '**/*.visual.tsx',
+    'src/test/setup.ts',
+    '.worktrees',
+    '.claude/worktrees',
+  ]),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -52,31 +68,46 @@ export default defineConfig([
       'local/no-init-time-imported-call': 'error',
       // TypeScript strict rules
       '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-      }],
-      '@typescript-eslint/consistent-type-imports': ['error', {
-        prefer: 'type-imports',
-        fixStyle: 'separate-type-imports',
-      }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'separate-type-imports',
+        },
+      ],
       '@typescript-eslint/no-non-null-assertion': 'error',
 
       // Pragmatic type-checked rule tuning
-      '@typescript-eslint/restrict-template-expressions': ['error', {
-        allowNumber: true,
-        allowBoolean: true,
-      }],
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+          allowNumber: true,
+          allowBoolean: true,
+        },
+      ],
       '@typescript-eslint/no-confusing-void-expression': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'error',
       '@typescript-eslint/no-deprecated': 'warn',
-      '@typescript-eslint/no-misused-promises': ['error', {
-        checksVoidReturn: { attributes: false },
-      }],
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        {
+          checksVoidReturn: { attributes: false },
+        },
+      ],
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-      '@typescript-eslint/restrict-plus-operands': ['error', {
-        allowNumberAndString: true,
-      }],
+      '@typescript-eslint/restrict-plus-operands': [
+        'error',
+        {
+          allowNumberAndString: true,
+        },
+      ],
       '@typescript-eslint/no-unsafe-assignment': 'warn',
       '@typescript-eslint/no-unsafe-member-access': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
@@ -106,7 +137,7 @@ export default defineConfig([
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prefer-const': 'error',
       'no-var': 'error',
-      'eqeqeq': ['error', 'always'],
+      eqeqeq: ['error', 'always'],
       'max-lines': ['warn', { max: 500, skipBlankLines: true, skipComments: true }],
 
       // Force every lazy() through lazyWithRetry so chunk-load failures on
@@ -115,57 +146,120 @@ export default defineConfig([
       //   - `import { lazy } from 'react'` → no-restricted-imports (resolves
       //     through module graph, won't false-flag a locally-named `lazy`).
       //   - `React.lazy(...)` member call → no-restricted-syntax.
-      'no-restricted-imports': ['error', {
-        paths: [{
-          name: 'react',
-          importNames: ['lazy'],
-          message: 'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
-        }],
-      }],
-      'no-restricted-syntax': ['error', {
-        selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="lazy"][callee.object.name="React"]',
-        message: 'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
-      }],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['lazy'],
+              message:
+                'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="lazy"][callee.object.name="React"]',
+          message:
+            'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
+        },
+      ],
 
       // i18n: Enforce localization of user-facing strings
-      'i18next/no-literal-string': ['error', {
-        mode: 'jsx-only',
-        'jsx-attributes': {
-          include: ['title', 'aria-label', 'placeholder', 'alt'],
+      'i18next/no-literal-string': [
+        'error',
+        {
+          mode: 'jsx-only',
+          'jsx-attributes': {
+            include: ['title', 'aria-label', 'placeholder', 'alt'],
+          },
+          'jsx-components': {
+            exclude: ['code', 'kbd', 'pre'],
+          },
+          words: {
+            exclude: [
+              // Symbols and punctuation
+              '×',
+              '·',
+              '—',
+              '→',
+              '←',
+              '↔',
+              '↑',
+              '↓',
+              '½',
+              '~',
+              '•',
+              '%',
+              '+',
+              '/',
+              ', ',
+              ':',
+              // Technical terms kept in English
+              'Gridfinity',
+              'STL',
+              '3MF',
+              'PLA',
+              'JSON',
+              'TSV',
+              'CSV',
+              '3D',
+              // Unit abbreviations and numeric fragments
+              'mm',
+              'px',
+              'u',
+              'm',
+              'h',
+              'x',
+              'pcs',
+              '.5',
+              '+.5',
+              'g',
+              // Ordered-list markers and loading ellipsis (presentational, not translatable)
+              '1.',
+              '2.',
+              '3.',
+              '...',
+              // CSS/SVG values
+              'normal',
+              '0.02em',
+              '100%',
+              'xMidYMid meet',
+              'xMinYMin meet',
+              'xMinYMid meet',
+              'xMidYMax meet',
+              // Currency symbol
+              '$',
+              // Numeric indicators
+              '9+',
+              // Brand names
+              'Zack Freedman',
+              'Andy Aragon',
+              // Keyboard shortcuts displayed as-is
+              'Ctrl',
+              'Shift',
+              'Esc',
+              'Enter',
+              'Space',
+              'WASD',
+              'H',
+              'R',
+              'V',
+              'L',
+              'M',
+              // Arrow key display
+              '↑↓←→',
+            ].map(literal),
+          },
+          callees: {
+            exclude: ['t', 'console.log', 'console.warn', 'console.error', 'Error', 'TypeError'],
+          },
         },
-        'jsx-components': {
-          exclude: ['code', 'kbd', 'pre'],
-        },
-        words: {
-          exclude: [
-            // Symbols and punctuation
-            '×', '·', '—', '→', '←', '↔', '↑', '↓', '½', '~', '•', '%', '+', '/', ', ', ':',
-            // Technical terms kept in English
-            'Gridfinity', 'STL', '3MF', 'PLA', 'JSON', 'TSV', 'CSV', '3D',
-            // Unit abbreviations and numeric fragments
-            'mm', 'px', 'u', 'm', 'h', 'x', 'pcs', '.5', '+.5', 'g',
-            // Ordered-list markers and loading ellipsis (presentational, not translatable)
-            '1.', '2.', '3.', '...',
-            // CSS/SVG values
-            'normal', '0.02em', '100%',
-            'xMidYMid meet', 'xMinYMin meet', 'xMinYMid meet', 'xMidYMax meet',
-            // Currency symbol
-            '$',
-            // Numeric indicators
-            '9+',
-            // Brand names
-            'Zack Freedman', 'Andy Aragon',
-            // Keyboard shortcuts displayed as-is
-            'Ctrl', 'Shift', 'Esc', 'Enter', 'Space',
-            'WASD', 'H', 'R', 'V', 'L', 'M',
-            // Arrow key display
-            '↑↓←→',
-          ].map(literal),
-        },
-        callees: {
-          exclude: ['t', 'console.log', 'console.warn', 'console.error', 'Error', 'TypeError'],
-        },
-      }],
+      ],
     },
   },
   // Architectural boundaries: enforce import rules between modules
@@ -218,78 +312,97 @@ export default defineConfig([
       //
       // The shared→feature edge is intentionally unrestricted today;
       // tightening it needs a per-violator cleanup pass.
-      'boundaries/dependencies': ['error', {
-        default: 'allow',
-        policies: [
-          // Features: disallow importing other features (cross-feature coupling)
-          {
-            from: { element: { type: 'feature' } },
-            disallow: [{ to: { element: { type: 'feature' } } }],
-          },
-          // Same feature is OK
-          {
-            from: { element: { type: 'feature' } },
-            allow: [
-              {
-                to: {
-                  element: {
-                    type: 'feature',
-                    captured: { featureName: '{{ from.captured.featureName }}' },
+      'boundaries/dependencies': [
+        'error',
+        {
+          default: 'allow',
+          policies: [
+            // Features: disallow importing other features (cross-feature coupling)
+            {
+              from: { element: { type: 'feature' } },
+              disallow: [{ to: { element: { type: 'feature' } } }],
+            },
+            // Same feature is OK
+            {
+              from: { element: { type: 'feature' } },
+              allow: [
+                {
+                  to: {
+                    element: {
+                      type: 'feature',
+                      captured: { featureName: '{{ from.captured.featureName }}' },
+                    },
                   },
                 },
-              },
-            ],
-          },
-          // Exception: design-linking -> bin-designer (integration layer)
-          {
-            from: { element: { type: 'feature', captured: { featureName: 'design-linking' } } },
-            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'bin-designer' } } } }],
-          },
-          // Exception: bin-inspector -> design-linking (lazy-loaded linked design section)
-          {
-            from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
-            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'design-linking' } } } }],
-          },
-          // Exception: bin-inspector -> bin-recommender (lazy-loaded size suggestion)
-          {
-            from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
-            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'bin-recommender' } } } }],
-          },
-          // Exception: layers -> design-linking (lazy-loaded Make Bento dialog)
-          {
-            from: { element: { type: 'feature', captured: { featureName: 'layers' } } },
-            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'design-linking' } } } }],
-          },
-          // `core/` is infrastructure — it must not depend on features or the
-          // app shell. (`core/` -> `shared/` is intentionally allowed; many
-          // `core/storage/*` modules use shared utilities/analytics.)
-          {
-            from: { element: { type: 'core' } },
-            disallow: [
-              { to: { element: { type: 'feature' } } },
-              { to: { element: { type: 'shell' } } },
-            ],
-          },
-          {
-            from: { element: { type: 'feature' } },
-            disallow: [{ to: { element: { type: 'shell' } } }],
-          },
-          // `design-system/` is UI primitives — it must not depend on any
-          // application-level layer. UI primitives take strings via props;
-          // they never read translations themselves, so `i18n` is in the
-          // disallow list alongside the app layers.
-          {
-            from: { element: { type: 'design-system' } },
-            disallow: [
-              { to: { element: { type: 'feature' } } },
-              { to: { element: { type: 'shell' } } },
-              { to: { element: { type: 'i18n' } } },
-              { to: { element: { type: 'shared' } } },
-              { to: { element: { type: 'core' } } },
-            ],
-          },
-        ],
-      }],
+              ],
+            },
+            // Exception: design-linking -> bin-designer (integration layer)
+            {
+              from: { element: { type: 'feature', captured: { featureName: 'design-linking' } } },
+              allow: [
+                { to: { element: { type: 'feature', captured: { featureName: 'bin-designer' } } } },
+              ],
+            },
+            // Exception: bin-inspector -> design-linking (lazy-loaded linked design section)
+            {
+              from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
+              allow: [
+                {
+                  to: { element: { type: 'feature', captured: { featureName: 'design-linking' } } },
+                },
+              ],
+            },
+            // Exception: bin-inspector -> bin-recommender (lazy-loaded size suggestion)
+            {
+              from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
+              allow: [
+                {
+                  to: {
+                    element: { type: 'feature', captured: { featureName: 'bin-recommender' } },
+                  },
+                },
+              ],
+            },
+            // Exception: layers -> design-linking (lazy-loaded Make Bento dialog)
+            {
+              from: { element: { type: 'feature', captured: { featureName: 'layers' } } },
+              allow: [
+                {
+                  to: { element: { type: 'feature', captured: { featureName: 'design-linking' } } },
+                },
+              ],
+            },
+            // `core/` is infrastructure — it must not depend on features or the
+            // app shell. (`core/` -> `shared/` is intentionally allowed; many
+            // `core/storage/*` modules use shared utilities/analytics.)
+            {
+              from: { element: { type: 'core' } },
+              disallow: [
+                { to: { element: { type: 'feature' } } },
+                { to: { element: { type: 'shell' } } },
+              ],
+            },
+            {
+              from: { element: { type: 'feature' } },
+              disallow: [{ to: { element: { type: 'shell' } } }],
+            },
+            // `design-system/` is UI primitives — it must not depend on any
+            // application-level layer. UI primitives take strings via props;
+            // they never read translations themselves, so `i18n` is in the
+            // disallow list alongside the app layers.
+            {
+              from: { element: { type: 'design-system' } },
+              disallow: [
+                { to: { element: { type: 'feature' } } },
+                { to: { element: { type: 'shell' } } },
+                { to: { element: { type: 'i18n' } } },
+                { to: { element: { type: 'shared' } } },
+                { to: { element: { type: 'core' } } },
+              ],
+            },
+          ],
+        },
+      ],
     },
   },
   // Bin-dimension discipline: every UI / validator / estimator that needs
@@ -314,22 +427,39 @@ export default defineConfig([
     rules: {
       // Flat-config replaces (does not merge) per-rule values, so the
       // React.lazy guard from the global block is duplicated here.
-      'no-restricted-syntax': ['error', {
-        selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="lazy"][callee.object.name="React"]',
-        message: 'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
-      }, {
-        selector: "BinaryExpression > MemberExpression[object.name='GRIDFINITY'][property.name='GRID_SIZE']",
-        message: 'Do not multiply/divide GRIDFINITY.GRID_SIZE directly — use binDimensions(params) (or thread params.gridUnitMm through) so the math tracks the user-configured grid unit. See src/features/bin-designer/utils/binDimensions.ts.',
-      }, {
-        selector: "BinaryExpression > MemberExpression[object.name='GRIDFINITY'][property.name='HEIGHT_UNIT']",
-        message: 'Do not multiply/divide GRIDFINITY.HEIGHT_UNIT directly — use binDimensions(params) (or thread params.heightUnitMm through) so the math tracks the user-configured height unit. See src/features/bin-designer/utils/binDimensions.ts.',
-      }, {
-        selector: "BinaryExpression > MemberExpression[object.name='GRIDFINITY_SPEC'][property.name='GRID_SIZE']",
-        message: 'Do not multiply/divide GRIDFINITY_SPEC.GRID_SIZE directly — thread the per-layout gridUnitMm through instead. See src/features/bin-designer/utils/binDimensions.ts.',
-      }, {
-        selector: "BinaryExpression > MemberExpression[object.name='GRIDFINITY_SPEC'][property.name='HEIGHT_UNIT']",
-        message: 'Do not multiply/divide GRIDFINITY_SPEC.HEIGHT_UNIT directly — thread the per-layout heightUnitMm through instead. See src/features/bin-designer/utils/binDimensions.ts.',
-      }],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="lazy"][callee.object.name="React"]',
+          message:
+            'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy() — raw lazy() leaks chunk-load failures to PostHog as unhandled rejections.',
+        },
+        {
+          selector:
+            "BinaryExpression > MemberExpression[object.name='GRIDFINITY'][property.name='GRID_SIZE']",
+          message:
+            'Do not multiply/divide GRIDFINITY.GRID_SIZE directly — use binDimensions(params) (or thread params.gridUnitMm through) so the math tracks the user-configured grid unit. See src/features/bin-designer/utils/binDimensions.ts.',
+        },
+        {
+          selector:
+            "BinaryExpression > MemberExpression[object.name='GRIDFINITY'][property.name='HEIGHT_UNIT']",
+          message:
+            'Do not multiply/divide GRIDFINITY.HEIGHT_UNIT directly — use binDimensions(params) (or thread params.heightUnitMm through) so the math tracks the user-configured height unit. See src/features/bin-designer/utils/binDimensions.ts.',
+        },
+        {
+          selector:
+            "BinaryExpression > MemberExpression[object.name='GRIDFINITY_SPEC'][property.name='GRID_SIZE']",
+          message:
+            'Do not multiply/divide GRIDFINITY_SPEC.GRID_SIZE directly — thread the per-layout gridUnitMm through instead. See src/features/bin-designer/utils/binDimensions.ts.',
+        },
+        {
+          selector:
+            "BinaryExpression > MemberExpression[object.name='GRIDFINITY_SPEC'][property.name='HEIGHT_UNIT']",
+          message:
+            'Do not multiply/divide GRIDFINITY_SPEC.HEIGHT_UNIT directly — thread the per-layout heightUnitMm through instead. See src/features/bin-designer/utils/binDimensions.ts.',
+        },
+      ],
     },
   },
   // Barrel-only restriction: design-linking may only import bin-designer barrel.
@@ -339,17 +469,25 @@ export default defineConfig([
     files: ['src/features/design-linking/**/*.{ts,tsx}'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
-      'no-restricted-imports': ['error', {
-        paths: [{
-          name: 'react',
-          importNames: ['lazy'],
-          message: 'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy().',
-        }],
-        patterns: [{
-          group: ['@/features/bin-designer/*', '@/features/bin-designer/**'],
-          message: 'Import from @/features/bin-designer barrel only',
-        }],
-      }],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['lazy'],
+              message:
+                'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy().',
+            },
+          ],
+          patterns: [
+            {
+              group: ['@/features/bin-designer/*', '@/features/bin-designer/**'],
+              message: 'Import from @/features/bin-designer barrel only',
+            },
+          ],
+        },
+      ],
     },
   },
   // Barrel-only restriction: bin-inspector may only import design-linking barrel.
@@ -357,17 +495,25 @@ export default defineConfig([
     files: ['src/features/bin-inspector/**/*.{ts,tsx}'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
-      'no-restricted-imports': ['error', {
-        paths: [{
-          name: 'react',
-          importNames: ['lazy'],
-          message: 'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy().',
-        }],
-        patterns: [{
-          group: ['@/features/design-linking/*', '@/features/design-linking/**'],
-          message: 'Import from @/features/design-linking barrel only',
-        }],
-      }],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['lazy'],
+              message:
+                'Use lazyWithRetry() from @/shared/utils/lazyWithRetry instead of React.lazy().',
+            },
+          ],
+          patterns: [
+            {
+              group: ['@/features/design-linking/*', '@/features/design-linking/**'],
+              message: 'Import from @/features/design-linking barrel only',
+            },
+          ],
+        },
+      ],
     },
   },
   // Design system: compound components are valid exports, and English
@@ -441,6 +587,9 @@ export default defineConfig([
       'src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx',
       'src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx',
       'src/features/bin-inspector/hooks/useBinInspector.ts', // single coordinating hook
+      'src/features/bin-designer/components/panel/LidSection/useLidSection.ts', // single coordinating hook: one state/handlers pair for the whole lid section
+      'src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts', // single coordinating hook: label plan, warnings and every setter in one closure
+      'src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts', // single coordinating hook: drag, rotate and hover share one pointer state machine
       'src/features/cloud-share/components/ShareButton/ShareButton.tsx',
       'src/features/command-palette/components/CommandPalette/CommandPalette.tsx',
       'src/features/grid-editor/components/Grid/Overlay/Overlay.tsx',
@@ -466,4 +615,4 @@ export default defineConfig([
       'no-console': 'off',
     },
   },
-])
+]);

--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -5,60 +5,25 @@
  * feature never imports the bin designer (see shared/types/communityDetail).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent } from 'react';
+import { useCallback } from 'react';
 import { Button, Dialog, IconButton, Menu, Spinner } from '@/design-system';
 import { MoreHorizontalIcon } from '@/design-system/Icon';
-import { useTranslation } from '@/i18n';
-import { isOk } from '@/core/result';
 import { useCommunityDetailStore } from '@/core/store/communityDetail';
 import type { CommunityDetailRequest } from '@/core/store/communityDetail';
-import { useGapFitStore } from '@/core/store/gapFit';
-import { useToastStore } from '@/core/store/toast';
-import { useSessionStore } from '@/core/sync/session/useSession';
 import { trackEvent } from '@/shared/analytics/posthog';
-import type { CommunityDesign, CommunityDesignCounts } from '@/shared/types/community';
-import type { CommunityPrint, CommunityPrintSummary } from '@/shared/types/communityPrint';
 import type { CommunityDetailProps } from '@/shared/types/communityDetail';
 import { savePendingLikeAction } from '@/shared/utils/communityPendingLikeAction';
-import { fetchCommunityDesign } from '../../api/client';
-import { buildDesignImages, findPhotoIndex } from '../../utils/designMedia';
-import { useLikeToggle } from '../../hooks/useLikeToggle';
-import type { LikeToggleTarget } from '../../hooks/useLikeToggle';
-import { useBrowseStore } from '../../store/browseStore';
-import type { CardLikePatch } from '../../store/browseStore';
-import { recordRecentlyViewed } from '../../utils/recentlyViewed';
 import { ReportDialog } from '../ReportDialog';
 import { CommunitySignInPrompt } from '../SignInPrompt';
-import { fetchPrints, reportPrint } from '../../api/printsClient';
-import { usePrintDialogStore } from '../../store/printDialogStore';
+import { reportPrint } from '../../api/printsClient';
 import { PrintDialog } from '../PrintDialog';
 import { PrintCostPanel } from '../PrintCostPanel';
 import { PrintsSection } from '../PrintsSection';
 import { MediaLightbox } from '../MediaLightbox';
 import { CommunityDetailContent } from './CommunityDetailContent';
-import type { OwnerModeration, ParentResolution } from './CommunityDetailContent';
 import { useDetailHistoryTrap } from './useDetailHistoryTrap';
-import { useResponsive } from '@/shared/hooks/useResponsive';
-import { useRetryOnReconnect } from '@/shared/hooks/useRetryOnReconnect';
-
-type DetailPhase = 'loading' | 'ready' | 'gone' | 'error';
-
-/** Stable empty reference so the media memo does not churn every render. */
-const EMPTY_PRINTS: readonly CommunityPrint[] = [];
-
-type BusyAction = 'remix' | 'edit' | 'duplicate' | 'place' | null;
-
-/** Detail-payload stats fallback for designs the capped browse index lacks. */
-interface DetailStats {
-  counts: CommunityDesignCounts;
-  likedByMe: boolean;
-}
-
-function publicDesignUrl(id: string): string {
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
-  return `${origin}/community/d/${id}`;
-}
+import { useCommunityDetailDialog } from './useCommunityDetailDialog';
+import type { CommunityDetailDialogProps } from './useCommunityDetailDialog';
 
 export function CommunityDetail(props: CommunityDetailProps) {
   const request = useCommunityDetailStore((s) => s.request);
@@ -97,426 +62,61 @@ function CommunityDetailHost({ request, ...props }: CommunityDetailHostProps) {
   );
 }
 
-interface CommunityDetailDialogProps extends CommunityDetailProps {
-  request: CommunityDetailRequest;
-  close: () => void;
-  consumeTrap: (onConsumed: () => void) => void;
-}
-
-function CommunityDetailDialog({
-  request,
-  close,
-  consumeTrap,
-  onRequestCloseGallery,
-  onRemixDesign,
-  onEditOriginal,
-  onPlaceInLayout,
-  surface = 'tab',
-}: CommunityDetailDialogProps) {
-  const t = useTranslation();
-  const { isMobile } = useResponsive();
-  const addToast = useToastStore((s) => s.addToast);
-
-  const [phase, setPhase] = useState<DetailPhase>('loading');
-  const [design, setDesign] = useState<CommunityDesign | null>(null);
-  const [detailStats, setDetailStats] = useState<DetailStats | null>(null);
-  const [isOwner, setIsOwner] = useState(false);
-  const [authorIsSupporter, setAuthorIsSupporter] = useState(false);
-  // Stamped with the design it belongs to rather than cleared on switch: the
-  // overlay can go ready for design B while this still holds A's answer, and a
-  // stamped value is stale-proof without a synchronous reset in an effect.
-  const [ownPrint, setOwnPrint] = useState<{
-    designId: string;
-    print: CommunityPrint | null;
-    summary: CommunityPrintSummary | null;
-  } | null>(null);
-  const [printsAvailable, setPrintsAvailable] = useState(true);
-  // The gap the viewer picked in the layout editor, if any. Read here rather
-  // than passed down so the detail answers the same question the gallery
-  // filtered on.
-  const gapContext = useBrowseStore((s) => s.fitsGapContext);
-  // Bumped after a write so the list refetches; the parent owns it because the
-  // CTA and the list must agree on whether the viewer has a print.
-  const [printsRefresh, setPrintsRefresh] = useState(0);
-  const [reportPrintTarget, setReportPrintTarget] = useState<CommunityPrint | null>(null);
-  // Stamped with its design as a guard, not as the mechanism: the dialog is
-  // keyed by designId, so switching designs remounts it. The stamp is what
-  // stops an in-flight response for the previous design from being read as
-  // this one's if that key ever goes away.
-  const [printItems, setPrintItems] = useState<{
-    designId: string;
-    items: readonly CommunityPrint[];
-  } | null>(null);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  const [ownerModeration, setOwnerModeration] = useState<OwnerModeration | null>(null);
-  const [offline, setOffline] = useState(false);
-  const [attempt, setAttempt] = useState(0);
-  const [busy, setBusy] = useState<BusyAction>(null);
-  const [parentResolution, setParentResolution] = useState<ParentResolution>({
-    kind: 'snapshot',
-  });
-  const [reportOpen, setReportOpen] = useState(false);
-  const [signInIntent, setSignInIntent] = useState<'like' | 'report' | null>(null);
-  const [overflowMenu, setOverflowMenu] = useState<{
-    open: boolean;
-    position: { x: number; y: number };
-  }>({ open: false, position: { x: 0, y: 0 } });
-
-  const { designId, card } = request;
-
-  // Live browse-store card for this design: optimistic like patches land in
-  // the store, so the stats row reflects them without local mirror state.
-  // A design the capped index lacks (or a cold deep link) falls back to the
-  // detail payload's stats, then to the request's snapshot.
-  const liveCard = useBrowseStore((s) => s.items.find((item) => item.id === designId) ?? null);
-
-  // Post-OAuth resumed like pushed by useCommunityLikeReturn: the record
-  // fetch can race the resumed like write server-side and snapshot a stale
-  // likedByMe that would contradict the "Design liked." toast, so a matching
-  // sync record overrides the fetched fallback until a manual toggle (which
-  // consumes it) or close.
-  const likeSync = useCommunityDetailStore((s) => s.likeSync);
-  const syncForThis = likeSync !== null && likeSync.designId === designId ? likeSync : null;
-  const detailCounts = useMemo(
-    () =>
-      detailStats !== null
-        ? syncForThis !== null
-          ? { ...detailStats.counts, likes: syncForThis.likes }
-          : detailStats.counts
-        : null,
-    [detailStats, syncForThis]
-  );
-  const counts = liveCard?.counts ?? detailCounts ?? card?.counts ?? null;
-  const likedByMe =
-    liveCard !== null
-      ? liveCard.likedByMe === true
-      : syncForThis !== null
-        ? syncForThis.likedByMe
-        : detailStats?.likedByMe === true;
-  const toggleLike = useLikeToggle();
-  const sessionStatus = useSessionStore((s) => s.status);
-
-  const patchDetailStats = useCallback((patch: CardLikePatch) => {
-    setDetailStats((current) =>
-      current === null
-        ? current
-        : {
-            counts:
-              patch.likes !== undefined
-                ? { ...current.counts, likes: patch.likes }
-                : current.counts,
-            likedByMe: patch.likedByMe ?? current.likedByMe,
-          }
-    );
-  }, []);
-
-  const handleToggleLike = useCallback(() => {
-    const target: LikeToggleTarget | null =
-      liveCard ??
-      (detailCounts !== null ? { id: designId, likedByMe, counts: detailCounts } : null);
-    if (target === null) return;
-    // The toggle starts from the synced state (folded into `target` above),
-    // so the sync record is spent; the optimistic patch below lands on
-    // detailStats and takes over as the source of truth.
-    useCommunityDetailStore.getState().clearLikeSync();
-    void toggleLike(target, patchDetailStats).then((outcome) => {
-      if (outcome === 'signin-required') setSignInIntent('like');
-    });
-  }, [designId, detailCounts, likedByMe, liveCard, patchDetailStats, toggleLike]);
-
-  const handleReportEntry = useCallback(() => {
-    if (sessionStatus !== 'authenticated') {
-      trackEvent('community_signin_prompt_shown', { intent: 'report' });
-      setSignInIntent('report');
-      return;
-    }
-    setReportOpen(true);
-  }, [sessionStatus]);
-
-  const handleOverflowOpen = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    // Anchor to the button's upper-left; Menu.Root clamps to the viewport.
-    setOverflowMenu({ open: true, position: { x: rect.left, y: rect.top - 8 } });
-  }, []);
-
-  // A bumped reconnectAttempt re-runs the load directly (the error copy stays
-  // up until the retry resolves); only the manual Retry button flips the
-  // phase back to loading.
-  const reconnectAttempt = useRetryOnReconnect(phase === 'error');
-
-  // One viewed event per dialog instance: the load effect re-runs on every
-  // manual retry and reconnect, which would otherwise inflate the metric.
-  const hasTrackedViewRef = useRef(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    void fetchCommunityDesign(designId).then((result) => {
-      if (cancelled) return;
-      if (isOk(result)) {
-        setDesign(result.value.design);
-        setDetailStats(
-          result.value.counts !== null
-            ? { counts: result.value.counts, likedByMe: result.value.likedByMe }
-            : null
-        );
-        setIsOwner(result.value.isOwner);
-        setAuthorIsSupporter(result.value.authorIsSupporter);
-        setOwnerModeration(
-          result.value.isOwner && result.value.design.status === 'hidden'
-            ? {
-                hiddenReason: result.value.hiddenReason,
-                hiddenReasonCategory: result.value.hiddenReasonCategory,
-              }
-            : null
-        );
-        setPhase('ready');
-        if (!hasTrackedViewRef.current) {
-          hasTrackedViewRef.current = true;
-          trackEvent('community_detail_viewed', { surface });
-          recordRecentlyViewed(designId);
-        }
-      } else if (result.error.kind === 'notFound') {
-        setPhase('gone');
-      } else {
-        setOffline(
-          result.error.kind === 'network' && typeof navigator !== 'undefined' && !navigator.onLine
-        );
-        setPhase('error');
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [designId, attempt, reconnectAttempt, surface]);
-
-  const retry = useCallback(() => {
-    setPhase('loading');
-    setAttempt((n) => n + 1);
-  }, []);
-
-  const parentId = phase === 'ready' ? (design?.lineage?.parentId ?? null) : null;
-  useEffect(() => {
-    if (parentId === null) return;
-    let cancelled = false;
-    void fetchCommunityDesign(parentId).then((result) => {
-      if (cancelled) return;
-      if (isOk(result)) {
-        setParentResolution({
-          kind: 'live',
-          name: result.value.design.name,
-          authorName: result.value.design.authorName,
-        });
-      } else if (result.error.kind === 'notFound') {
-        setParentResolution({ kind: 'gone' });
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [parentId]);
-
-  const switchToDesignerAndClose = useCallback(() => {
-    // Pop the trapped history entry before switch-to-designer pushes
-    // /designer, otherwise the trap entry is stranded under the new route.
-    consumeTrap(() => {
-      window.dispatchEvent(new Event('switch-to-designer'));
-      close();
-      onRequestCloseGallery();
-    });
-  }, [close, consumeTrap, onRequestCloseGallery]);
-
-  const runDuplicate = useCallback(
-    async (target: CommunityDesign, action: Exclude<BusyAction, null>) => {
-      setBusy(action);
-      try {
-        const created = await onRemixDesign(target, { ownDuplicate: action === 'duplicate' });
-        if (!created) {
-          addToast(t('community.detail.remixFailed'), 'error');
-          return;
-        }
-        if (action === 'remix') {
-          trackEvent('community_remix_opened');
-          addToast(t('community.detail.remixCreated'), 'success');
-        } else {
-          addToast(t('community.detail.duplicateCreated'), 'success');
-        }
-        switchToDesignerAndClose();
-      } finally {
-        setBusy(null);
-      }
-    },
-    [addToast, onRemixDesign, switchToDesignerAndClose, t]
-  );
-
-  const handleRemix = useCallback(() => {
-    if (design === null || busy !== null) return;
-    void runDuplicate(design, 'remix');
-  }, [busy, design, runDuplicate]);
-
-  const handleDuplicate = useCallback(() => {
-    if (design === null || busy !== null) return;
-    void runDuplicate(design, 'duplicate');
-  }, [busy, design, runDuplicate]);
-
-  const handleEditOriginal = useCallback(async () => {
-    if (design === null || busy !== null) return;
-    setBusy('edit');
-    try {
-      const outcome = await onEditOriginal(design);
-      if (outcome === 'opened') {
-        switchToDesignerAndClose();
-        return;
-      }
-      if (outcome === 'missing') {
-        // The lost-local-design trap: no local copy carries this publishedId,
-        // so fall back to a fresh copy instead of a dead end.
-        addToast(t('community.detail.editOriginalMissing'), 'info');
-        setBusy(null);
-        await runDuplicate(design, 'duplicate');
-        return;
-      }
-      addToast(t('community.detail.editOriginalFailed'), 'error');
-    } finally {
-      setBusy(null);
-    }
-  }, [addToast, busy, design, onEditOriginal, runDuplicate, switchToDesignerAndClose, t]);
-
-  // Fits-gap context: active only while the layout editor's handoff is live
-  // AND the host wired the placement bridge (the /community route does not).
-  const gapConstraintActive = useGapFitStore((s) => s.constraint !== null);
-  const placeAvailable = gapConstraintActive && onPlaceInLayout !== undefined;
-
-  const handlePlaceInLayout = useCallback(async () => {
-    if (design === null || busy !== null || onPlaceInLayout === undefined) return;
-    setBusy('place');
-    try {
-      const outcome = await onPlaceInLayout(design);
-      if (outcome === 'placed') {
-        trackEvent('community_place_in_layout');
-        addToast(t('community.detail.placedInLayout'), 'success');
-        // Stay on the layout canvas with the placed bin selected: close both
-        // the detail and the whole gallery, but never switch-to-designer.
-        close();
-        onRequestCloseGallery();
-        return;
-      }
-      if (outcome === 'no-fit') {
-        // Gallery and detail stay open so the user can pick another design.
-        addToast(t('community.detail.placeNoFit'), 'error');
-        return;
-      }
-      if (outcome === 'error-copy-saved') {
-        // The remix copy was already saved before placement failed; the
-        // message must own that side effect.
-        addToast(t('community.detail.placeFailedCopySaved'), 'error');
-        return;
-      }
-      addToast(t('community.detail.placeFailed'), 'error');
-    } finally {
-      setBusy(null);
-    }
-  }, [addToast, busy, close, design, onPlaceInLayout, onRequestCloseGallery, t]);
-
-  // The caller's own print decides whether the CTA posts or edits. The list
-  // response carries it even when it is not on the first page, so this is one
-  // request rather than a walk.
-  // Keyed off the id, not the design object: a counts refresh replaces the
-  // object without changing which design this is, and depending on the object
-  // would re-fetch prints every time.
-  const printsDesignId = design?.id ?? null;
-  useEffect(() => {
-    if (phase !== 'ready' || printsDesignId === null) return;
-    let cancelled = false;
-    void fetchPrints(printsDesignId).then((result) => {
-      if (cancelled) return;
-      if (isOk(result)) {
-        setOwnPrint({
-          designId: printsDesignId,
-          print: result.value.mine,
-          summary: result.value.summary,
-        });
-        setPrintItems({ designId: printsDesignId, items: result.value.items });
-        return;
-      }
-      // The kill switch is the one failure worth acting on: a CTA that opens a
-      // dialog which can only fail is worse than no CTA. Any other error just
-      // leaves the button in its "post" state.
-      setPrintsAvailable(result.error.kind !== 'disabled');
-      setOwnPrint({ designId: printsDesignId, print: null, summary: null });
-    });
-    return () => {
-      cancelled = true;
-    };
-    // printsRefresh is a dependency, not just PrintsSection's: the cost panel
-    // reads its summary from here, so without it a save could leave the panel
-    // showing "estimated" after the report that should have flipped it.
-  }, [phase, printsDesignId, printsRefresh]);
-
-  const stampedPrints = design !== null && ownPrint?.designId === design.id ? ownPrint : null;
-  const myPrint = stampedPrints?.print ?? null;
-  const printSummary = stampedPrints?.summary ?? null;
-
-  const mediaPrints =
-    design !== null && printItems?.designId === design.id ? printItems.items : EMPTY_PRINTS;
-  const images = useMemo(
-    () => buildDesignImages(design?.thumbnails ?? [], mediaPrints),
-    [design?.thumbnails, mediaPrints]
-  );
-
-  const handlePrintItemsChange = useCallback(
-    (items: readonly CommunityPrint[]) => {
-      if (design === null) return;
-      setPrintItems({ designId: design.id, items });
-    },
-    [design]
-  );
-
-  const handleOpenPhoto = useCallback(
-    (printId: string, photoIndex: number) => {
-      const index = findPhotoIndex(images, mediaPrints, printId, photoIndex);
-      if (index >= 0) setLightboxIndex(index);
-    },
-    [images, mediaPrints]
-  );
-
-  const closeLightbox = useCallback(() => setLightboxIndex(null), []);
-
-  const printDialogOpen = usePrintDialogStore((s) => s.phase !== 'closed');
-
-  // Opening by bare id rather than a card: an ancestor may sit outside the
-  // loaded index, and the detail view already handles a cold id fetch.
-  const handleOpenAncestor = useCallback((ancestorId: string) => {
-    useCommunityDetailStore.getState().open(ancestorId);
-  }, []);
-
-  const handleAddPrint = useCallback(() => {
-    if (design === null) return;
-    usePrintDialogStore.getState().open({
-      designId: design.id,
-      designName: design.name,
-      signedIn: sessionStatus === 'authenticated',
-      existing: myPrint,
-    });
-  }, [design, myPrint, sessionStatus]);
-
-  const handleFilterByAuthor = useCallback(() => {
-    if (design === null) return;
-    useBrowseStore.getState().setAuthor({ id: design.authorPublicId, name: design.authorName });
-    trackEvent('community_author_filter_applied', { surface: 'detail' });
-    // Closing reveals the gallery beneath (tab) or returns the route to
-    // /community, where the author sync appends ?author= for sharing.
-    close();
-  }, [close, design]);
-
-  const handleShare = useCallback(async () => {
-    const url = publicDesignUrl(designId);
-    try {
-      await navigator.clipboard.writeText(url);
-      addToast(t('community.detail.shareCopied'), 'success');
-    } catch {
-      addToast(t('community.detail.shareFailed'), 'error');
-    }
-  }, [addToast, designId, t]);
+function CommunityDetailDialog(props: CommunityDetailDialogProps) {
+  const { close } = props;
+  const {
+    t,
+    isMobile,
+    phase,
+    design,
+    detailStats,
+    isOwner,
+    authorIsSupporter,
+    setOwnPrint,
+    printsAvailable,
+    gapContext,
+    printsRefresh,
+    setPrintsRefresh,
+    reportPrintTarget,
+    setReportPrintTarget,
+    lightboxIndex,
+    setLightboxIndex,
+    ownerModeration,
+    offline,
+    busy,
+    parentResolution,
+    reportOpen,
+    setReportOpen,
+    signInIntent,
+    setSignInIntent,
+    overflowMenu,
+    setOverflowMenu,
+    designId,
+    card,
+    liveCard,
+    counts,
+    likedByMe,
+    handleToggleLike,
+    handleReportEntry,
+    handleOverflowOpen,
+    retry,
+    handleRemix,
+    handleDuplicate,
+    handleEditOriginal,
+    placeAvailable,
+    handlePlaceInLayout,
+    myPrint,
+    printSummary,
+    images,
+    handlePrintItemsChange,
+    handleOpenPhoto,
+    closeLightbox,
+    printDialogOpen,
+    handleOpenAncestor,
+    handleAddPrint,
+    handleFilterByAuthor,
+    handleShare,
+  } = useCommunityDetailDialog(props);
 
   const title = design?.name ?? card?.name ?? t('community.detail.title');
 

--- a/src/features/community/components/CommunityDetail/useCommunityDetailDialog.ts
+++ b/src/features/community/components/CommunityDetail/useCommunityDetailDialog.ts
@@ -26,20 +26,20 @@ import type { OwnerModeration, ParentResolution } from './CommunityDetailContent
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useRetryOnReconnect } from '@/shared/hooks/useRetryOnReconnect';
 
-export type DetailPhase = 'loading' | 'ready' | 'gone' | 'error';
+type DetailPhase = 'loading' | 'ready' | 'gone' | 'error';
 
 /** Stable empty reference so the media memo does not churn every render. */
-export const EMPTY_PRINTS: readonly CommunityPrint[] = [];
+const EMPTY_PRINTS: readonly CommunityPrint[] = [];
 
-export type BusyAction = 'remix' | 'edit' | 'duplicate' | 'place' | null;
+type BusyAction = 'remix' | 'edit' | 'duplicate' | 'place' | null;
 
 /** Detail-payload stats fallback for designs the capped browse index lacks. */
-export interface DetailStats {
+interface DetailStats {
   counts: CommunityDesignCounts;
   likedByMe: boolean;
 }
 
-export function publicDesignUrl(id: string): string {
+function publicDesignUrl(id: string): string {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
   return `${origin}/community/d/${id}`;
 }

--- a/src/features/community/components/CommunityDetail/useCommunityDetailDialog.ts
+++ b/src/features/community/components/CommunityDetail/useCommunityDetailDialog.ts
@@ -1,0 +1,521 @@
+/** Record loading, print and moderation state, and every action handler behind the community detail dialog; the component keeps the markup. */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MouseEvent } from 'react';
+import { useTranslation } from '@/i18n';
+import { isOk } from '@/core/result';
+import { useCommunityDetailStore } from '@/core/store/communityDetail';
+import type { CommunityDetailRequest } from '@/core/store/communityDetail';
+import { useGapFitStore } from '@/core/store/gapFit';
+import { useToastStore } from '@/core/store/toast';
+import { useSessionStore } from '@/core/sync/session/useSession';
+import { trackEvent } from '@/shared/analytics/posthog';
+import type { CommunityDesign, CommunityDesignCounts } from '@/shared/types/community';
+import type { CommunityPrint, CommunityPrintSummary } from '@/shared/types/communityPrint';
+import type { CommunityDetailProps } from '@/shared/types/communityDetail';
+import { fetchCommunityDesign } from '../../api/client';
+import { buildDesignImages, findPhotoIndex } from '../../utils/designMedia';
+import { useLikeToggle } from '../../hooks/useLikeToggle';
+import type { LikeToggleTarget } from '../../hooks/useLikeToggle';
+import { useBrowseStore } from '../../store/browseStore';
+import type { CardLikePatch } from '../../store/browseStore';
+import { recordRecentlyViewed } from '../../utils/recentlyViewed';
+import { fetchPrints } from '../../api/printsClient';
+import { usePrintDialogStore } from '../../store/printDialogStore';
+import type { OwnerModeration, ParentResolution } from './CommunityDetailContent';
+import { useResponsive } from '@/shared/hooks/useResponsive';
+import { useRetryOnReconnect } from '@/shared/hooks/useRetryOnReconnect';
+
+export type DetailPhase = 'loading' | 'ready' | 'gone' | 'error';
+
+/** Stable empty reference so the media memo does not churn every render. */
+export const EMPTY_PRINTS: readonly CommunityPrint[] = [];
+
+export type BusyAction = 'remix' | 'edit' | 'duplicate' | 'place' | null;
+
+/** Detail-payload stats fallback for designs the capped browse index lacks. */
+export interface DetailStats {
+  counts: CommunityDesignCounts;
+  likedByMe: boolean;
+}
+
+export function publicDesignUrl(id: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/community/d/${id}`;
+}
+
+export interface CommunityDetailDialogProps extends CommunityDetailProps {
+  request: CommunityDetailRequest;
+  close: () => void;
+  consumeTrap: (onConsumed: () => void) => void;
+}
+
+export function useCommunityDetailDialog({
+  request,
+  close,
+  consumeTrap,
+  onRequestCloseGallery,
+  onRemixDesign,
+  onEditOriginal,
+  onPlaceInLayout,
+  surface = 'tab',
+}: CommunityDetailDialogProps) {
+  const t = useTranslation();
+  const { isMobile } = useResponsive();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [phase, setPhase] = useState<DetailPhase>('loading');
+  const [design, setDesign] = useState<CommunityDesign | null>(null);
+  const [detailStats, setDetailStats] = useState<DetailStats | null>(null);
+  const [isOwner, setIsOwner] = useState(false);
+  const [authorIsSupporter, setAuthorIsSupporter] = useState(false);
+  // Stamped with the design it belongs to rather than cleared on switch: the
+  // overlay can go ready for design B while this still holds A's answer, and a
+  // stamped value is stale-proof without a synchronous reset in an effect.
+  const [ownPrint, setOwnPrint] = useState<{
+    designId: string;
+    print: CommunityPrint | null;
+    summary: CommunityPrintSummary | null;
+  } | null>(null);
+  const [printsAvailable, setPrintsAvailable] = useState(true);
+  // The gap the viewer picked in the layout editor, if any. Read here rather
+  // than passed down so the detail answers the same question the gallery
+  // filtered on.
+  const gapContext = useBrowseStore((s) => s.fitsGapContext);
+  // Bumped after a write so the list refetches; the parent owns it because the
+  // CTA and the list must agree on whether the viewer has a print.
+  const [printsRefresh, setPrintsRefresh] = useState(0);
+  const [reportPrintTarget, setReportPrintTarget] = useState<CommunityPrint | null>(null);
+  // Stamped with its design as a guard, not as the mechanism: the dialog is
+  // keyed by designId, so switching designs remounts it. The stamp is what
+  // stops an in-flight response for the previous design from being read as
+  // this one's if that key ever goes away.
+  const [printItems, setPrintItems] = useState<{
+    designId: string;
+    items: readonly CommunityPrint[];
+  } | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [ownerModeration, setOwnerModeration] = useState<OwnerModeration | null>(null);
+  const [offline, setOffline] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [busy, setBusy] = useState<BusyAction>(null);
+  const [parentResolution, setParentResolution] = useState<ParentResolution>({
+    kind: 'snapshot',
+  });
+  const [reportOpen, setReportOpen] = useState(false);
+  const [signInIntent, setSignInIntent] = useState<'like' | 'report' | null>(null);
+  const [overflowMenu, setOverflowMenu] = useState<{
+    open: boolean;
+    position: { x: number; y: number };
+  }>({ open: false, position: { x: 0, y: 0 } });
+
+  const { designId, card } = request;
+
+  // Live browse-store card for this design: optimistic like patches land in
+  // the store, so the stats row reflects them without local mirror state.
+  // A design the capped index lacks (or a cold deep link) falls back to the
+  // detail payload's stats, then to the request's snapshot.
+  const liveCard = useBrowseStore((s) => s.items.find((item) => item.id === designId) ?? null);
+
+  // Post-OAuth resumed like pushed by useCommunityLikeReturn: the record
+  // fetch can race the resumed like write server-side and snapshot a stale
+  // likedByMe that would contradict the "Design liked." toast, so a matching
+  // sync record overrides the fetched fallback until a manual toggle (which
+  // consumes it) or close.
+  const likeSync = useCommunityDetailStore((s) => s.likeSync);
+  const syncForThis = likeSync !== null && likeSync.designId === designId ? likeSync : null;
+  const detailCounts = useMemo(
+    () =>
+      detailStats !== null
+        ? syncForThis !== null
+          ? { ...detailStats.counts, likes: syncForThis.likes }
+          : detailStats.counts
+        : null,
+    [detailStats, syncForThis]
+  );
+  const counts = liveCard?.counts ?? detailCounts ?? card?.counts ?? null;
+  const likedByMe =
+    liveCard !== null
+      ? liveCard.likedByMe === true
+      : syncForThis !== null
+        ? syncForThis.likedByMe
+        : detailStats?.likedByMe === true;
+  const toggleLike = useLikeToggle();
+  const sessionStatus = useSessionStore((s) => s.status);
+
+  const patchDetailStats = useCallback((patch: CardLikePatch) => {
+    setDetailStats((current) =>
+      current === null
+        ? current
+        : {
+            counts:
+              patch.likes !== undefined
+                ? { ...current.counts, likes: patch.likes }
+                : current.counts,
+            likedByMe: patch.likedByMe ?? current.likedByMe,
+          }
+    );
+  }, []);
+
+  const handleToggleLike = useCallback(() => {
+    const target: LikeToggleTarget | null =
+      liveCard ??
+      (detailCounts !== null ? { id: designId, likedByMe, counts: detailCounts } : null);
+    if (target === null) return;
+    // The toggle starts from the synced state (folded into `target` above),
+    // so the sync record is spent; the optimistic patch below lands on
+    // detailStats and takes over as the source of truth.
+    useCommunityDetailStore.getState().clearLikeSync();
+    void toggleLike(target, patchDetailStats).then((outcome) => {
+      if (outcome === 'signin-required') setSignInIntent('like');
+    });
+  }, [designId, detailCounts, likedByMe, liveCard, patchDetailStats, toggleLike]);
+
+  const handleReportEntry = useCallback(() => {
+    if (sessionStatus !== 'authenticated') {
+      trackEvent('community_signin_prompt_shown', { intent: 'report' });
+      setSignInIntent('report');
+      return;
+    }
+    setReportOpen(true);
+  }, [sessionStatus]);
+
+  const handleOverflowOpen = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    // Anchor to the button's upper-left; Menu.Root clamps to the viewport.
+    setOverflowMenu({ open: true, position: { x: rect.left, y: rect.top - 8 } });
+  }, []);
+
+  // A bumped reconnectAttempt re-runs the load directly (the error copy stays
+  // up until the retry resolves); only the manual Retry button flips the
+  // phase back to loading.
+  const reconnectAttempt = useRetryOnReconnect(phase === 'error');
+
+  // One viewed event per dialog instance: the load effect re-runs on every
+  // manual retry and reconnect, which would otherwise inflate the metric.
+  const hasTrackedViewRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchCommunityDesign(designId).then((result) => {
+      if (cancelled) return;
+      if (isOk(result)) {
+        setDesign(result.value.design);
+        setDetailStats(
+          result.value.counts !== null
+            ? { counts: result.value.counts, likedByMe: result.value.likedByMe }
+            : null
+        );
+        setIsOwner(result.value.isOwner);
+        setAuthorIsSupporter(result.value.authorIsSupporter);
+        setOwnerModeration(
+          result.value.isOwner && result.value.design.status === 'hidden'
+            ? {
+                hiddenReason: result.value.hiddenReason,
+                hiddenReasonCategory: result.value.hiddenReasonCategory,
+              }
+            : null
+        );
+        setPhase('ready');
+        if (!hasTrackedViewRef.current) {
+          hasTrackedViewRef.current = true;
+          trackEvent('community_detail_viewed', { surface });
+          recordRecentlyViewed(designId);
+        }
+      } else if (result.error.kind === 'notFound') {
+        setPhase('gone');
+      } else {
+        setOffline(
+          result.error.kind === 'network' && typeof navigator !== 'undefined' && !navigator.onLine
+        );
+        setPhase('error');
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [designId, attempt, reconnectAttempt, surface]);
+
+  const retry = useCallback(() => {
+    setPhase('loading');
+    setAttempt((n) => n + 1);
+  }, []);
+
+  const parentId = phase === 'ready' ? (design?.lineage?.parentId ?? null) : null;
+  useEffect(() => {
+    if (parentId === null) return;
+    let cancelled = false;
+    void fetchCommunityDesign(parentId).then((result) => {
+      if (cancelled) return;
+      if (isOk(result)) {
+        setParentResolution({
+          kind: 'live',
+          name: result.value.design.name,
+          authorName: result.value.design.authorName,
+        });
+      } else if (result.error.kind === 'notFound') {
+        setParentResolution({ kind: 'gone' });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [parentId]);
+
+  const switchToDesignerAndClose = useCallback(() => {
+    // Pop the trapped history entry before switch-to-designer pushes
+    // /designer, otherwise the trap entry is stranded under the new route.
+    consumeTrap(() => {
+      window.dispatchEvent(new Event('switch-to-designer'));
+      close();
+      onRequestCloseGallery();
+    });
+  }, [close, consumeTrap, onRequestCloseGallery]);
+
+  const runDuplicate = useCallback(
+    async (target: CommunityDesign, action: Exclude<BusyAction, null>) => {
+      setBusy(action);
+      try {
+        const created = await onRemixDesign(target, { ownDuplicate: action === 'duplicate' });
+        if (!created) {
+          addToast(t('community.detail.remixFailed'), 'error');
+          return;
+        }
+        if (action === 'remix') {
+          trackEvent('community_remix_opened');
+          addToast(t('community.detail.remixCreated'), 'success');
+        } else {
+          addToast(t('community.detail.duplicateCreated'), 'success');
+        }
+        switchToDesignerAndClose();
+      } finally {
+        setBusy(null);
+      }
+    },
+    [addToast, onRemixDesign, switchToDesignerAndClose, t]
+  );
+
+  const handleRemix = useCallback(() => {
+    if (design === null || busy !== null) return;
+    void runDuplicate(design, 'remix');
+  }, [busy, design, runDuplicate]);
+
+  const handleDuplicate = useCallback(() => {
+    if (design === null || busy !== null) return;
+    void runDuplicate(design, 'duplicate');
+  }, [busy, design, runDuplicate]);
+
+  const handleEditOriginal = useCallback(async () => {
+    if (design === null || busy !== null) return;
+    setBusy('edit');
+    try {
+      const outcome = await onEditOriginal(design);
+      if (outcome === 'opened') {
+        switchToDesignerAndClose();
+        return;
+      }
+      if (outcome === 'missing') {
+        // The lost-local-design trap: no local copy carries this publishedId,
+        // so fall back to a fresh copy instead of a dead end.
+        addToast(t('community.detail.editOriginalMissing'), 'info');
+        setBusy(null);
+        await runDuplicate(design, 'duplicate');
+        return;
+      }
+      addToast(t('community.detail.editOriginalFailed'), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }, [addToast, busy, design, onEditOriginal, runDuplicate, switchToDesignerAndClose, t]);
+
+  // Fits-gap context: active only while the layout editor's handoff is live
+  // AND the host wired the placement bridge (the /community route does not).
+  const gapConstraintActive = useGapFitStore((s) => s.constraint !== null);
+  const placeAvailable = gapConstraintActive && onPlaceInLayout !== undefined;
+
+  const handlePlaceInLayout = useCallback(async () => {
+    if (design === null || busy !== null || onPlaceInLayout === undefined) return;
+    setBusy('place');
+    try {
+      const outcome = await onPlaceInLayout(design);
+      if (outcome === 'placed') {
+        trackEvent('community_place_in_layout');
+        addToast(t('community.detail.placedInLayout'), 'success');
+        // Stay on the layout canvas with the placed bin selected: close both
+        // the detail and the whole gallery, but never switch-to-designer.
+        close();
+        onRequestCloseGallery();
+        return;
+      }
+      if (outcome === 'no-fit') {
+        // Gallery and detail stay open so the user can pick another design.
+        addToast(t('community.detail.placeNoFit'), 'error');
+        return;
+      }
+      if (outcome === 'error-copy-saved') {
+        // The remix copy was already saved before placement failed; the
+        // message must own that side effect.
+        addToast(t('community.detail.placeFailedCopySaved'), 'error');
+        return;
+      }
+      addToast(t('community.detail.placeFailed'), 'error');
+    } finally {
+      setBusy(null);
+    }
+  }, [addToast, busy, close, design, onPlaceInLayout, onRequestCloseGallery, t]);
+
+  // The caller's own print decides whether the CTA posts or edits. The list
+  // response carries it even when it is not on the first page, so this is one
+  // request rather than a walk.
+  // Keyed off the id, not the design object: a counts refresh replaces the
+  // object without changing which design this is, and depending on the object
+  // would re-fetch prints every time.
+  const printsDesignId = design?.id ?? null;
+  useEffect(() => {
+    if (phase !== 'ready' || printsDesignId === null) return;
+    let cancelled = false;
+    void fetchPrints(printsDesignId).then((result) => {
+      if (cancelled) return;
+      if (isOk(result)) {
+        setOwnPrint({
+          designId: printsDesignId,
+          print: result.value.mine,
+          summary: result.value.summary,
+        });
+        setPrintItems({ designId: printsDesignId, items: result.value.items });
+        return;
+      }
+      // The kill switch is the one failure worth acting on: a CTA that opens a
+      // dialog which can only fail is worse than no CTA. Any other error just
+      // leaves the button in its "post" state.
+      setPrintsAvailable(result.error.kind !== 'disabled');
+      setOwnPrint({ designId: printsDesignId, print: null, summary: null });
+    });
+    return () => {
+      cancelled = true;
+    };
+    // printsRefresh is a dependency, not just PrintsSection's: the cost panel
+    // reads its summary from here, so without it a save could leave the panel
+    // showing "estimated" after the report that should have flipped it.
+  }, [phase, printsDesignId, printsRefresh]);
+
+  const stampedPrints = design !== null && ownPrint?.designId === design.id ? ownPrint : null;
+  const myPrint = stampedPrints?.print ?? null;
+  const printSummary = stampedPrints?.summary ?? null;
+
+  const mediaPrints =
+    design !== null && printItems?.designId === design.id ? printItems.items : EMPTY_PRINTS;
+  const images = useMemo(
+    () => buildDesignImages(design?.thumbnails ?? [], mediaPrints),
+    [design?.thumbnails, mediaPrints]
+  );
+
+  const handlePrintItemsChange = useCallback(
+    (items: readonly CommunityPrint[]) => {
+      if (design === null) return;
+      setPrintItems({ designId: design.id, items });
+    },
+    [design]
+  );
+
+  const handleOpenPhoto = useCallback(
+    (printId: string, photoIndex: number) => {
+      const index = findPhotoIndex(images, mediaPrints, printId, photoIndex);
+      if (index >= 0) setLightboxIndex(index);
+    },
+    [images, mediaPrints]
+  );
+
+  const closeLightbox = useCallback(() => setLightboxIndex(null), []);
+
+  const printDialogOpen = usePrintDialogStore((s) => s.phase !== 'closed');
+
+  // Opening by bare id rather than a card: an ancestor may sit outside the
+  // loaded index, and the detail view already handles a cold id fetch.
+  const handleOpenAncestor = useCallback((ancestorId: string) => {
+    useCommunityDetailStore.getState().open(ancestorId);
+  }, []);
+
+  const handleAddPrint = useCallback(() => {
+    if (design === null) return;
+    usePrintDialogStore.getState().open({
+      designId: design.id,
+      designName: design.name,
+      signedIn: sessionStatus === 'authenticated',
+      existing: myPrint,
+    });
+  }, [design, myPrint, sessionStatus]);
+
+  const handleFilterByAuthor = useCallback(() => {
+    if (design === null) return;
+    useBrowseStore.getState().setAuthor({ id: design.authorPublicId, name: design.authorName });
+    trackEvent('community_author_filter_applied', { surface: 'detail' });
+    // Closing reveals the gallery beneath (tab) or returns the route to
+    // /community, where the author sync appends ?author= for sharing.
+    close();
+  }, [close, design]);
+
+  const handleShare = useCallback(async () => {
+    const url = publicDesignUrl(designId);
+    try {
+      await navigator.clipboard.writeText(url);
+      addToast(t('community.detail.shareCopied'), 'success');
+    } catch {
+      addToast(t('community.detail.shareFailed'), 'error');
+    }
+  }, [addToast, designId, t]);
+
+  return {
+    t,
+    isMobile,
+    phase,
+    design,
+    detailStats,
+    isOwner,
+    authorIsSupporter,
+    setOwnPrint,
+    printsAvailable,
+    gapContext,
+    printsRefresh,
+    setPrintsRefresh,
+    reportPrintTarget,
+    setReportPrintTarget,
+    lightboxIndex,
+    setLightboxIndex,
+    ownerModeration,
+    offline,
+    busy,
+    parentResolution,
+    reportOpen,
+    setReportOpen,
+    signInIntent,
+    setSignInIntent,
+    overflowMenu,
+    setOverflowMenu,
+    designId,
+    card,
+    liveCard,
+    counts,
+    likedByMe,
+    handleToggleLike,
+    handleReportEntry,
+    handleOverflowOpen,
+    retry,
+    handleRemix,
+    handleDuplicate,
+    handleEditOriginal,
+    placeAvailable,
+    handlePlaceInLayout,
+    myPrint,
+    printSummary,
+    images,
+    handlePrintItemsChange,
+    handleOpenPhoto,
+    closeLightbox,
+    printDialogOpen,
+    handleOpenAncestor,
+    handleAddPrint,
+    handleFilterByAuthor,
+    handleShare,
+  };
+}

--- a/src/features/generation/worker/generators/assemblyPartCutter.ts
+++ b/src/features/generation/worker/generators/assemblyPartCutter.ts
@@ -1,0 +1,104 @@
+/** The profile cutter that carves an assembly part's outline out of its blank. */
+import { drawCircle, drawRoundedRectangle, fuseAll, unwrap } from 'brepjs';
+import type { Drawing, Shape3D, ValidSolid } from 'brepjs';
+import type { CutterParams, CutterProfile } from '@/shared/types/assembly';
+import {
+  clampPolygonSides,
+  regularPolygonPoints,
+  slotCornerRadius,
+} from '@/shared/utils/cutoutPolygon';
+import { dropCoincidentPoints } from '@/shared/utils/polyline';
+import { flattenPathToPolyline, pathWire, polylineSelfIntersects } from './cutoutBuilder';
+import { offsetClosedPolygon } from './polygonOffset';
+import { sketch } from './meshUtils';
+
+/** Cutters overshoot their seat so the cut opens the top face cleanly. */
+const CUTTER_TOP_OVERSHOOT = 1;
+
+function centeredOnBounds(pts: readonly { x: number; y: number }[]): { x: number; y: number }[] {
+  const xs = pts.map((p) => p.x);
+  const ys = pts.map((p) => p.y);
+  const cx = (Math.min(...xs) + Math.max(...xs)) / 2;
+  const cy = (Math.min(...ys) + Math.max(...ys)) / 2;
+  return pts.map((p) => ({ x: p.x - cx, y: p.y - cy }));
+}
+
+/**
+ * 2D drawing for a cutter profile, grown outward by `grow` mm. Matches the
+ * proxy's centering rule: parametric shapes are origin-centered, path and
+ * outline profiles are centered on their own bounding box. Null when the
+ * profile is degenerate.
+ */
+export function cutterProfileDrawing(profile: CutterProfile, grow: number): Drawing | null {
+  switch (profile.shape) {
+    case 'circle': {
+      const r = profile.diameter / 2 + grow;
+      return r > 0.05 ? drawCircle(r) : null;
+    }
+    case 'rectangle': {
+      const w = profile.width + 2 * grow;
+      const d = profile.depth + 2 * grow;
+      if (w <= 0.1 || d <= 0.1) return null;
+      const r = Math.min(Math.max(profile.cornerRadius + grow, 0), Math.min(w, d) / 2 - 0.01);
+      return drawRoundedRectangle(w, d, Math.max(r, 0));
+    }
+    case 'polygon': {
+      const sides = clampPolygonSides(profile.sides);
+      const dia = profile.diameter;
+      if (dia <= 0.1) return null;
+      const pts = regularPolygonPoints(sides, dia, dia);
+      const grown = grow !== 0 ? offsetClosedPolygon(pts, grow) : pts;
+      if (grown.length < 3) return null;
+      return pathWire(grown);
+    }
+    case 'slot': {
+      const length = profile.length + 2 * grow;
+      const width = profile.width + 2 * grow;
+      if (length <= 0.1 || width <= 0.1) return null;
+      return drawRoundedRectangle(length, width, slotCornerRadius(length, width) - 0.01);
+    }
+    case 'path': {
+      const polyline = dropCoincidentPoints(flattenPathToPolyline(profile.points));
+      if (polyline.length < 3 || polylineSelfIntersects(polyline)) return null;
+      const centered = centeredOnBounds(polyline);
+      const grown = grow !== 0 ? offsetClosedPolygon(centered, grow) : centered;
+      if (grown.length < 3) return null;
+      return pathWire(grown);
+    }
+    case 'outline': {
+      const polyline = dropCoincidentPoints(profile.points.map((p) => ({ x: p.x, y: p.y })));
+      if (polyline.length < 3 || polylineSelfIntersects(polyline)) return null;
+      const centered = centeredOnBounds(polyline);
+      const grown = grow !== 0 ? offsetClosedPolygon(centered, grow) : centered;
+      if (grown.length < 3) return null;
+      return pathWire(grown);
+    }
+  }
+}
+
+/**
+ * A cutter tool solid in the seat frame: occupies z ∈ [-depth, +overshoot]
+ * with an optional 45°-ish entry chamfer collar lofted at the seat.
+ */
+export function buildCutterSolid(params: CutterParams): Shape3D | null {
+  const drawing = cutterProfileDrawing(params.profile, params.clearance);
+  if (!drawing) return null;
+  const body = sketch(drawing, 'XY', -params.depth).extrude(params.depth + CUTTER_TOP_OVERSHOOT);
+  if (params.chamfer <= 0) return body;
+  const inner = cutterProfileDrawing(params.profile, params.clearance);
+  const outer = cutterProfileDrawing(params.profile, params.clearance + params.chamfer);
+  if (!inner || !outer) return body;
+  try {
+    const collar = sketch(inner, 'XY', -params.chamfer).loftWith(
+      [sketch(outer, 'XY', CUTTER_TOP_OVERSHOOT)],
+      { ruled: true }
+    );
+    const fused = fuseAll([body, collar] as ValidSolid[], { optimisation: 'commonFace' });
+    const result = unwrap(fused);
+    if (result !== body) body.delete();
+    if (result !== collar) collar.delete();
+    return result;
+  } catch {
+    return body;
+  }
+}

--- a/src/features/generation/worker/generators/assemblyPartTemplate.ts
+++ b/src/features/generation/worker/generators/assemblyPartTemplate.ts
@@ -8,7 +8,6 @@ import {
   cutAll,
   cylinder,
   draw,
-  drawCircle,
   drawRoundedRectangle,
   edgeFinder,
   fuseAll,
@@ -19,23 +18,13 @@ import {
   translate,
   unwrap,
 } from 'brepjs';
-import type { Drawing, Edge, Shape3D, ValidSolid } from 'brepjs';
-import type { AssemblyPartNode, CutterParams, CutterProfile } from '@/shared/types/assembly';
-import {
-  clampPolygonSides,
-  regularPolygonPoints,
-  slotCornerRadius,
-} from '@/shared/utils/cutoutPolygon';
-import { dropCoincidentPoints } from '@/shared/utils/polyline';
+import type { Edge, Shape3D, ValidSolid } from 'brepjs';
+import type { AssemblyPartNode } from '@/shared/types/assembly';
 import { COPLANAR_OVERLAP } from './generatorConstants';
-import {
-  applyFilletWithFallback,
-  flattenPathToPolyline,
-  pathWire,
-  polylineSelfIntersects,
-} from './cutoutBuilder';
-import { offsetClosedPolygon } from './polygonOffset';
+import { applyFilletWithFallback } from './cutoutBuilder';
 import { sketch } from './meshUtils';
+import { buildCutterSolid } from './assemblyPartCutter';
+export { cutterProfileDrawing } from './assemblyPartCutter';
 
 export const DEG = Math.PI / 180;
 
@@ -49,17 +38,6 @@ export const DEG = Math.PI / 180;
 const TOP_EASE_MM = 1;
 
 const CORNER_FILLET_MM = 2.5;
-
-/** Cutters overshoot their seat so the cut opens the top face cleanly. */
-const CUTTER_TOP_OVERSHOOT = 1;
-
-function centeredOnBounds(pts: readonly { x: number; y: number }[]): { x: number; y: number }[] {
-  const xs = pts.map((p) => p.x);
-  const ys = pts.map((p) => p.y);
-  const cx = (Math.min(...xs) + Math.max(...xs)) / 2;
-  const cy = (Math.min(...ys) + Math.max(...ys)) / 2;
-  return pts.map((p) => ({ x: p.x - cx, y: p.y - cy }));
-}
 
 /** Edges lying IN the plane at `z` (planar rims, junction seams) — never a
  *  vertical edge that merely crosses it, the classic sliver source. */
@@ -126,86 +104,6 @@ function easedOrOriginal(shape: Shape3D, edges: readonly Edge[], radius: number)
   const result = applyFilletWithFallback(shape, edges, radius);
   if (result !== shape) shape.delete();
   return result;
-}
-
-/**
- * 2D drawing for a cutter profile, grown outward by `grow` mm. Matches the
- * proxy's centering rule: parametric shapes are origin-centered, path and
- * outline profiles are centered on their own bounding box. Null when the
- * profile is degenerate.
- */
-export function cutterProfileDrawing(profile: CutterProfile, grow: number): Drawing | null {
-  switch (profile.shape) {
-    case 'circle': {
-      const r = profile.diameter / 2 + grow;
-      return r > 0.05 ? drawCircle(r) : null;
-    }
-    case 'rectangle': {
-      const w = profile.width + 2 * grow;
-      const d = profile.depth + 2 * grow;
-      if (w <= 0.1 || d <= 0.1) return null;
-      const r = Math.min(Math.max(profile.cornerRadius + grow, 0), Math.min(w, d) / 2 - 0.01);
-      return drawRoundedRectangle(w, d, Math.max(r, 0));
-    }
-    case 'polygon': {
-      const sides = clampPolygonSides(profile.sides);
-      const dia = profile.diameter;
-      if (dia <= 0.1) return null;
-      const pts = regularPolygonPoints(sides, dia, dia);
-      const grown = grow !== 0 ? offsetClosedPolygon(pts, grow) : pts;
-      if (grown.length < 3) return null;
-      return pathWire(grown);
-    }
-    case 'slot': {
-      const length = profile.length + 2 * grow;
-      const width = profile.width + 2 * grow;
-      if (length <= 0.1 || width <= 0.1) return null;
-      return drawRoundedRectangle(length, width, slotCornerRadius(length, width) - 0.01);
-    }
-    case 'path': {
-      const polyline = dropCoincidentPoints(flattenPathToPolyline(profile.points));
-      if (polyline.length < 3 || polylineSelfIntersects(polyline)) return null;
-      const centered = centeredOnBounds(polyline);
-      const grown = grow !== 0 ? offsetClosedPolygon(centered, grow) : centered;
-      if (grown.length < 3) return null;
-      return pathWire(grown);
-    }
-    case 'outline': {
-      const polyline = dropCoincidentPoints(profile.points.map((p) => ({ x: p.x, y: p.y })));
-      if (polyline.length < 3 || polylineSelfIntersects(polyline)) return null;
-      const centered = centeredOnBounds(polyline);
-      const grown = grow !== 0 ? offsetClosedPolygon(centered, grow) : centered;
-      if (grown.length < 3) return null;
-      return pathWire(grown);
-    }
-  }
-}
-
-/**
- * A cutter tool solid in the seat frame: occupies z ∈ [-depth, +overshoot]
- * with an optional 45°-ish entry chamfer collar lofted at the seat.
- */
-function buildCutterSolid(params: CutterParams): Shape3D | null {
-  const drawing = cutterProfileDrawing(params.profile, params.clearance);
-  if (!drawing) return null;
-  const body = sketch(drawing, 'XY', -params.depth).extrude(params.depth + CUTTER_TOP_OVERSHOOT);
-  if (params.chamfer <= 0) return body;
-  const inner = cutterProfileDrawing(params.profile, params.clearance);
-  const outer = cutterProfileDrawing(params.profile, params.clearance + params.chamfer);
-  if (!inner || !outer) return body;
-  try {
-    const collar = sketch(inner, 'XY', -params.chamfer).loftWith(
-      [sketch(outer, 'XY', CUTTER_TOP_OVERSHOOT)],
-      { ruled: true }
-    );
-    const fused = fuseAll([body, collar] as ValidSolid[], { optimisation: 'commonFace' });
-    const result = unwrap(fused);
-    if (result !== body) body.delete();
-    if (result !== collar) collar.delete();
-    return result;
-  } catch {
-    return body;
-  }
 }
 
 /**

--- a/src/features/grid-editor/components/Grid/IsometricPreview/useIsometricPreview.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/useIsometricPreview.ts
@@ -1,6 +1,5 @@
 /** Store selections, camera and interaction state behind the isometric preview; the component keeps the markup. */
 import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
-// Side-effect: must run before any <Text> mounts under this Canvas.
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { effectiveGridUnitMmY } from '@/core/types';


### PR DESCRIPTION
Last batch of the `max-lines` sweep. With #4203 this brings `pnpm run lint` to zero `max-lines` warnings.

**Moves**

- `CommunityDetail.tsx` (682 code lines, now 378): the dialog's record loading, print and moderation state, and every action handler move into `useCommunityDetailDialog.ts` (421), the same hook-plus-view shape as the previous batch; the component keeps its host wrapper, the two JSX constants and the markup. Hook order, dependency arrays and handler bodies are unchanged.
- `assemblyPartTemplate.ts` (516 after the previous generator split) hands the profile cutter (`centeredOnBounds`, `cutterProfileDrawing`, `buildCutterSolid`) to `assemblyPartCutter.ts` and lands at 429.

**Exemptions**

Three hooks join the existing "single coordinating hook" entry in the ESLint `max-lines` allow-list, each with its reason inline: `useLidSection.ts` (one `state`/`handlers` pair for the whole lid section), `useLabelTabsSection.ts` (label plan, warnings and every setter in one closure) and `useWorkshopInteraction.ts` (drag, rotate and hover share one pointer state machine). Splitting any of them would mean threading a dozen setters through a second hook for no reader's benefit; the precedent for the entry is `useBinInspector.ts`.

**Verification**

- Typecheck, ESLint and the pre-commit gates pass.
- Vitest over the CommunityDetail folder (7 files, 108 tests) and the assembly generator suites (4 files, 30 tests).
- Full `pnpm run lint` on this branch reports only the six files #4203 fixes.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

