### PR TITLE
fix: clear an exact-tangency sliver in the lid's stack grid

### DIFF
--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -374,14 +374,23 @@ describe('lid generation and export scenarios', () => {
       expect(l.maxZ).toBeCloseTo(LIP_EDGE_Z, 3);
     });
 
-    it('is a no-op at 1x1, where the grid is already a single pocket', async () => {
+    it('is a near-no-op at 1x1, where the grid is already a single pocket', async () => {
       const { generateLid } = await import('./lidOrchestrator');
       const one = { width: 1, depth: 1, height: 2 } as const;
       const grid = generateLid(makeParams({ stackableTop: true }, one));
       const lipOnly = generateLid(makeParams({ stackableTop: true, stackLipOnly: true }, one));
       expect(grid).not.toBeNull();
       expect(lipOnly).not.toBeNull();
-      expect(lipOnly!.triangleCount).toBe(grid!.triangleCount);
+      // Not exactly equal since #4208: the per-cell path grows its pocket by
+      // POCKET_RADIAL_OVERLAP_MM to clear an exact-tangency sliver against
+      // the slab's own outer edge, which `stackLipOnly`'s dedicated cutter
+      // does not (see lidStackGrid.ts). The two remain the same SHAPE within
+      // that sub-mm margin — same footprint, same top height.
+      const g = boundingBox(grid!.vertices);
+      const l = boundingBox(lipOnly!.vertices);
+      expect(l.maxX - l.minX).toBeCloseTo(g.maxX - g.minX, 1);
+      expect(l.maxY - l.minY).toBeCloseTo(g.maxY - g.minY, 1);
+      expect(l.maxZ).toBeCloseTo(g.maxZ, 0);
     });
 
     it('follows the polygon outline on a cellMask lid', async () => {

--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -381,15 +381,17 @@ describe('lid generation and export scenarios', () => {
       const lipOnly = generateLid(makeParams({ stackableTop: true, stackLipOnly: true }, one));
       expect(grid).not.toBeNull();
       expect(lipOnly).not.toBeNull();
-      // Not exactly equal since #4208: the per-cell path grows its pocket by
-      // POCKET_RADIAL_OVERLAP_MM to clear an exact-tangency sliver against
+      // Not exactly equal: the per-cell path grows its pocket by
+      // POCKET_EDGE_GROWTH_MM to clear an exact-tangency sliver against
       // the slab's own outer edge, which `stackLipOnly`'s dedicated cutter
       // does not (see lidStackGrid.ts). The two remain the same SHAPE within
       // that sub-mm margin — same footprint, same top height.
       const g = boundingBox(grid!.vertices);
       const l = boundingBox(lipOnly!.vertices);
-      expect(l.maxX - l.minX).toBeCloseTo(g.maxX - g.minX, 1);
-      expect(l.maxY - l.minY).toBeCloseTo(g.maxY - g.minY, 1);
+      expect(l.minX).toBeCloseTo(g.minX, 1);
+      expect(l.maxX).toBeCloseTo(g.maxX, 1);
+      expect(l.minY).toBeCloseTo(g.minY, 1);
+      expect(l.maxY).toBeCloseTo(g.maxY, 1);
       expect(l.maxZ).toBeCloseTo(g.maxZ, 0);
     });
 

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -65,43 +65,30 @@ function loftPocket(outlineAt: (inset: number) => Drawing): Shape3D {
 /**
  * Growth (mm, per side) on a per-cell pocket cutter's footprint.
  *
- * An edge cell's rounded corner (radius `CORNER_RADIUS`, from the NOMINAL
- * socket grid) and the slab's own outer corner (radius `lidCornerR`, from
- * the `fitClearance`-shrunk perimeter) land EXACTLY tangent: the grid shrink
- * and the two radii differ by the identical `fitClearance` (0.25mm), so
- * `nominalHalf - CORNER_RADIUS === shrunkHalf - lidCornerR` to the bit. Two
- * arcs meeting at exact tangency, not a real overlap, is the same trap
- * `COPLANAR_OVERLAP` exists for on flat faces (generatorConstants.ts) — here
- * it produced sub-mm² sliver triangles at every edge cell's outer corner
- * (aspect ratio ~11:1, #4208), not a topology break `assertNoDegenerateTriangles`
- * or a watertight check would catch. Growing every pocket by this — cheap,
- * since it is a cutter — breaks the tangency everywhere at once rather than
- * needing to single out which cells sit on the boundary.
+ * An edge cell's rounded corner (from the NOMINAL socket grid) and the
+ * slab's own outer corner (from the `fitClearance`-shrunk perimeter) land
+ * EXACTLY tangent, because the grid shrink and the two corner radii differ
+ * by the identical `fitClearance`. Two arcs meeting at exact tangency, not a
+ * real overlap, is the same trap `COPLANAR_OVERLAP` exists for on flat faces
+ * (generatorConstants.ts): it produces sliver triangles no topology or
+ * watertight check catches. Growing every pocket by this — cheap, since it
+ * is a cutter — breaks the tangency everywhere at once.
  *
- * `COPLANAR_OVERLAP` (0.01mm) alone thinned the sliver but did not clear it:
- * the loft is RULED between breakpoints, so the near-tangent corner recurs,
- * slightly smaller, all the way down the ruled segment into the big taper —
- * not one Z plane to overlap but a whole interpolated run of them. 5x that
- * margin clears every sampled Z along a cell's STRAIGHT edge, where one
- * curve meets a straight run — the case #4208 reported and this fixes.
+ * Bigger than `COPLANAR_OVERLAP` itself because the loft is RULED between
+ * breakpoints: the near-tangent corner recurs, slightly smaller, down the
+ * whole ruled segment into the big taper, not just at one Z plane.
  *
- * It does not clear the corner CELLS' own 90° corner, where the pocket's
- * arc and the slab's own corner arc are tangent to each other on BOTH axes
- * at once — measured two orders of magnitude worse (aspect ~350-1600) than
- * the straight-edge case, unmoved by growing this well past what a cutter
- * should reasonably need. Two arcs tangent on two axes wants a different
- * fix than "grow the rectangle" — filed separately as #4215 rather than
- * folded into this one blind.
+ * Clears the case where one cell edge's straight run meets the slab's
+ * corner arc; does NOT clear a corner cell's own 90° corner, where the
+ * pocket's arc and the slab's corner arc are tangent to each other on BOTH
+ * axes at once — that needs a different fix than growing the rectangle.
  *
- * `buildStackLipCutter` below has the identical straight-edge tangency by
- * the same math,
+ * `buildStackLipCutter` below has the identical tangency by the same math
  * but stays unmodified: its exact peak position is pinned by
- * `lidGenerator.scenario`'s stacking-lip-only assertions, and nobody has
- * reported a visible defect there — a corner grown by this same margin
- * shifted its measured edge by exactly that margin and broke them. Worth
- * revisiting together if that mode ever gets its own report.
+ * `lidGenerator.scenario`'s stacking-lip-only assertions, and growing it the
+ * same way shifts that pinned edge and breaks them.
  */
-const POCKET_RADIAL_OVERLAP_MM = 5 * COPLANAR_OVERLAP;
+const POCKET_EDGE_GROWTH_MM = 5 * COPLANAR_OVERLAP;
 
 /**
  * Build a single pocket cutter for one cell. Multi-section loft with
@@ -114,8 +101,8 @@ function buildLidStackPocketCutter(cellW_mm: number, cellD_mm: number): Shape3D 
   const cornerR = pocketCornerRadius(cellW_mm, cellD_mm);
   return loftPocket((inset) =>
     drawRoundedRectangle(
-      Math.max(cellW_mm + 2 * POCKET_RADIAL_OVERLAP_MM - 2 * inset, MIN_POCKET_MM),
-      Math.max(cellD_mm + 2 * POCKET_RADIAL_OVERLAP_MM - 2 * inset, MIN_POCKET_MM),
+      Math.max(cellW_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset, MIN_POCKET_MM),
+      Math.max(cellD_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset, MIN_POCKET_MM),
       Math.max(cornerR - inset, MIN_POCKET_MM)
     )
   );

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -15,7 +15,7 @@
 
 import { drawRoundedRectangle, unwrap, translate, cutAll } from 'brepjs';
 import type { Shape3D, DisposalScope, Drawing, Sketch, ValidSolid } from 'brepjs';
-import { pocketCornerRadius } from './generatorConstants';
+import { COPLANAR_OVERLAP, pocketCornerRadius } from './generatorConstants';
 import { SOCKET_HEIGHT, SOCKET_BIG_TAPER, SOCKET_TAPER_WIDTH, CLEARANCE } from './generatorTypes';
 import { LID_COPLANAR_MARGIN, LID_MIN_CORNER_RADIUS } from './lidConstants';
 import { isRegionFilled } from '@/shared/utils/cellMask';
@@ -63,6 +63,47 @@ function loftPocket(outlineAt: (inset: number) => Drawing): Shape3D {
 }
 
 /**
+ * Growth (mm, per side) on a per-cell pocket cutter's footprint.
+ *
+ * An edge cell's rounded corner (radius `CORNER_RADIUS`, from the NOMINAL
+ * socket grid) and the slab's own outer corner (radius `lidCornerR`, from
+ * the `fitClearance`-shrunk perimeter) land EXACTLY tangent: the grid shrink
+ * and the two radii differ by the identical `fitClearance` (0.25mm), so
+ * `nominalHalf - CORNER_RADIUS === shrunkHalf - lidCornerR` to the bit. Two
+ * arcs meeting at exact tangency, not a real overlap, is the same trap
+ * `COPLANAR_OVERLAP` exists for on flat faces (generatorConstants.ts) — here
+ * it produced sub-mm² sliver triangles at every edge cell's outer corner
+ * (aspect ratio ~11:1, #4208), not a topology break `assertNoDegenerateTriangles`
+ * or a watertight check would catch. Growing every pocket by this — cheap,
+ * since it is a cutter — breaks the tangency everywhere at once rather than
+ * needing to single out which cells sit on the boundary.
+ *
+ * `COPLANAR_OVERLAP` (0.01mm) alone thinned the sliver but did not clear it:
+ * the loft is RULED between breakpoints, so the near-tangent corner recurs,
+ * slightly smaller, all the way down the ruled segment into the big taper —
+ * not one Z plane to overlap but a whole interpolated run of them. 5x that
+ * margin clears every sampled Z along a cell's STRAIGHT edge, where one
+ * curve meets a straight run — the case #4208 reported and this fixes.
+ *
+ * It does not clear the corner CELLS' own 90° corner, where the pocket's
+ * arc and the slab's own corner arc are tangent to each other on BOTH axes
+ * at once — measured two orders of magnitude worse (aspect ~350-1600) than
+ * the straight-edge case, unmoved by growing this well past what a cutter
+ * should reasonably need. Two arcs tangent on two axes wants a different
+ * fix than "grow the rectangle" — filed separately as #4215 rather than
+ * folded into this one blind.
+ *
+ * `buildStackLipCutter` below has the identical straight-edge tangency by
+ * the same math,
+ * but stays unmodified: its exact peak position is pinned by
+ * `lidGenerator.scenario`'s stacking-lip-only assertions, and nobody has
+ * reported a visible defect there — a corner grown by this same margin
+ * shifted its measured edge by exactly that margin and broke them. Worth
+ * revisiting together if that mode ever gets its own report.
+ */
+const POCKET_RADIAL_OVERLAP_MM = 5 * COPLANAR_OVERLAP;
+
+/**
  * Build a single pocket cutter for one cell. Multi-section loft with
  * the same five sections + two coplanar caps that
  * `baseplateGenerator.buildPocketCutter` uses, just translated UP by
@@ -73,8 +114,8 @@ function buildLidStackPocketCutter(cellW_mm: number, cellD_mm: number): Shape3D 
   const cornerR = pocketCornerRadius(cellW_mm, cellD_mm);
   return loftPocket((inset) =>
     drawRoundedRectangle(
-      Math.max(cellW_mm - 2 * inset, MIN_POCKET_MM),
-      Math.max(cellD_mm - 2 * inset, MIN_POCKET_MM),
+      Math.max(cellW_mm + 2 * POCKET_RADIAL_OVERLAP_MM - 2 * inset, MIN_POCKET_MM),
+      Math.max(cellD_mm + 2 * POCKET_RADIAL_OVERLAP_MM - 2 * inset, MIN_POCKET_MM),
       Math.max(cornerR - inset, MIN_POCKET_MM)
     )
   );


### PR DESCRIPTION
## Summary
- A per-cell pocket cutter's rounded corner (radius `CORNER_RADIUS`, from the NOMINAL socket grid) and the slab's own outer edge (radius `lidCornerR`, from the `fitClearance`-shrunk perimeter) land **exactly tangent** wherever an interior divider meets the perimeter ring — the grid shrink and the two radii happen to differ by precisely the same `fitClearance` (0.25mm)
- Two surfaces meeting at exact tangency rather than a real overlap is the same trap `COPLANAR_OVERLAP` already exists for on flat faces (`generatorConstants.ts`) — here it produced sliver triangles with edge-length aspect ratios upward of 10:1 right on the slab's top face, at every divider/ring junction
- Watertight, manifold, no zero-area triangle — every structural check already run against this geometry stayed green, since a real but very thin sliver is exactly what none of them are built to catch. Visible in a render as the notches reported in the screenshots
- Fix: grow every per-cell pocket cutter by a small radial margin so the tangency never lands exactly, the same fix shape as `COPLANAR_OVERLAP`

## Scope
- Fix is applied only to the per-cell grid path (`buildLidStackPocketCutter`). `stackLipOnly`'s single-pocket cutter has the identical tangency by the same math, but its exact peak position is pinned by existing `lidGenerator.scenario` assertions and nobody has reported a defect there — growing it broke those tests, so it's left alone (documented in the diff for whoever picks that up)
- The stack grid's own four 90° corners carry a **different**, still-open tangency (two arcs meeting on both axes at once, not one arc meeting a straight run) — roughly two orders of magnitude worse than what this fixes, and unmoved by widening this same margin. Filed separately as #4215
- Filed #4214 separately for a pre-existing, unrelated sliver in the lid's mating wall found while investigating this

## Test plan
- [x] Measured directly on the solids: worst triangle aspect ratio at the divider/ring junction dropped from ~11:1 to <3:1 after the fix (3x3/4x4 grids)
- [x] `pnpm run test:run` on `lidGenerator.scenario`, `lidStackGrid` — 82/82 pass, including an updated "no-op at 1x1" assertion that now tolerates the deliberate sub-mm margin
- [x] `pnpm run test:run src/features/generation/worker/generators/binGenerator.scenario` — 813/813 pass, no snapshot churn
- [x] `pnpm run typecheck` clean

Fixes #4208

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

