### PR TITLE
fix: reach the hinge trim cut to the wall's corners, not just the run

### DIFF
--- a/src/features/generation/worker/generators/hingeBarrel.ts
+++ b/src/features/generation/worker/generators/hingeBarrel.ts
@@ -425,7 +425,9 @@ export function applyLidHinge(
   const bores: Shape3D[] = [];
 
   for (const run of g.runs) {
-    cutters.push(orient(scope, trimHalfSpace(scope, g, frame, run.lo, run.hi), frame.rotationDeg));
+    cutters.push(
+      orient(scope, trimHalfSpace(scope, g, frame, run.trimLo, run.trimHi), frame.rotationDeg)
+    );
     for (const cutter of slotCutters(scope, g, frame, run, 'bin')) {
       cutters.push(orient(scope, cutter, frame.rotationDeg));
     }
@@ -443,9 +445,14 @@ export function applyLidHinge(
     bores.push(...boresFor(scope, g, frame, run).map((b) => orient(scope, b, frame.rotationDeg)));
   }
 
-  // A run's trim only spans that run, so a wall segmented by a cutout keeps
-  // its shell across the gap between runs — which is correct: there is no
-  // barrel there to swing about, and the material is what the gap needs.
+  // The trim reaches `run.trimLo/trimHi`, not `run.lo/hi`: those only bound
+  // where a KNUCKLE may sit, inset from the wall's ends for corner clearance,
+  // and the bin's lip is fully present under that margin. The trim cut has to
+  // reach it too, or the untouched strip there keeps its full closed-position
+  // profile and sweeps into the bin's corner on every hinge wall, obstructed
+  // or not (#4147). Only where an obstruction (a cutout, a handle) actually
+  // removes the lip does the trim stop short, at `trimLo`/`trimHi` — the plan
+  // states that boundary, not this builder.
   //
   // The scope owns each body this REPLACES, never the one it returns: a
   // registered result would be freed the moment the scope closes, and the

--- a/src/features/generation/worker/generators/hingeBarrel.ts
+++ b/src/features/generation/worker/generators/hingeBarrel.ts
@@ -450,9 +450,9 @@ export function applyLidHinge(
   // and the bin's lip is fully present under that margin. The trim cut has to
   // reach it too, or the untouched strip there keeps its full closed-position
   // profile and sweeps into the bin's corner on every hinge wall, obstructed
-  // or not (#4147). Only where an obstruction (a cutout, a handle) actually
-  // removes the lip does the trim stop short, at `trimLo`/`trimHi` — the plan
-  // states that boundary, not this builder.
+  // or not. Only where an obstruction (a cutout, a handle) actually removes
+  // the lip does the trim stop short, at `trimLo`/`trimHi` — the plan states
+  // that boundary, not this builder.
   //
   // The scope owns each body this REPLACES, never the one it returns: a
   // registered result would be freed the moment the scope closes, and the

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -35,7 +35,11 @@ import {
 import { lidZOffset } from './__kernel-tests__/lidSeating';
 import { boundingBox } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
-import { DEFAULT_LID_HINGE_CONFIG, LID_HINGE_PIN_MM } from '@/features/bin-designer/types/lid';
+import {
+  DEFAULT_LID_HINGE_CONFIG,
+  LID_HINGE_FACE_RELIEF_MM,
+  LID_HINGE_PIN_MM,
+} from '@/features/bin-designer/types/lid';
 import { planHingeLid } from '@/shared/utils/hingeLidPlan';
 import { overhangExpansion, resolveOverhang } from '@/shared/utils/overhang';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
@@ -62,6 +66,23 @@ const CONTACT_FLOOR_MM3 = 5;
  * Measured 0.0mm³ through 104° and 0.1 at 106, so this sits in the gap.
  */
 const STOP_CONTACT_FLOOR_MM3 = 0.3;
+
+/**
+ * Shared-volume floor (mm³) for corner clearance once the lid has actually
+ * lifted off its closed pose.
+ *
+ * Tighter than {@link CONTACT_FLOOR_MM3}, on purpose: that floor has to
+ * tolerate the coincident-face noise a boolean leaves AT 0°, which is a
+ * closed-pose artifact, not a mid-swing one. #4147 shipped a sliver of
+ * exactly that shape — the lid's corner-inset margin (no obstruction narrows
+ * the run there, so nothing trimmed it) swinging into the bin's corner,
+ * measured 0.0000mm³ through 1°, then 0.04-0.15mm³ from 2° through 30° on the
+ * reported design and the default params here alike, comfortably under the
+ * coarser floor. Sampling only once the closed-pose noise has cleared catches
+ * that class without retuning the floor every other angle in the suite
+ * depends on.
+ */
+const CORNER_CONTACT_FLOOR_MM3 = 0.05;
 
 function hingeParams(
   over: Partial<BinParams> = {},
@@ -133,6 +154,29 @@ describe('hinged lid', () => {
         const samples = await sweepSwing(bin, lid, axis, dz, [0, 5, 10, 20, 40, 60, 80, 95, 100]);
         const worst = samples.reduce((a, b) => (b.mm3 > a.mm3 ? b : a));
         expect(worst.mm3).toBeLessThan(CONTACT_FLOOR_MM3);
+      } finally {
+        lid.delete();
+      }
+    },
+    600_000
+  );
+
+  it.each<LidRailSide>(['back', 'front', 'left', 'right'])(
+    'clears the bin corner where no obstruction narrows the hinge run, on the %s wall (#4147)',
+    async (side) => {
+      // A plain box: no cutout or handle to create a genuine obstruction gap,
+      // so the run's ends sit at the corner-inset margin on both sides — the
+      // one case #4147's fix has to hold for. `CONTACT_FLOOR_MM3` alone would
+      // not have caught this: the collision peaks under 0.2mm³, two orders of
+      // magnitude below it.
+      const params = hingeParams({}, { side, catchMode: 'none' });
+      const { bin, lid, dz } = await buildSolids(params);
+      const axis = swingAxis(params, 0, 0);
+      if (!axis) throw new Error('expected an axis');
+      try {
+        const samples = await sweepSwing(bin, lid, axis, dz, [2, 5, 8, 10, 12, 15, 18, 20, 25, 30]);
+        const worst = samples.reduce((a, b) => (b.mm3 > a.mm3 ? b : a));
+        expect(worst.mm3).toBeLessThan(CORNER_CONTACT_FLOOR_MM3);
       } finally {
         lid.delete();
       }
@@ -225,7 +269,12 @@ describe('hinged lid', () => {
   it('grows the footprint by the overhang and not by the hinge', async () => {
     // The hinge must add nothing to a footprint the overhang has already
     // widened — the barrel is inset from wherever the face ended up, not hung
-    // off the nominal one.
+    // off the nominal one. The lid's own cross-axis span (Y, for a back-wall
+    // hinge) is a deliberate exception: the trim now reaches the wall's
+    // corners (#4147), so the nose there — like everywhere else along the
+    // wall — sits `LID_HINGE_FACE_RELIEF_MM` inboard of the friction control,
+    // the same relief that keeps the barrel off a boolean-hostile tangent
+    // line. A shrink, never a growth, which is what this test guards against.
     const over = { enabled: true, left: 0, right: 2, front: 0, back: 3 };
     const params = hingeParams({ overhang: over }, { side: 'back', catchMode: 'none' });
     const hinged = await meshes(params);
@@ -237,9 +286,10 @@ describe('hinged lid', () => {
         what,
         x: +(b.maxX - b.minX).toFixed(3),
       });
-      expect({ what, y: +(a.maxY - a.minY).toFixed(3) }).toEqual({
+      const yShrink = +(b.maxY - b.minY - (a.maxY - a.minY)).toFixed(3);
+      expect({ what, yShrink }).toEqual({
         what,
-        y: +(b.maxY - b.minY).toFixed(3),
+        yShrink: what === 'lid' ? LID_HINGE_FACE_RELIEF_MM : 0,
       });
     }
   }, 600_000);
@@ -250,6 +300,13 @@ describe('hinged lid', () => {
     // print, still swing, and still take its pin — and would foul the bin
     // behind it and refuse to seat in its own baseplate cell. Nothing else in
     // the suite would notice.
+    //
+    // The lid's own footprint on its CROSS axis (perpendicular to the hinge
+    // wall — Y for back/front, X for left/right) is the one deliberate
+    // exception: since #4147, the trim reaches the wall's corners too, so the
+    // nose sits `LID_HINGE_FACE_RELIEF_MM` inboard of spec there, same as
+    // along the rest of the wall. Every other axis, and the bin on every
+    // axis, still hits spec exactly.
     for (const side of ['back', 'front', 'left', 'right'] as const) {
       const params = hingeParams({}, { side, catchMode: 'none' });
       const hinged = await meshes(params);
@@ -259,11 +316,14 @@ describe('hinged lid', () => {
         x: params.width * params.gridUnitMm - GRIDFINITY_SPEC.TOLERANCE,
         y: params.depth * params.gridUnitMm - GRIDFINITY_SPEC.TOLERANCE,
       };
+      const alongX = side === 'back' || side === 'front';
       for (const [what, mesh] of [
         ['bin', hinged.bin],
         ['lid', hinged.lid],
       ] as const) {
         const bb = boundingBox(mesh.vertices);
+        const reliefX = what === 'lid' && !alongX ? LID_HINGE_FACE_RELIEF_MM : 0;
+        const reliefY = what === 'lid' && alongX ? LID_HINGE_FACE_RELIEF_MM : 0;
         // Against the SPEC, not against the control: the control proves the
         // hinge changed nothing, the spec proves what it did not change was
         // already right. Either alone would pass a pair that agreed and were
@@ -271,12 +331,12 @@ describe('hinged lid', () => {
         expect({ side, what, x: +(bb.maxX - bb.minX).toFixed(3) }).toEqual({
           side,
           what,
-          x: spec.x,
+          x: +(spec.x - reliefX).toFixed(3),
         });
         expect({ side, what, y: +(bb.maxY - bb.minY).toFixed(3) }).toEqual({
           side,
           what,
-          y: spec.y,
+          y: +(spec.y - reliefY).toFixed(3),
         });
       }
 

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -73,14 +73,9 @@ const STOP_CONTACT_FLOOR_MM3 = 0.3;
  *
  * Tighter than {@link CONTACT_FLOOR_MM3}, on purpose: that floor has to
  * tolerate the coincident-face noise a boolean leaves AT 0°, which is a
- * closed-pose artifact, not a mid-swing one. #4147 shipped a sliver of
- * exactly that shape — the lid's corner-inset margin (no obstruction narrows
- * the run there, so nothing trimmed it) swinging into the bin's corner,
- * measured 0.0000mm³ through 1°, then 0.04-0.15mm³ from 2° through 30° on the
- * reported design and the default params here alike, comfortably under the
- * coarser floor. Sampling only once the closed-pose noise has cleared catches
- * that class without retuning the floor every other angle in the suite
- * depends on.
+ * closed-pose artifact, not a mid-swing one. Sampling only once the
+ * closed-pose noise has cleared catches a genuine corner collision without
+ * retuning the floor every other angle in the suite depends on.
  */
 const CORNER_CONTACT_FLOOR_MM3 = 0.05;
 
@@ -162,13 +157,12 @@ describe('hinged lid', () => {
   );
 
   it.each<LidRailSide>(['back', 'front', 'left', 'right'])(
-    'clears the bin corner where no obstruction narrows the hinge run, on the %s wall (#4147)',
+    'clears the bin corner where no obstruction narrows the hinge run, on the %s wall',
     async (side) => {
       // A plain box: no cutout or handle to create a genuine obstruction gap,
-      // so the run's ends sit at the corner-inset margin on both sides — the
-      // one case #4147's fix has to hold for. `CONTACT_FLOOR_MM3` alone would
-      // not have caught this: the collision peaks under 0.2mm³, two orders of
-      // magnitude below it.
+      // so the run's ends sit at the corner-inset margin on both sides.
+      // `CONTACT_FLOOR_MM3` alone would not catch a collision here: it peaks
+      // two orders of magnitude below that floor.
       const params = hingeParams({}, { side, catchMode: 'none' });
       const { bin, lid, dz } = await buildSolids(params);
       const axis = swingAxis(params, 0, 0);
@@ -270,11 +264,11 @@ describe('hinged lid', () => {
     // The hinge must add nothing to a footprint the overhang has already
     // widened — the barrel is inset from wherever the face ended up, not hung
     // off the nominal one. The lid's own cross-axis span (Y, for a back-wall
-    // hinge) is a deliberate exception: the trim now reaches the wall's
-    // corners (#4147), so the nose there — like everywhere else along the
-    // wall — sits `LID_HINGE_FACE_RELIEF_MM` inboard of the friction control,
-    // the same relief that keeps the barrel off a boolean-hostile tangent
-    // line. A shrink, never a growth, which is what this test guards against.
+    // hinge) is a deliberate exception: the trim reaches the wall's corners,
+    // so the nose there — like everywhere else along the wall — sits
+    // `LID_HINGE_FACE_RELIEF_MM` inboard of the friction control, the same
+    // relief that keeps the barrel off a boolean-hostile tangent line. A
+    // shrink, never a growth, which is what this test guards against.
     const over = { enabled: true, left: 0, right: 2, front: 0, back: 3 };
     const params = hingeParams({ overhang: over }, { side: 'back', catchMode: 'none' });
     const hinged = await meshes(params);
@@ -303,10 +297,10 @@ describe('hinged lid', () => {
     //
     // The lid's own footprint on its CROSS axis (perpendicular to the hinge
     // wall — Y for back/front, X for left/right) is the one deliberate
-    // exception: since #4147, the trim reaches the wall's corners too, so the
-    // nose sits `LID_HINGE_FACE_RELIEF_MM` inboard of spec there, same as
-    // along the rest of the wall. Every other axis, and the bin on every
-    // axis, still hits spec exactly.
+    // exception: the trim reaches the wall's corners too, so the nose sits
+    // `LID_HINGE_FACE_RELIEF_MM` inboard of spec there, same as along the
+    // rest of the wall. Every other axis, and the bin on every axis, still
+    // hits spec exactly.
     for (const side of ['back', 'front', 'left', 'right'] as const) {
       const params = hingeParams({}, { side, catchMode: 'none' });
       const hinged = await meshes(params);

--- a/src/shared/utils/hingeLidPlan.test.ts
+++ b/src/shared/utils/hingeLidPlan.test.ts
@@ -173,6 +173,30 @@ describe('planHingeLid — segmentation around absences', () => {
     expect(one.geometry?.runs).toHaveLength(1);
   });
 
+  it("reaches the trim to the cutout's true edge, not the rail's safety margin", async () => {
+    // #4211 review: `clearRuns` used to subtract `lipGapRailBlocks` — each
+    // gap widened by `LIP_GAP_RAIL_MARGIN` (1mm) — for BOTH the knuckle span
+    // AND the trim span. That margin is right for a knuckle root (stay clear
+    // of the cutout edge), but told the trim the lip was absent for that
+    // extra 1mm too. The lip is not absent there — only the cutout itself
+    // removed it — so the trim stopped 1mm short of the cutout's real edge,
+    // reintroducing this file's own bug (#4147) in miniature next to every
+    // cutout or handle on a hinge wall.
+    const { lipGaps } = await import('./lipGapPlan');
+    const p = withCutout('back', 'back', 30);
+    const gap = lipGaps(p).find((g) => g.side === 'back');
+    if (!gap) throw new Error('expected a lip gap on the cutout wall');
+
+    const plan = planHingeLid(p);
+    expect(plan.geometry?.runs).toHaveLength(2);
+    const [left, right] = plan.geometry!.runs;
+    // The run below the cutout reaches up to the cutout's own lower edge;
+    // the run above it starts at the cutout's own upper edge — not 1mm short
+    // on either side.
+    expect(left.trimHi).toBeCloseTo(gap.lo, 6);
+    expect(right.trimLo).toBeCloseTo(gap.hi, 6);
+  });
+
   it('does NOT segment around dividers or label tabs', () => {
     // Both live inboard of the inner wall face and below the rim; the barrel is
     // above the rim and hard against the outer face. Which walls an obstruction

--- a/src/shared/utils/hingeLidPlan.test.ts
+++ b/src/shared/utils/hingeLidPlan.test.ts
@@ -174,14 +174,11 @@ describe('planHingeLid — segmentation around absences', () => {
   });
 
   it("reaches the trim to the cutout's true edge, not the rail's safety margin", async () => {
-    // #4211 review: `clearRuns` used to subtract `lipGapRailBlocks` — each
-    // gap widened by `LIP_GAP_RAIL_MARGIN` (1mm) — for BOTH the knuckle span
-    // AND the trim span. That margin is right for a knuckle root (stay clear
-    // of the cutout edge), but told the trim the lip was absent for that
-    // extra 1mm too. The lip is not absent there — only the cutout itself
-    // removed it — so the trim stopped 1mm short of the cutout's real edge,
-    // reintroducing this file's own bug (#4147) in miniature next to every
-    // cutout or handle on a hinge wall.
+    // `LIP_GAP_RAIL_MARGIN` widens a gap for knuckle-root clearance, but the
+    // lip is only actually absent where the cutout itself removed it. The
+    // trim must key off the raw gap bounds, not the margin-widened ones, or
+    // it stops short of the cutout's real edge — an untrimmed strip next to
+    // every cutout or handle on a hinge wall.
     const { lipGaps } = await import('./lipGapPlan');
     const p = withCutout('back', 'back', 30);
     const gap = lipGaps(p).find((g) => g.side === 'back');

--- a/src/shared/utils/hingeLidPlan.test.ts
+++ b/src/shared/utils/hingeLidPlan.test.ts
@@ -185,8 +185,9 @@ describe('planHingeLid — segmentation around absences', () => {
     if (!gap) throw new Error('expected a lip gap on the cutout wall');
 
     const plan = planHingeLid(p);
-    expect(plan.geometry?.runs).toHaveLength(2);
-    const [left, right] = plan.geometry!.runs;
+    if (!plan.geometry) throw new Error('expected hinge geometry');
+    expect(plan.geometry.runs).toHaveLength(2);
+    const [left, right] = plan.geometry.runs;
     // The run below the cutout reaches up to the cutout's own lower edge;
     // the run above it starts at the cutout's own upper edge — not 1mm short
     // on either side.

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -191,14 +191,13 @@ export interface HingeRun {
    *
    * `lo`/`hi` reserve {@link LID_HINGE_CORNER_INSET_MM} off each end for
    * knuckle placement, but that margin does not remove the bin's lip — only an
-   * obstruction does. Trimming the lid only to `[lo, hi]` left the corner
-   * margin's lid material un-trimmed, still carrying its full closed-position
-   * profile, which is what the lid swept into the bin's rounded corner on
-   * every plain hinge wall (#4147): nothing had to be obstructed for the bug
-   * to fire, because the untrimmed strip is there on every design. An end that
-   * IS adjacent to an obstruction keeps `lo`/`hi` exactly — the bin's lip is
-   * genuinely gone there, so there is nothing left to collide with, and the
-   * material past it is what the gap needs.
+   * obstruction does. An end not adjacent to an obstruction still carries the
+   * bin's lip at full closed-position profile past `lo`/`hi`, so the trim
+   * must reach past it too or that untrimmed strip sweeps into the bin's
+   * rounded corner mid-swing, on every plain hinge wall regardless of
+   * obstruction. An end that IS adjacent to an obstruction keeps `lo`/`hi`
+   * exactly — the bin's lip is genuinely gone there, so there is nothing left
+   * to collide with, and the material past it is what the gap needs.
    */
   readonly trimLo: number;
   readonly trimHi: number;
@@ -384,10 +383,10 @@ const CLEAR_RUN_EPSILON_MM = 1e-6;
  * wide (trim) pass subtracts the RAW {@link LipGap} bounds instead: widening
  * there would tell the trim the lip is absent for that extra margin too,
  * when it is not, and the trim would stop short of the true obstruction edge
- * by exactly that margin — an untrimmed strip next to every cutout or handle
- * on a hinge wall, the same class of bug this file exists to fix (#4147),
- * just narrower. See the module header on why dividers and label tabs are
- * deliberately absent from both lists.
+ * by exactly that margin — an untrimmed strip left next to every cutout or
+ * handle on a hinge wall, the same corner-collision failure this file exists
+ * to prevent, just narrower. See the module header on why dividers and label
+ * tabs are deliberately absent from both lists.
  *
  * Runs the obstruction subtraction twice, from two different starting
  * intervals: once from the full span for the wide stretches where the bin's

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -378,26 +378,33 @@ const CLEAR_RUN_EPSILON_MM = 1e-6;
 /**
  * Stretches of the hinge wall no absence has taken.
  *
- * Only {@link lipGapRailBlocks} feeds this — see the module header on why
- * dividers and label tabs are deliberately absent from the list.
+ * The narrow (knuckle-placement) pass subtracts {@link lipGapRailBlocks} —
+ * each obstruction widened by `LIP_GAP_RAIL_MARGIN` — the same margin every
+ * other rail consumer keeps a knuckle root clear of a cutout's edge by. The
+ * wide (trim) pass subtracts the RAW {@link LipGap} bounds instead: widening
+ * there would tell the trim the lip is absent for that extra margin too,
+ * when it is not, and the trim would stop short of the true obstruction edge
+ * by exactly that margin — an untrimmed strip next to every cutout or handle
+ * on a hinge wall, the same class of bug this file exists to fix (#4147),
+ * just narrower. See the module header on why dividers and label tabs are
+ * deliberately absent from both lists.
  *
- * Runs the same obstruction subtraction twice, from two different starting
- * intervals: once from the full span, for the wide stretches where the bin's
+ * Runs the obstruction subtraction twice, from two different starting
+ * intervals: once from the full span for the wide stretches where the bin's
  * lip genuinely exists, and once from the span already narrowed by
- * {@link LID_HINGE_CORNER_INSET_MM}, for where a knuckle may sit. Every
- * narrow segment nests inside exactly one wide one — the narrow pass
- * subtracts the identical blocks from a tighter interval, so it can only
- * shrink further, never cross a wide boundary — which is what lets each
+ * {@link LID_HINGE_CORNER_INSET_MM} for where a knuckle may sit. Every
+ * narrow segment nests inside exactly one wide one — the margin only makes
+ * the narrow pass's blocks a superset of the wide pass's, so it can still
+ * only shrink further, never cross a wide boundary — which is what lets each
  * narrow run look up the wide extent its trim cut needs.
  */
 function clearRuns(params: BinParams, side: LidCompatibilitySide, span: number): ClearRun[] {
-  const blocks: readonly WallSpanBlock[] = lipGapRailBlocks(lipGaps(params)).filter(
-    (b) => b.side === side
-  );
+  const gaps = lipGaps(params).filter((g) => g.side === side);
+  const railBlocks: readonly WallSpanBlock[] = lipGapRailBlocks(gaps);
 
   let wide: RailSegment[] = [{ lo: -span / 2, hi: span / 2 }];
-  for (const b of blocks) {
-    wide = subtractSpan(wide, b.lo, b.hi);
+  for (const g of gaps) {
+    wide = subtractSpan(wide, g.lo, g.hi);
     if (wide.length === 0) break;
   }
 
@@ -405,7 +412,7 @@ function clearRuns(params: BinParams, side: LidCompatibilitySide, span: number):
   const narrowHi = span / 2 - LID_HINGE_CORNER_INSET_MM;
   if (narrowHi <= narrowLo) return [];
   let narrow: RailSegment[] = [{ lo: narrowLo, hi: narrowHi }];
-  for (const b of blocks) {
+  for (const b of railBlocks) {
     narrow = subtractSpan(narrow, b.lo, b.hi);
     if (narrow.length === 0) break;
   }

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -426,8 +426,10 @@ function clearRuns(params: BinParams, side: LidCompatibilitySide, span: number):
       return {
         lo: s.lo,
         hi: s.hi,
-        trimLo: w.lo <= -span / 2 + CLEAR_RUN_EPSILON_MM ? -HINGE_TRIM_AXIAL_REACH_MM : w.lo,
-        trimHi: w.hi >= span / 2 - CLEAR_RUN_EPSILON_MM ? HINGE_TRIM_AXIAL_REACH_MM : w.hi,
+        trimLo:
+          w.lo <= -span / 2 + CLEAR_RUN_EPSILON_MM ? -span / 2 - HINGE_TRIM_AXIAL_REACH_MM : w.lo,
+        trimHi:
+          w.hi >= span / 2 - CLEAR_RUN_EPSILON_MM ? span / 2 + HINGE_TRIM_AXIAL_REACH_MM : w.hi,
       };
     });
 }

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -185,6 +185,23 @@ export interface HingeKnuckle {
 export interface HingeRun {
   readonly lo: number;
   readonly hi: number;
+  /**
+   * The lid's trim cut's own extent — wider than `[lo, hi]` whenever an end
+   * is not adjacent to a real obstruction.
+   *
+   * `lo`/`hi` reserve {@link LID_HINGE_CORNER_INSET_MM} off each end for
+   * knuckle placement, but that margin does not remove the bin's lip — only an
+   * obstruction does. Trimming the lid only to `[lo, hi]` left the corner
+   * margin's lid material un-trimmed, still carrying its full closed-position
+   * profile, which is what the lid swept into the bin's rounded corner on
+   * every plain hinge wall (#4147): nothing had to be obstructed for the bug
+   * to fire, because the untrimmed strip is there on every design. An end that
+   * IS adjacent to an obstruction keeps `lo`/`hi` exactly — the bin's lip is
+   * genuinely gone there, so there is nothing left to collide with, and the
+   * material past it is what the gap needs.
+   */
+  readonly trimLo: number;
+  readonly trimHi: number;
   readonly knuckles: readonly HingeKnuckle[];
   /**
    * Length (mm) of the filament offcut this run takes.
@@ -343,25 +360,70 @@ function layKnuckles(lo: number, hi: number): readonly HingeKnuckle[] | null {
   return out;
 }
 
+/** A knuckle-placement run paired with the wider extent its trim cut reaches. */
+interface ClearRun extends RailSegment {
+  readonly trimLo: number;
+  readonly trimHi: number;
+}
+
+/**
+ * How far past a wall's natural end the trim cutter reaches when that end is
+ * not adjacent to an obstruction. A cutter, so overshooting the lid's actual
+ * corner costs nothing — see {@link HingeRun.trimLo}.
+ */
+const HINGE_TRIM_AXIAL_REACH_MM = 400;
+
+const CLEAR_RUN_EPSILON_MM = 1e-6;
+
 /**
  * Stretches of the hinge wall no absence has taken.
  *
  * Only {@link lipGapRailBlocks} feeds this — see the module header on why
  * dividers and label tabs are deliberately absent from the list.
+ *
+ * Runs the same obstruction subtraction twice, from two different starting
+ * intervals: once from the full span, for the wide stretches where the bin's
+ * lip genuinely exists, and once from the span already narrowed by
+ * {@link LID_HINGE_CORNER_INSET_MM}, for where a knuckle may sit. Every
+ * narrow segment nests inside exactly one wide one — the narrow pass
+ * subtracts the identical blocks from a tighter interval, so it can only
+ * shrink further, never cross a wide boundary — which is what lets each
+ * narrow run look up the wide extent its trim cut needs.
  */
-function clearRuns(params: BinParams, side: LidCompatibilitySide, span: number): RailSegment[] {
-  const lo = -span / 2 + LID_HINGE_CORNER_INSET_MM;
-  const hi = span / 2 - LID_HINGE_CORNER_INSET_MM;
-  if (hi <= lo) return [];
+function clearRuns(params: BinParams, side: LidCompatibilitySide, span: number): ClearRun[] {
+  const blocks: readonly WallSpanBlock[] = lipGapRailBlocks(lipGaps(params)).filter(
+    (b) => b.side === side
+  );
 
-  let segments: RailSegment[] = [{ lo, hi }];
-  const blocks: readonly WallSpanBlock[] = lipGapRailBlocks(lipGaps(params));
+  let wide: RailSegment[] = [{ lo: -span / 2, hi: span / 2 }];
   for (const b of blocks) {
-    if (b.side !== side) continue;
-    segments = subtractSpan(segments, b.lo, b.hi);
-    if (segments.length === 0) break;
+    wide = subtractSpan(wide, b.lo, b.hi);
+    if (wide.length === 0) break;
   }
-  return segments.filter((s) => s.hi - s.lo >= LID_HINGE_MIN_RUN_MM);
+
+  const narrowLo = -span / 2 + LID_HINGE_CORNER_INSET_MM;
+  const narrowHi = span / 2 - LID_HINGE_CORNER_INSET_MM;
+  if (narrowHi <= narrowLo) return [];
+  let narrow: RailSegment[] = [{ lo: narrowLo, hi: narrowHi }];
+  for (const b of blocks) {
+    narrow = subtractSpan(narrow, b.lo, b.hi);
+    if (narrow.length === 0) break;
+  }
+
+  return narrow
+    .filter((s) => s.hi - s.lo >= LID_HINGE_MIN_RUN_MM)
+    .map((s) => {
+      const w =
+        wide.find(
+          (c) => c.lo <= s.lo + CLEAR_RUN_EPSILON_MM && s.hi <= c.hi + CLEAR_RUN_EPSILON_MM
+        ) ?? s;
+      return {
+        lo: s.lo,
+        hi: s.hi,
+        trimLo: w.lo <= -span / 2 + CLEAR_RUN_EPSILON_MM ? -HINGE_TRIM_AXIAL_REACH_MM : w.lo,
+        trimHi: w.hi >= span / 2 - CLEAR_RUN_EPSILON_MM ? HINGE_TRIM_AXIAL_REACH_MM : w.hi,
+      };
+    });
 }
 
 /** Clamp a stored fit clearance into the range the panel offers. */
@@ -407,6 +469,8 @@ export function planHingeLid(params: BinParams): HingePlan {
     runs.push({
       lo: seg.lo,
       hi: seg.hi,
+      trimLo: seg.trimLo,
+      trimHi: seg.trimHi,
       knuckles,
       pinLengthMm: Math.round((seg.hi - seg.lo - 2 * PIN_END_RECESS_MM) * 10) / 10,
     });


### PR DESCRIPTION
## Summary
- The lid's swing-clearance trim cut was clipped to `[run.lo, run.hi]`, the same bounds used for knuckle placement — which reserve `LID_HINGE_CORNER_INSET_MM` (3mm) off each end of the wall for corner clearance
- That margin does not remove the bin's lip, only a real obstruction (cutout/handle) does — so the untrimmed strip there kept its full closed-position profile and swept into the bin's rounded corner on **every** hinge wall, obstructed or not
- Reproduced on the reported design (2×2×3, plain hinge, no cutouts): shared volume is 0 at 0-1°, then real overlap from 2° through 30°, peaking ~0.15mm³ around 12-15° — right where the reporter's screenshots and Fusion 360 boolean showed it
- `HingeRun` now carries a separate `trimLo`/`trimHi`: the wider extent the trim cut reaches, computed by subtracting only genuine obstructions from the full wall span (not the knuckle-placement margin), extended to the wall's natural end wherever that end isn't already bounded by a real obstruction. Knuckle placement itself is untouched.

Two existing footprint assertions turned out to be unknowingly pinned to the bug: the lid's cross-axis span at the hinge wall now comes out exactly `LID_HINGE_FACE_RELIEF_MM` (0.2mm) narrower than spec/the friction control — the same relief that already keeps the barrel off the wall's face everywhere else along that wall. Updated both to expect the relief instead of an exact match.

## Test plan
- [x] New regression test: sweeps 2-30° on all four walls with a floor tight enough to catch this class (`CONTACT_FLOOR_MM3` alone is ~2 orders of magnitude too coarse for a sub-mm³ corner sliver)
- [x] Verified against the reporter's exact design JSON: pre-fix shows the same 2-30° overlap profile; post-fix it's zero from 2° on
- [x] `pnpm run test:run src/features/generation/worker/generators/hingeSwing.scenario` — 26/26 pass
- [x] `pnpm run test:run` on `lidBuilder`, `lidGenerator.scenario`, `lidCompatibility`, `hingeLidPlan` — 235/235 pass
- [x] `pnpm run typecheck` clean

Fixes #4147

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

