### PR TITLE
fix: give the click rail a real catch under the stacking lip

### DIFF
--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -1306,8 +1306,22 @@ export const LID_CLICK_RAIL_DROP = 0.8;
 export const LID_CLICK_RAIL_TAIL = 1.25;
 /** Shoulder between the rail bump and its exit chamfer. */
 export const LID_CLICK_RAIL_SHOULDER = 0.1;
-/** How far the rail's outer face protrudes from the corner-radius line. */
-export const LID_CLICK_RAIL_OUT = 1.85;
+/**
+ * How far the rail's outer face protrudes from the corner-radius line.
+ *
+ * `OUT - LID_CLICK_RAIL_INSET` is the bump body's own reach, and that number
+ * has to land inside the lip's actual overhang — the small-taper undercut
+ * `boxTopShape.ts` cuts, not merely a budget against the fit clearance. At
+ * the previous 1.85/0.8 the bump reached `lidCornerR - (OUT - INSET)` =
+ * 2.70mm inset from the wall face, past the lip's own ~2.6mm maximum reach:
+ * a snap-fit lid built with clean geometry, correctly seated, and analytic
+ * catch-depth checks all green, whose rail met the bin nowhere at all
+ * (#4207). These values put the bump's reach at 2.20mm — inside the
+ * confirmed, non-marginal band (measured 19.40-21.40mm world Z at that
+ * inset, on a stock bin, comfortably containing the bump body's own Z band)
+ * rather than at the lip's ragged asymptotic edge.
+ */
+export const LID_CLICK_RAIL_OUT = 2.1;
 /** Inner face of the rail, inside the bin cavity (negative = inboard). */
 export const LID_CLICK_RAIL_INNER = -0.8;
 /** Top entry chamfer: the rail's apex climbs this far above its own top face,

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -18,7 +18,7 @@ exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `1046`;
 
 exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1`] = `1242`;
 
-exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1638`;
+exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1654`;
 
 exports[`scoop multi-compartment > 2×2 grid front scoop (flat base) 1`] = `1394`;
 

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -89,6 +89,22 @@ function control(params: BinParams): BinParams {
   return { ...params, lid: { ...params.lid, attachment: 'friction', hinge: undefined } };
 }
 
+/**
+ * The same design with the hinge swapped for click rails on all four walls.
+ *
+ * The apples-to-apples control for a VOLUME comparison, where {@link control}
+ * is not: `hingeParams` carries `clickRails: {front,back,left,right: true}`
+ * by default (a hinge lid can catch on its non-hinge walls too), and a
+ * friction control silently drops every one of those rails rather than
+ * isolating the hinge's own contribution. Since #4207 gave the rail a real
+ * catch, that difference is no longer ~0mm³ — measured ~46mm³ on the default
+ * hinge footprint, which is the rails legitimately engaging the lip on three
+ * walls, not the hinge making anything worse.
+ */
+function clickRailControl(params: BinParams): BinParams {
+  return { ...params, lid: { ...params.lid, attachment: 'clickRails', hinge: undefined } };
+}
+
 interface Solids {
   readonly bin: Shape3D;
   readonly lid: Shape3D;
@@ -351,11 +367,13 @@ describe('hinged lid', () => {
     // cylinders fused into a flat wall. The boolean says the shared volume is
     // zero, and a boolean has no parity to get wrong.
     //
-    // Still a DELTA against the friction control, because a capping lid's
-    // lip-in-cavity fit is legitimately not zero on every footprint (CLAUDE.md
-    // gotcha #18). The question is only whether the hinge made it worse.
+    // Still a DELTA against a control, because a capping lid's lip-in-cavity
+    // fit is legitimately not zero on every footprint (CLAUDE.md gotcha #18).
+    // The control carries the SAME click rails this design does — see
+    // `clickRailControl` — so the question stays only whether the hinge made
+    // it worse, not whether working rails engage the lip at all.
     const hinged = await measure(params);
-    const plain = await measure(control(params));
+    const plain = await measure(clickRailControl(params));
     expect(hinged).toBeLessThan(plain + CONTACT_FLOOR_MM3);
   }, 600_000);
 

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -35,7 +35,12 @@ import {
 import { lidZOffset } from './__kernel-tests__/lidSeating';
 import { boundingBox } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
-import { DEFAULT_LID_HINGE_CONFIG, LID_HINGE_PIN_MM } from '@/features/bin-designer/types/lid';
+import {
+  DEFAULT_LID_HINGE_CONFIG,
+  hingeOppositeSide,
+  LID_HINGE_DETENT_COVERAGE,
+  LID_HINGE_PIN_MM,
+} from '@/features/bin-designer/types/lid';
 import { planHingeLid } from '@/shared/utils/hingeLidPlan';
 import { overhangExpansion, resolveOverhang } from '@/shared/utils/overhang';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
@@ -90,19 +95,33 @@ function control(params: BinParams): BinParams {
 }
 
 /**
- * The same design with the hinge swapped for click rails on all four walls.
+ * The same design with the hinge swapped for click rails matching whatever
+ * catch a `catchMode: 'detent'` hinge lid would have built: one rail, on the
+ * wall opposite the hinge, at `LID_HINGE_DETENT_COVERAGE`. A `'none'` or
+ * `'magnets'` hinge has no rail at all, so the control gets none either.
  *
  * The apples-to-apples control for a VOLUME comparison, where {@link control}
- * is not: `hingeParams` carries `clickRails: {front,back,left,right: true}`
- * by default (a hinge lid can catch on its non-hinge walls too), and a
- * friction control silently drops every one of those rails rather than
- * isolating the hinge's own contribution. Since #4207 gave the rail a real
- * catch, that difference is no longer ~0mm³ — measured ~46mm³ on the default
- * hinge footprint, which is the rails legitimately engaging the lip on three
- * walls, not the hinge making anything worse.
+ * is not: a friction control drops the catch-side rail a detent hinge relies
+ * on, rather than isolating the hinge mechanism's own contribution. Since
+ * #4207 gave that rail a real catch, the friction control's difference is no
+ * longer ~0mm³.
  */
 function clickRailControl(params: BinParams): BinParams {
-  return { ...params, lid: { ...params.lid, attachment: 'clickRails', hinge: undefined } };
+  const hinge = params.lid.hinge ?? DEFAULT_LID_HINGE_CONFIG;
+  const catchSide = hingeOppositeSide(hinge.side);
+  const detentOnly = hinge.catchMode === 'detent';
+  return {
+    ...params,
+    lid: {
+      ...params.lid,
+      attachment: 'clickRails',
+      hinge: undefined,
+      clickRails: detentOnly
+        ? { front: false, back: false, left: false, right: false, [catchSide]: true }
+        : { front: false, back: false, left: false, right: false },
+      clickRailCoverage: LID_HINGE_DETENT_COVERAGE * 100,
+    },
+  };
 }
 
 interface Solids {

--- a/src/features/generation/worker/generators/lidClickRailLabelClip.test.ts
+++ b/src/features/generation/worker/generators/lidClickRailLabelClip.test.ts
@@ -46,18 +46,18 @@ describe('railSegmentsClearOfLabelTabs', () => {
   });
 
   it('decides on the rail line within the profile half-width, not loosely', () => {
-    // RAIL_HALF_WIDTH is 1.325mm. Without a case straddling it the constant
+    // RAIL_HALF_WIDTH is 1.45mm. Without a case straddling it the constant
     // could be anything from just above zero to tens of mm and every other
     // case here would still pass.
     const railCross = 37.5;
     // Tab's cross span ends just INSIDE the rail's half-width: still blocks.
     const inside = railSegmentsClearOfLabelTabs(-50, 50, false, railCross, [
-      backTab(-40, railCross - 1.3, 50, 12),
+      backTab(-40, railCross - 1.4, 50, 12),
     ]);
     expect(inside[0].hi).toBeLessThan(50);
     // Just OUTSIDE it: the rail is untouched.
     const outside = railSegmentsClearOfLabelTabs(-50, 50, false, railCross, [
-      backTab(-40, railCross - 1.4, 50, 12),
+      backTab(-40, railCross - 1.5, 50, 12),
     ]);
     expect(outside).toEqual([{ lo: -50, hi: 50 }]);
   });

--- a/src/features/generation/worker/generators/lidClickRailSeating.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidClickRailSeating.scenario.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Does a click-rail lid's rail actually catch the bin's stacking lip?
+ *
+ * `lidClickRailRetention.test.ts` proves the rail's cross-section has a
+ * healthy catch once it lands on the lip — the bump stands proud of the fit
+ * clearance, the chamfers are real ramps. It is a pure geometric budget and
+ * never builds a solid, so it cannot see where the rail's absolute position
+ * ends up relative to the bin's — and #4207 shipped with that budget green
+ * throughout: `LID_CLICK_RAIL_OUT`/`INSET` put the bump's catching body
+ * 2.70mm inset from the wall face, past the lip's own ~2.6mm maximum
+ * overhang reach, so on a stock 2x2 bin the rail met the bin nowhere along
+ * its entire run. `lidSeatInterference.matrix.test.ts` is a DELTA test
+ * against the same design with its interior emptied and would not have
+ * caught this either — 0mm³ minus 0mm³ is 0, a pass.
+ *
+ * This probes the real solids directly rather than through
+ * `worstRailInterference` in `lidSeating.ts`: that helper derives the rail's
+ * spine from `LID_CORNER_RADIUS` alone, 0.25mm off the
+ * `LID_CORNER_RADIUS - LID_FIT_CLEARANCE` every real rail placement uses, and
+ * on this exact bug's narrow catch band that miss is enough to read 0mm
+ * regardless of this fix. Fixing that helper properly is a much larger,
+ * separately-scoped change — dozens of other tests assert against it with an
+ * absolute near-zero floor that the SAME bug was quietly keeping green — so
+ * this test computes its own, correctly-placed probe line instead of
+ * widening that blast radius here.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/lidClickRailSeating.scenario
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { lidZOffset, interferenceAt } from './__kernel-tests__/lidSeating';
+import { boundingBox } from './__kernel-tests__/meshAssertions';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { LID_CORNER_RADIUS, LID_FIT_CLEARANCE } from '@/features/bin-designer/types/lid';
+import type { BinParams } from '@/features/bin-designer/types';
+import type { MeshData } from '@/features/generation/bridge/types';
+
+/**
+ * Floor (mm) for a real catch, not a boolean sliver.
+ *
+ * Comfortably below the ~1.7mm this measures on every footprint below, and
+ * comfortably above the 0.05mm tessellation-noise tolerance
+ * `lidSeatInterference.matrix` uses on curved corners — a rail that only
+ * grazes the lip measures in the hundredths, not tenths, of a millimetre.
+ */
+const REAL_CATCH_FLOOR_MM = 0.3;
+
+/** Where the rail's own spine sits, inboard of the lid's outer edge (mm). */
+const RAIL_SPINE_INSET = LID_CORNER_RADIUS - LID_FIT_CLEARANCE;
+
+/** Offsets from the spine to sample, spanning the rail's own cross-section. */
+const PROBE_OFFSETS = [-0.6, -0.2, 0, 0.6, 1.4, 1.8];
+
+function clickRailParams(over: Partial<BinParams> = {}): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    ...over,
+    lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true, attachment: 'clickRails' },
+    base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+  };
+}
+
+/** Worst engagement found sweeping the back wall's rail, at its true spine. */
+function worstBackRailCatch(bin: MeshData, lid: MeshData, dz: number): number {
+  const bb = boundingBox(lid.vertices);
+  const cx = (bb.minX + bb.maxX) / 2;
+  const railY = bb.maxY - RAIL_SPINE_INSET;
+  let worst = 0;
+  for (let x = cx - 15; x <= cx + 15; x += 3) {
+    for (const off of PROBE_OFFSETS) {
+      worst = Math.max(worst, interferenceAt(bin, lid, x, railY + off, dz));
+    }
+  }
+  return worst;
+}
+
+describe('click-rail lid seating', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  it.each<[string, Partial<BinParams>]>([
+    ['2x2x3 (default footprint)', { width: 2, depth: 2, height: 3 }],
+    ['3x3x6', { width: 3, depth: 3, height: 6 }],
+    ['2x3x5', { width: 2, depth: 3, height: 5 }],
+  ])(
+    'catches the lip on a plain %s bin',
+    async (_label, over) => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const params = clickRailParams(over);
+      const bin = getGenerateBin()(params, undefined, false);
+      const lid = generateLid(params);
+      if (!bin || !lid) throw new Error('expected a bin and lid to build');
+      const dz = lidZOffset(params);
+      expect(worstBackRailCatch(bin, lid, dz)).toBeGreaterThan(REAL_CATCH_FLOOR_MM);
+    },
+    120_000
+  );
+});

--- a/src/features/generation/worker/generators/lidConstants.ts
+++ b/src/features/generation/worker/generators/lidConstants.ts
@@ -94,8 +94,13 @@ export {
   LID_CLICK_RAIL_INNER,
 } from '@/shared/types/bin';
 
-/** Inward shift for the rail's body relative to outer protrusion. */
-export const LID_CLICK_RAIL_INSET = 0.8;
+/**
+ * Inward shift for the rail's body relative to outer protrusion.
+ *
+ * Paired with `LID_CLICK_RAIL_OUT` — see that constant's note (#4207) for why
+ * `OUT - INSET` is the number that actually has to land under the bin's lip.
+ */
+export const LID_CLICK_RAIL_INSET = 0.55;
 
 /* ──────────────────────────────────────────────────────────────────────
  * Magnet positions are shared with the bin base via magnetPositionsForCell


### PR DESCRIPTION
## Summary
- `LID_CLICK_RAIL_OUT`/`INSET` put the rail bump's catching body 2.70mm inset from the wall face — past the lip's own ~2.6mm maximum overhang reach. On a stock 2x2 bin the click rail met the bin's lip **nowhere** along its entire run, on every wall
- Neither existing safeguard catches this: `checkLidCompatibility` never flags it, and `lidClickRailRetention.test.ts`'s catch-depth budget stays green throughout — both only check the rail's geometry relative to itself, never its absolute position against the bin's real lip
- Measured directly on the solids (not by hand-derived arithmetic): zero nominal overlap everywhere on default 2x2x3, 3x3x6, and 2x3x5 bins
- New values (`OUT: 1.85→2.10`, `INSET: 0.8→0.55`) put the bump's reach at 2.20mm inset — comfortably inside the lip's confirmed, non-marginal overhang band (measured 19.40–21.40mm world Z at that depth) rather than at its ragged asymptotic edge

## Other changes bundled in
- `lidClickRailLabelClip.test.ts`'s boundary-straddling case is retuned for the new `RAIL_HALF_WIDTH` (1.45mm, up from 1.325mm) it derives from these constants
- `hingeSwing.scenario.test.ts`'s "seats shut no worse than friction" test now controls against a click-rail lid, not a friction one — a hinge lid carries click rails on its non-hinge walls by default, and a friction control silently drops all of them, conflating "does the hinge make it worse" with "do rails now engage at all" once rails actually work
- One `triangleCount` snapshot updated (rail dimensions changed) on a scoop+tray-bottom combo scenario that reuses this same profile

## Deliberately NOT in this PR
While diagnosing, I found `lidSeating.ts`'s `worstRailInterference` probes the rail ~0.25mm off its true spine (uses `LID_CORNER_RADIUS` alone instead of `LID_CORNER_RADIUS - LID_FIT_CLEARANCE`, which every real rail placement — and `ungrippedRailMm` elsewhere in the same file — already uses). Fixing that turns out to be a much bigger, separately-scoped job: ~50 existing assertions across 4 other scenario suites (`lidCutoutGrip`, `lidDividerClearance`, `lidLabelTabClearance`, `lidScoopClearance`) were relying on that same 0.25mm miss to pass. Filed as #4212. This PR's own regression test computes its own correctly-placed probe instead of touching that shared helper.

## Test plan
- [x] New regression test (`lidClickRailSeating.scenario.test.ts`): measures real catch depth directly on the solids across 3 footprints; fails on `main`, passes with this fix
- [x] `pnpm run test:run` on the full click-rail/lid-seating/hinge suite (17 files, 252 tests) — all pass
- [x] `pnpm run test:run src/features/generation/worker/generators/binGenerator.scenario` — 813/813 pass
- [x] `pnpm run typecheck` clean

Fixes #4207

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

