### PR TITLE
fix: clamp anchored overflow menus to the viewport

### DIFF
--- a/src/shared/hooks/useAnchoredMenu.test.tsx
+++ b/src/shared/hooks/useAnchoredMenu.test.tsx
@@ -58,6 +58,30 @@ describe('useAnchoredMenu', () => {
     expect(menu.style.top).toBe('');
   });
 
+  it('clamps max-height to the room below and scrolls, so content taller than the viewport never lands off-screen', () => {
+    render(<Harness />);
+    const button = screen.getByRole('button', { name: 'more' });
+    vi.spyOn(button, 'getBoundingClientRect').mockReturnValue(rectAt(100));
+
+    fireEvent.click(button);
+
+    const menu = screen.getByRole('menu');
+    expect(menu.style.maxHeight).toBe('676px');
+    expect(menu.style.overflowY).toBe('auto');
+  });
+
+  it('clamps max-height to the room above when opening upward', () => {
+    render(<Harness />);
+    const button = screen.getByRole('button', { name: 'more' });
+    vi.spyOn(button, 'getBoundingClientRect').mockReturnValue(rectAt(700));
+
+    fireEvent.click(button);
+
+    const menu = screen.getByRole('menu');
+    expect(menu.style.maxHeight).toBe('696px');
+    expect(menu.style.overflowY).toBe('auto');
+  });
+
   it('closes on a click outside and reports it', () => {
     const onClose = vi.fn();
     render(<Harness onClose={onClose} />);

--- a/src/shared/hooks/useAnchoredMenu.ts
+++ b/src/shared/hooks/useAnchoredMenu.ts
@@ -59,10 +59,16 @@ export function useAnchoredMenu({ onClose }: UseAnchoredMenuOptions = {}) {
       const button = menuButtonRef.current;
       if (button) {
         const rect = button.getBoundingClientRect();
-        const openAbove = window.innerHeight - rect.bottom < MIN_SPACE_BELOW_PX;
+        const spaceBelowPx = window.innerHeight - rect.bottom;
+        const openAbove = spaceBelowPx < MIN_SPACE_BELOW_PX;
         setMenuStyle({
           position: 'fixed',
           right: window.innerWidth - rect.right,
+          // Clamps content taller than the available side regardless of cause
+          // (a longer-language label set, a deep menu, a short viewport) so the
+          // last item scrolls into view instead of landing off-screen.
+          maxHeight: Math.max(0, (openAbove ? rect.top : spaceBelowPx) - GAP_PX),
+          overflowY: 'auto',
           ...(openAbove
             ? { bottom: window.innerHeight - rect.top + GAP_PX }
             : { top: rect.bottom + GAP_PX }),


### PR DESCRIPTION
## Summary
- `useAnchoredMenu` decided which side of the button to open on, but never bounded the menu's own rendered height against the available space
- In German, several Saved Designs menu labels ("Im Layout platzieren", "JSON herunterladen") wrap to two lines, making the menu taller than the 200px threshold assumed room below the button — pushing Delete off the bottom of the screen with no way to reach it
- Clamp `maxHeight` to the actual room on whichever side the menu opens and let it scroll internally, so this holds for any locale, item count, or viewport size, not just German

## Test plan
- [x] `pnpm run test:run src/shared/hooks/useAnchoredMenu.test.tsx` — new coverage for the max-height clamp on both open-above and open-below
- [x] `pnpm run test:run` on the three consumers (bin-designer DesignActions, layout-library LayoutActions, baseplate BaseplateLibraryModal) — all pass unchanged

Fixes #4209

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

