### PR TITLE
fix: build bins and lids at grid pitches below 6.5mm

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/roundedRectLimit.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/roundedRectLimit.test.ts
@@ -1,49 +1,59 @@
 // @vitest-environment node
 /**
- * Diagnostic (not a CI gate): re-measure the radius/size ratio at which
- * brepjs's `drawRoundedRectangle` stops building, which is where
- * `MAX_SECTION_RADIUS_FRACTION` (generatorConstants.ts) comes from.
+ * Re-measures the radius/size ratio at which brepjs's `drawRoundedRectangle`
+ * stops building, which is the threshold `MAX_SECTION_RADIUS_FRACTION`
+ * (generatorConstants.ts) sits under.
  *
- * Worth re-running on a brepjs bump: the constant is a measured limit, not a
- * documented one, and the failure it guards is a hard throw rather than a
- * clamp.
+ * Worth re-running on a brepjs bump: the limit is a measured property of the
+ * sketcher rather than a documented one, and it fails as a hard throw rather
+ * than a clamp.
  */
-import { describe, it, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { drawRoundedRectangle, mesh } from 'brepjs';
 import { initBrepjs } from './wasmInit';
 
 beforeAll(async () => {
   await initBrepjs();
 }, 120_000);
 
+/** Whether brepjs will build a rounded rectangle at these proportions. */
+function builds(size: number, radius: number): boolean {
+  try {
+    drawRoundedRectangle(size, size, radius);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SCALES = [0.1, 1, 42];
+
 describe('drawRoundedRectangle limit', () => {
-  it('sweeps radius as a fraction of the shorter side', async () => {
-    const { drawRoundedRectangle } = await import('brepjs');
-    for (const size of [0.1, 1, 42]) {
-      const results: string[] = [];
-      for (const frac of [0.1, 0.25, 0.4, 0.45, 0.49, 0.499, 0.5, 0.5001, 0.51, 0.6, 1.0]) {
-        try {
-          drawRoundedRectangle(size, size, size * frac);
-          results.push(`${frac}:ok`);
-        } catch {
-          results.push(`${frac}:THROW`);
-        }
+  it('accepts any radius under half the shorter side, at every scale', () => {
+    for (const size of SCALES) {
+      for (const frac of [0.1, 0.25, 0.4, 0.45, 0.49, 0.499]) {
+        expect(builds(size, size * frac), `size=${size} frac=${frac}`).toBe(true);
       }
-      console.log(`\nsize=${size}mm  ${results.join('  ')}`);
     }
   });
 
-  it('confirms a capped section still lofts against a full-size one', async () => {
-    const brepjs = await import('brepjs');
-    const { drawRoundedRectangle } = brepjs;
+  it('throws at half the shorter side and beyond', () => {
+    for (const size of SCALES) {
+      for (const frac of [0.5, 0.5001, 0.51, 0.6, 1.0]) {
+        expect(builds(size, size * frac), `size=${size} frac=${frac}`).toBe(false);
+      }
+    }
+  });
+
+  it('lofts a floored section against a full-size one', () => {
+    const top = drawRoundedRectangle(42, 42, 4).sketchOnPlane('XY', 5);
+    const bot = drawRoundedRectangle(0.25, 0.25, 0.1).sketchOnPlane('XY', 0);
+    const solid = bot.loftWith([top], { ruled: true });
     try {
-      const top = drawRoundedRectangle(42, 42, 4).sketchOnPlane('XY', 5);
-      const bot = drawRoundedRectangle(0.1, 0.1, 0.04).sketchOnPlane('XY', 0);
-      const solid = bot.loftWith([top], { ruled: true });
-      const m = brepjs.mesh(solid, { tolerance: 0.01, angularTolerance: 0.05 });
-      console.log(`\nloft 0.1mm section -> 42mm section: ok, ${m.vertices.length / 3} vertices`);
+      const m = mesh(solid, { tolerance: 0.01, angularTolerance: 0.05 });
+      expect(m.vertices.length).toBeGreaterThan(0);
+    } finally {
       solid.delete();
-    } catch (e) {
-      console.log(`\nloft 0.1mm section -> 42mm section: THREW ${String(e).slice(0, 120)}`);
     }
   });
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/roundedRectLimit.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/roundedRectLimit.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+/**
+ * Diagnostic (not a CI gate): re-measure the radius/size ratio at which
+ * brepjs's `drawRoundedRectangle` stops building, which is where
+ * `MAX_SECTION_RADIUS_FRACTION` (generatorConstants.ts) comes from.
+ *
+ * Worth re-running on a brepjs bump: the constant is a measured limit, not a
+ * documented one, and the failure it guards is a hard throw rather than a
+ * clamp.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import { initBrepjs } from './wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+describe('drawRoundedRectangle limit', () => {
+  it('sweeps radius as a fraction of the shorter side', async () => {
+    const { drawRoundedRectangle } = await import('brepjs');
+    for (const size of [0.1, 1, 42]) {
+      const results: string[] = [];
+      for (const frac of [0.1, 0.25, 0.4, 0.45, 0.49, 0.499, 0.5, 0.5001, 0.51, 0.6, 1.0]) {
+        try {
+          drawRoundedRectangle(size, size, size * frac);
+          results.push(`${frac}:ok`);
+        } catch {
+          results.push(`${frac}:THROW`);
+        }
+      }
+      console.log(`\nsize=${size}mm  ${results.join('  ')}`);
+    }
+  });
+
+  it('confirms a capped section still lofts against a full-size one', async () => {
+    const brepjs = await import('brepjs');
+    const { drawRoundedRectangle } = brepjs;
+    try {
+      const top = drawRoundedRectangle(42, 42, 4).sketchOnPlane('XY', 5);
+      const bot = drawRoundedRectangle(0.1, 0.1, 0.04).sketchOnPlane('XY', 0);
+      const solid = bot.loftWith([top], { ruled: true });
+      const m = brepjs.mesh(solid, { tolerance: 0.01, angularTolerance: 0.05 });
+      console.log(`\nloft 0.1mm section -> 42mm section: ok, ${m.vertices.length / 3} vertices`);
+      solid.delete();
+    } catch (e) {
+      console.log(`\nloft 0.1mm section -> 42mm section: THREW ${String(e).slice(0, 120)}`);
+    }
+  });
+});

--- a/src/features/generation/worker/generators/baseplatePockets.ts
+++ b/src/features/generation/worker/generators/baseplatePockets.ts
@@ -20,6 +20,7 @@ import {
   INSET_BOT,
   pocketCornerRadius,
   COPLANAR_MARGIN,
+  safeSectionRect,
 } from './generatorTypes';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { pocketTemplateCache } from './baseplateCaches';
@@ -52,10 +53,12 @@ function pocketSection(
   z: number,
   inset: number
 ): Sketch {
-  const w = cellW_mm - 2 * inset;
-  const d = cellD_mm - 2 * inset;
-  const r = Math.max(cornerR - inset, 0.1);
-  return drawRoundedRectangle(w, d, r).sketchOnPlane('XY', z) as Sketch;
+  const { width, depth, radius } = safeSectionRect(
+    cellW_mm - 2 * inset,
+    cellD_mm - 2 * inset,
+    cornerR - inset
+  );
+  return drawRoundedRectangle(width, depth, radius).sketchOnPlane('XY', z) as Sketch;
 }
 
 /**

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -29,6 +29,7 @@ import {
   BOX_CORNER_RADIUS,
   COPLANAR_MARGIN,
   capSectionRadius,
+  safeSectionRect,
   sketch,
 } from './generatorTypes';
 import { getBoxCache, setBoxCache } from './shapeCache';
@@ -243,12 +244,11 @@ export function buildBinBox(
   // wider side reaches further out; symmetric/zero overhang leaves it centered.
   const recenter = (d: Drawing): Drawing => translateDrawing(d, offX, offY);
 
-  const makeFootprint = (): Drawing =>
-    polygon
-      ? buildMaskDrawing(cellMask, gridUnitMm)
-      : recenter(
-          drawRoundedRectangle(outerW, outerD, capSectionRadius(outerW, outerD, BOX_CORNER_RADIUS))
-        );
+  const makeFootprint = (): Drawing => {
+    if (polygon) return buildMaskDrawing(cellMask, gridUnitMm);
+    const { width, depth, radius } = safeSectionRect(outerW, outerD, BOX_CORNER_RADIUS);
+    return recenter(drawRoundedRectangle(width, depth, radius));
+  };
 
   const makeInnerFootprint = (): Drawing => {
     if (polygon) return buildMaskDrawingInset(cellMask, gridUnitMm, wallThickness);

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -23,7 +23,14 @@ import {
   withScope,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
-import { SIZE, CLEARANCE, BOX_CORNER_RADIUS, COPLANAR_MARGIN, sketch } from './generatorTypes';
+import {
+  SIZE,
+  CLEARANCE,
+  BOX_CORNER_RADIUS,
+  COPLANAR_MARGIN,
+  capSectionRadius,
+  sketch,
+} from './generatorTypes';
 import { getBoxCache, setBoxCache } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { resolvePitch, pitchKeySegments, type GridUnitInput } from './gridPitch';
@@ -239,18 +246,22 @@ export function buildBinBox(
   const makeFootprint = (): Drawing =>
     polygon
       ? buildMaskDrawing(cellMask, gridUnitMm)
-      : recenter(drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS));
-
-  const makeInnerFootprint = (): Drawing =>
-    polygon
-      ? buildMaskDrawingInset(cellMask, gridUnitMm, wallThickness)
       : recenter(
-          drawRoundedRectangle(
-            Math.max(outerW - 2 * wallThickness, 0.1),
-            Math.max(outerD - 2 * wallThickness, 0.1),
-            Math.max(BOX_CORNER_RADIUS - wallThickness, 0)
-          )
+          drawRoundedRectangle(outerW, outerD, capSectionRadius(outerW, outerD, BOX_CORNER_RADIUS))
         );
+
+  const makeInnerFootprint = (): Drawing => {
+    if (polygon) return buildMaskDrawingInset(cellMask, gridUnitMm, wallThickness);
+    const w = Math.max(outerW - 2 * wallThickness, 0.1);
+    const d = Math.max(outerD - 2 * wallThickness, 0.1);
+    return recenter(
+      drawRoundedRectangle(
+        w,
+        d,
+        capSectionRadius(w, d, Math.max(BOX_CORNER_RADIUS - wallThickness, 0))
+      )
+    );
+  };
 
   // Holes in the mask (O-shape-style interiors) — pre-extracted so every
   // branch below can decide whether it needs to subtract them. Empty for

--- a/src/features/generation/worker/generators/boxTopShape.ts
+++ b/src/features/generation/worker/generators/boxTopShape.ts
@@ -24,6 +24,7 @@ import {
   LIP_HEIGHT,
   LIP_TAPER_WIDTH,
   LIP_OVERLAP,
+  safeSectionRect,
 } from './generatorTypes';
 import { getLipCache, setLipCache } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
@@ -126,10 +127,12 @@ function buildTopShapeLoft(
           : buildMaskDrawingInset(cellMask, gridUnitMm, inset);
       return d.sketchOnPlane('XY', z) as Sketch;
     }
-    const w = outerW - 2 * inset;
-    const d = outerD - 2 * inset;
-    const r = Math.max(BOX_CORNER_RADIUS - inset, 0.1);
-    const rect = drawRoundedRectangle(w, d, r);
+    const { width, depth, radius } = safeSectionRect(
+      outerW - 2 * inset,
+      outerD - 2 * inset,
+      BOX_CORNER_RADIUS - inset
+    );
+    const rect = drawRoundedRectangle(width, depth, radius);
     return translateDrawing(rect, offX, offY).sketchOnPlane('XY', z) as Sketch;
   };
 
@@ -286,7 +289,8 @@ function buildTopShapeSweep(
   const holeDrawings = polygon ? buildMaskHoleDrawings(cellMask, gridUnitMm) : [];
 
   return withScope((scope: DisposalScope) => {
-    const outerRect = drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS);
+    const outerSafe = safeSectionRect(outerW, outerD, BOX_CORNER_RADIUS);
+    const outerRect = drawRoundedRectangle(outerSafe.width, outerSafe.depth, outerSafe.radius);
     const boxSketch = polygon
       ? (buildMaskDrawing(cellMask, gridUnitMm).sketchOnPlane() as Sketch)
       : (translateDrawing(outerRect, offX, offY).sketchOnPlane() as Sketch);

--- a/src/features/generation/worker/generators/generatorConstants.test.ts
+++ b/src/features/generation/worker/generators/generatorConstants.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { safeSectionRect, capSectionRadius } from './generatorConstants';
+import { MIN_ARC_RADIUS } from './maskPolygon';
 
 /**
  * The invariant both helpers exist for: brepjs sketches each corner arc tangent
  * to the side before it, so a radius AT half the shorter side leaves that side
- * zero-length and `drawRoundedRectangle` throws instead of clamping. Measured
- * threshold is exactly 0.5, at every scale.
+ * zero-length and `drawRoundedRectangle` throws instead of clamping.
  */
 function expectBuildable(width: number, depth: number, radius: number): void {
   expect(radius).toBeLessThan(Math.min(width, depth) / 2);
@@ -17,36 +17,45 @@ describe('safeSectionRect', () => {
   });
 
   it('caps the radius against the size that survived its own floor', () => {
-    // The #4218 shape: a 1mm-pitch cell at the deepest taper inset drives width
-    // and radius to the same 0.1mm floor, which is radius == width.
+    // A 1mm-pitch cell at the deepest taper inset drives width and radius to
+    // their floors, where an independent clamp leaves radius >= width / 2.
     const r = safeSectionRect(1 + 0.1 - 2 * 2.95, 1 + 0.1 - 2 * 2.95, 0.4 - 2.95);
-    expect(r.width).toBe(0.1);
-    expect(r.depth).toBe(0.1);
     expectBuildable(r.width, r.depth, r.radius);
   });
 
   it('keeps the radius positive so every loft section carries the same curve count', () => {
-    for (const size of [0.01, 0.1, 1, 42]) {
+    for (const size of [-5, 0, 0.01, 0.1, 1, 42]) {
       const r = safeSectionRect(size, size, -10);
       expect(r.radius).toBeGreaterThan(0);
       expectBuildable(r.width, r.depth, r.radius);
     }
   });
 
+  it('never rounds a section too tightly for the polygon builder to arc it', () => {
+    // `buildLoopDrawing` squares off any corner under MIN_ARC_RADIUS. A section
+    // below that floor and one above it are handed to the same loft, whose
+    // ruled surfaces cannot bridge their differing curve counts — so the size
+    // floor is derived from this threshold rather than chosen alongside it.
+    for (const size of [-5, 0, 0.01, 0.1, 0.25, 1, 42]) {
+      for (const desired of [-10, 0, 0.01, 4]) {
+        expect(safeSectionRect(size, size, desired).radius).toBeGreaterThanOrEqual(MIN_ARC_RADIUS);
+      }
+    }
+  });
+
   it('caps against the shorter side of a non-square section', () => {
     const r = safeSectionRect(40, 0.2, 4);
-    expect(r.depth).toBe(0.2);
     expectBuildable(r.width, r.depth, r.radius);
   });
 
   it('stays buildable across the designer grid-pitch range at every taper inset', () => {
-    // Pitches down to DESIGNER_GRID_UNIT_MM_MIN against the socket profile's
-    // three insets — the sweep that used to throw from 6.5mm down.
+    // The designer's pitch range against the socket profile's three insets.
     for (const pitch of [1, 2, 3, 4, 6, 6.5, 7, 12, 42, 200]) {
       for (const inset of [0, 2.15, 2.95]) {
         const cell = pitch - 0.5;
         const r = safeSectionRect(cell - 2 * inset, cell - 2 * inset, 4 - inset);
         expectBuildable(r.width, r.depth, r.radius);
+        expect(r.radius).toBeGreaterThanOrEqual(MIN_ARC_RADIUS);
       }
     }
   });
@@ -64,7 +73,7 @@ describe('capSectionRadius', () => {
   });
 
   it('caps a fixed radius against a footprint smaller than twice it', () => {
-    // 3 cells at a 2mm pitch: a 5.5mm body against the fixed 3.75mm box radius.
+    // A 5.5mm body against the fixed 3.75mm box radius.
     expectBuildable(5.5, 5.5, capSectionRadius(5.5, 5.5, 3.75));
   });
 });

--- a/src/features/generation/worker/generators/generatorConstants.test.ts
+++ b/src/features/generation/worker/generators/generatorConstants.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { safeSectionRect, capSectionRadius } from './generatorConstants';
+
+/**
+ * The invariant both helpers exist for: brepjs sketches each corner arc tangent
+ * to the side before it, so a radius AT half the shorter side leaves that side
+ * zero-length and `drawRoundedRectangle` throws instead of clamping. Measured
+ * threshold is exactly 0.5, at every scale.
+ */
+function expectBuildable(width: number, depth: number, radius: number): void {
+  expect(radius).toBeLessThan(Math.min(width, depth) / 2);
+}
+
+describe('safeSectionRect', () => {
+  it('leaves a full-size section untouched', () => {
+    expect(safeSectionRect(42, 42, 4)).toEqual({ width: 42, depth: 42, radius: 4 });
+  });
+
+  it('caps the radius against the size that survived its own floor', () => {
+    // The #4218 shape: a 1mm-pitch cell at the deepest taper inset drives width
+    // and radius to the same 0.1mm floor, which is radius == width.
+    const r = safeSectionRect(1 + 0.1 - 2 * 2.95, 1 + 0.1 - 2 * 2.95, 0.4 - 2.95);
+    expect(r.width).toBe(0.1);
+    expect(r.depth).toBe(0.1);
+    expectBuildable(r.width, r.depth, r.radius);
+  });
+
+  it('keeps the radius positive so every loft section carries the same curve count', () => {
+    for (const size of [0.01, 0.1, 1, 42]) {
+      const r = safeSectionRect(size, size, -10);
+      expect(r.radius).toBeGreaterThan(0);
+      expectBuildable(r.width, r.depth, r.radius);
+    }
+  });
+
+  it('caps against the shorter side of a non-square section', () => {
+    const r = safeSectionRect(40, 0.2, 4);
+    expect(r.depth).toBe(0.2);
+    expectBuildable(r.width, r.depth, r.radius);
+  });
+
+  it('stays buildable across the designer grid-pitch range at every taper inset', () => {
+    // Pitches down to DESIGNER_GRID_UNIT_MM_MIN against the socket profile's
+    // three insets — the sweep that used to throw from 6.5mm down.
+    for (const pitch of [1, 2, 3, 4, 6, 6.5, 7, 12, 42, 200]) {
+      for (const inset of [0, 2.15, 2.95]) {
+        const cell = pitch - 0.5;
+        const r = safeSectionRect(cell - 2 * inset, cell - 2 * inset, 4 - inset);
+        expectBuildable(r.width, r.depth, r.radius);
+      }
+    }
+  });
+});
+
+describe('capSectionRadius', () => {
+  it('leaves a radius that already fits alone', () => {
+    expect(capSectionRadius(42, 42, 3.75)).toBe(3.75);
+  });
+
+  it('preserves a caller-chosen zero rather than imposing a floor', () => {
+    // A wall thicker than BOX_CORNER_RADIUS squares off the cavity corner, and
+    // an extruded footprint has no loft partner whose curve count it must match.
+    expect(capSectionRadius(10, 10, 0)).toBe(0);
+  });
+
+  it('caps a fixed radius against a footprint smaller than twice it', () => {
+    // 3 cells at a 2mm pitch: a 5.5mm body against the fixed 3.75mm box radius.
+    expectBuildable(5.5, 5.5, capSectionRadius(5.5, 5.5, 3.75));
+  });
+});

--- a/src/features/generation/worker/generators/generatorConstants.ts
+++ b/src/features/generation/worker/generators/generatorConstants.ts
@@ -93,6 +93,56 @@ export function pocketCornerRadius(cellW_mm: number, cellD_mm: number): number {
   return Math.min(CORNER_RADIUS, maxRadius);
 }
 
+/** Smallest side, and smallest corner radius, an inset-derived section may reach. */
+const MIN_SECTION_MM = 0.1;
+
+/**
+ * Radius ceiling as a fraction of the shorter side. `drawRoundedRectangle`
+ * sketches each corner arc tangent to the side before it, so at exactly half
+ * the shorter side that side has no length left and brepjs raises
+ * `Bug in Sketcher2d.tangentArc` instead of clamping. Measured stable up to
+ * 0.499 at every scale; 0.4 leaves a real straight run between arcs.
+ */
+const MAX_SECTION_RADIUS_FRACTION = 0.4;
+
+/**
+ * Clamp a rounded rectangle's width, depth and corner radius together so it is
+ * buildable at any size.
+ *
+ * Sections along a tapered loft derive their size and their radius from the
+ * same inset but shrink at different rates, so flooring the three
+ * independently lets the radius bottom out first and then outgrow the
+ * rectangle it is rounding. Returning them as a set is what keeps them
+ * consistent — the radius is capped against the size that survived ITS floor,
+ * not the raw one.
+ *
+ * The radius never reaches zero: a squared corner carries four fewer curves
+ * than a rounded one, and a ruled loft cannot bridge sections whose curve
+ * counts differ.
+ */
+export function safeSectionRect(
+  width: number,
+  depth: number,
+  radius: number
+): { width: number; depth: number; radius: number } {
+  const w = Math.max(width, MIN_SECTION_MM);
+  const d = Math.max(depth, MIN_SECTION_MM);
+  return {
+    width: w,
+    depth: d,
+    radius: capSectionRadius(w, d, Math.max(radius, MIN_SECTION_MM)),
+  };
+}
+
+/**
+ * The cap alone, for a footprint that is extruded rather than lofted — there a
+ * squared corner is a legitimate result, so the radius keeps whatever floor its
+ * caller chose instead of picking up {@link safeSectionRect}'s.
+ */
+export function capSectionRadius(width: number, depth: number, radius: number): number {
+  return Math.min(radius, MAX_SECTION_RADIUS_FRACTION * Math.min(width, depth));
+}
+
 /**
  * Resolve per-corner radii from params, applying defaults and clamping.
  * Priority: cornerRadii > cornerRadius > PLATE_CORNER_RADIUS (spec default).

--- a/src/features/generation/worker/generators/generatorConstants.ts
+++ b/src/features/generation/worker/generators/generatorConstants.ts
@@ -93,17 +93,29 @@ export function pocketCornerRadius(cellW_mm: number, cellD_mm: number): number {
   return Math.min(CORNER_RADIUS, maxRadius);
 }
 
-/** Smallest side, and smallest corner radius, an inset-derived section may reach. */
-const MIN_SECTION_MM = 0.1;
-
 /**
  * Radius ceiling as a fraction of the shorter side. `drawRoundedRectangle`
  * sketches each corner arc tangent to the side before it, so at exactly half
  * the shorter side that side has no length left and brepjs raises
- * `Bug in Sketcher2d.tangentArc` instead of clamping. Measured stable up to
- * 0.499 at every scale; 0.4 leaves a real straight run between arcs.
+ * `Bug in Sketcher2d.tangentArc` instead of clamping. This leaves each straight
+ * run a fifth of its side rather than a sliver.
  */
 const MAX_SECTION_RADIUS_FRACTION = 0.4;
+
+/**
+ * Smallest corner radius a section may carry. Above `MIN_ARC_RADIUS`, so the
+ * polygon builder rounds every section of a loft rather than squaring off the
+ * small ones — mixing the two inside one loft gives its sections different
+ * curve counts, which a ruled loft cannot bridge.
+ */
+const MIN_SECTION_RADIUS_MM = 0.1;
+
+/**
+ * Smallest side a section may shrink to, DERIVED so the cap above can never
+ * push a radius below its own floor. Choosing the two independently is the bug
+ * this module exists to prevent, one level up.
+ */
+const MIN_SECTION_MM = MIN_SECTION_RADIUS_MM / MAX_SECTION_RADIUS_FRACTION;
 
 /**
  * Clamp a rounded rectangle's width, depth and corner radius together so it is
@@ -115,10 +127,6 @@ const MAX_SECTION_RADIUS_FRACTION = 0.4;
  * rectangle it is rounding. Returning them as a set is what keeps them
  * consistent — the radius is capped against the size that survived ITS floor,
  * not the raw one.
- *
- * The radius never reaches zero: a squared corner carries four fewer curves
- * than a rounded one, and a ruled loft cannot bridge sections whose curve
- * counts differ.
  */
 export function safeSectionRect(
   width: number,
@@ -130,7 +138,7 @@ export function safeSectionRect(
   return {
     width: w,
     depth: d,
-    radius: capSectionRadius(w, d, Math.max(radius, MIN_SECTION_MM)),
+    radius: capSectionRadius(w, d, Math.max(radius, MIN_SECTION_RADIUS_MM)),
   };
 }
 

--- a/src/features/generation/worker/generators/generatorTypes.ts
+++ b/src/features/generation/worker/generators/generatorTypes.ts
@@ -37,6 +37,8 @@ export {
   HOLE_OFFSET,
   INSET_BOT,
   pocketCornerRadius,
+  safeSectionRect,
+  capSectionRadius,
   resolveCornerRadii,
   TONGUE_PROTRUSION,
   TONGUE_BASE_HALF,

--- a/src/features/generation/worker/generators/lidProfile.ts
+++ b/src/features/generation/worker/generators/lidProfile.ts
@@ -10,8 +10,8 @@
 
 import { drawRoundedRectangle, unwrap, cut } from 'brepjs';
 import type { Shape3D, DisposalScope, Sketch, Drawing } from 'brepjs';
-import { LIP_BIG_TAPER } from './generatorConstants';
-import { LID_COPLANAR_MARGIN, LID_MIN_CORNER_RADIUS } from './lidConstants';
+import { LIP_BIG_TAPER, safeSectionRect } from './generatorConstants';
+import { LID_COPLANAR_MARGIN } from './lidConstants';
 import { buildMaskDrawingAtInset } from './maskPolygon';
 import type { LidInputs } from './lidInputs';
 
@@ -25,7 +25,11 @@ export function buildOutlineDrawing(inputs: LidInputs, outerInset: number): Draw
   const { lidOuterW, lidOuterD, lidCornerR, gridUnitMm, gridUnitMmY, fitClearance, cellMask } =
     inputs;
   const { outerOffsetX, outerOffsetY } = inputs;
-  const radius = Math.max(lidCornerR - outerInset, LID_MIN_CORNER_RADIUS);
+  const { width, depth, radius } = safeSectionRect(
+    lidOuterW - 2 * outerInset,
+    lidOuterD - 2 * outerInset,
+    lidCornerR - outerInset
+  );
 
   const outline = cellMask
     ? // Polygon path: total inset from the base (full grid) polygon =
@@ -39,7 +43,7 @@ export function buildOutlineDrawing(inputs: LidInputs, outerInset: number): Draw
         radius
       )
     : // Rectangular path
-      drawRoundedRectangle(lidOuterW - 2 * outerInset, lidOuterD - 2 * outerInset, radius);
+      drawRoundedRectangle(width, depth, radius);
 
   // Asymmetric overhang shifts the bin's outer body off the socket grid; the
   // lid's perimeter follows so it wraps the lip. Symmetric/absent overhang

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -15,9 +15,9 @@
 
 import { drawRoundedRectangle, unwrap, translate, cutAll } from 'brepjs';
 import type { Shape3D, DisposalScope, Drawing, Sketch, ValidSolid } from 'brepjs';
-import { COPLANAR_OVERLAP, pocketCornerRadius } from './generatorConstants';
+import { COPLANAR_OVERLAP, pocketCornerRadius, safeSectionRect } from './generatorConstants';
 import { SOCKET_HEIGHT, SOCKET_BIG_TAPER, SOCKET_TAPER_WIDTH, CLEARANCE } from './generatorTypes';
-import { LID_COPLANAR_MARGIN, LID_MIN_CORNER_RADIUS } from './lidConstants';
+import { LID_COPLANAR_MARGIN } from './lidConstants';
 import { isRegionFilled } from '@/shared/utils/cellMask';
 import { forEachCell, type CellInfo } from './cellDecomposition';
 import { buildMaskDrawingAtInset } from './maskPolygon';
@@ -31,11 +31,6 @@ const STACK_INSET_MID = SOCKET_BIG_TAPER - CLEARANCE / 2; // 2.15mm
  *  lip's inner face sits inside the nominal socket grid. `lidTextBuilder` sizes
  *  the text fit box from it. */
 export const STACK_INSET_BOT = SOCKET_TAPER_WIDTH - CLEARANCE / 2; // 2.95mm
-
-/** Floor for every inset-derived pocket dimension. The deepest inset is
- *  STACK_INSET_BOT (2.95mm per side), which a small enough cell or grid unit
- *  would otherwise drive to zero or negative. */
-const MIN_POCKET_MM = 0.1;
 
 /**
  * Z breakpoints of the pocket profile, paired with their per-side inset — the
@@ -54,7 +49,7 @@ const POCKET_PROFILE: readonly (readonly [z: number, inset: number])[] = [
 
 /** `outlineAt` must return sections that share a vertex topology at every
  *  inset — a ruled loft can't bridge differing curve counts, which is why both
- *  callers floor their corner radius rather than let it reach zero. */
+ *  callers size their sections through `safeSectionRect`. */
 function loftPocket(outlineAt: (inset: number) => Drawing): Shape3D {
   const [first, ...rest] = POCKET_PROFILE.map(
     ([z, inset]) => outlineAt(inset).sketchOnPlane('XY', z) as Sketch
@@ -99,13 +94,14 @@ const POCKET_EDGE_GROWTH_MM = 5 * COPLANAR_OVERLAP;
  */
 function buildLidStackPocketCutter(cellW_mm: number, cellD_mm: number): Shape3D {
   const cornerR = pocketCornerRadius(cellW_mm, cellD_mm);
-  return loftPocket((inset) =>
-    drawRoundedRectangle(
-      Math.max(cellW_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset, MIN_POCKET_MM),
-      Math.max(cellD_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset, MIN_POCKET_MM),
-      Math.max(cornerR - inset, MIN_POCKET_MM)
-    )
-  );
+  return loftPocket((inset) => {
+    const { width, depth, radius } = safeSectionRect(
+      cellW_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset,
+      cellD_mm + 2 * POCKET_EDGE_GROWTH_MM - 2 * inset,
+      cornerR - inset
+    );
+    return drawRoundedRectangle(width, depth, radius);
+  });
 }
 
 /**
@@ -125,14 +121,14 @@ function buildStackLipCutter(inputs: LidInputs): Shape3D {
   const cornerR = pocketCornerRadius(totalW, totalD);
 
   return loftPocket((inset) => {
-    const radius = Math.max(cornerR - inset, LID_MIN_CORNER_RADIUS);
+    const { width, depth, radius } = safeSectionRect(
+      totalW - 2 * inset,
+      totalD - 2 * inset,
+      cornerR - inset
+    );
     return cellMask
       ? buildMaskDrawingAtInset(cellMask, { x: gridUnitMm, y: gridUnitMmY }, inset, radius)
-      : drawRoundedRectangle(
-          Math.max(totalW - 2 * inset, MIN_POCKET_MM),
-          Math.max(totalD - 2 * inset, MIN_POCKET_MM),
-          radius
-        );
+      : drawRoundedRectangle(width, depth, radius);
   });
 }
 

--- a/src/features/generation/worker/generators/maskPolygon.ts
+++ b/src/features/generation/worker/generators/maskPolygon.ts
@@ -33,7 +33,7 @@ interface Point2Mm {
 }
 
 /** Minimum arc radius — below this we emit a sharp corner instead. */
-const MIN_ARC_RADIUS = 0.05;
+export const MIN_ARC_RADIUS = 0.05;
 
 /**
  * Inset an axis-aligned CCW polygon by `inset` mm, moving every edge

--- a/src/features/generation/worker/generators/smallGridPitch.scenario.test.ts
+++ b/src/features/generation/worker/generators/smallGridPitch.scenario.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Small-grid-pitch generation scenarios.
+ *
+ * The designer accepts a grid pitch anywhere in 1-200mm
+ * (`DESIGNER_GRID_UNIT_MM_MIN`/`_MAX`), and every tapered section along the
+ * socket, box and lid profiles derives its size and its corner radius from the
+ * same inset. Flooring those independently let the radius outgrow the rectangle
+ * it was rounding, which brepjs answers with a hard
+ * `Bug in Sketcher2d.tangentArc` rather than a clamp: bins threw below a 6.5mm
+ * pitch and stack-grid lids below 6mm (#4218).
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/smallGridPitch.scenario
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { assertStructurallyValid } from './__kernel-tests__/meshAssertions';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/features/bin-designer/types';
+import { generateBin } from './binGenerator';
+import { generateLid } from './lidOrchestrator';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+/** Spans the designer's range, clustered where the profile insets bite. */
+const PITCHES = [1, 2, 3, 4, 6, 6.5, 7, 12, 42] as const;
+
+function params(pitch: number, stackableTop: boolean): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 3,
+    depth: 3,
+    height: 3,
+    gridUnitMm: pitch,
+    gridUnitMmY: pitch,
+    lid: {
+      ...DEFAULT_BIN_PARAMS.lid,
+      enabled: true,
+      attachment: 'friction',
+      stackableTop,
+    },
+  };
+}
+
+describe('small grid pitch', () => {
+  it.each(PITCHES)('builds a bin at a %smm pitch', (pitch) => {
+    assertStructurallyValid(generateBin(params(pitch, false), undefined, true), `bin @ ${pitch}mm`);
+  });
+
+  it.each(PITCHES)('builds a lid at a %smm pitch', (pitch) => {
+    const lid = generateLid(params(pitch, false), undefined, true);
+    expect(lid, `lid @ ${pitch}mm`).not.toBeNull();
+    if (lid) assertStructurallyValid(lid, `lid @ ${pitch}mm`);
+  });
+
+  it.each(PITCHES)('builds a stack-grid lid at a %smm pitch', (pitch) => {
+    const lid = generateLid(params(pitch, true), undefined, true);
+    expect(lid, `stack lid @ ${pitch}mm`).not.toBeNull();
+    if (lid) assertStructurallyValid(lid, `stack lid @ ${pitch}mm`);
+  });
+
+  it('builds a non-square pitch whose axes straddle the old threshold', () => {
+    const p = { ...params(42, true), gridUnitMm: 4, gridUnitMmY: 20 };
+    assertStructurallyValid(generateBin(p, undefined, true), 'bin @ 4x20mm');
+    const lid = generateLid(p, undefined, true);
+    expect(lid).not.toBeNull();
+    if (lid) assertStructurallyValid(lid, 'stack lid @ 4x20mm');
+  });
+});

--- a/src/features/generation/worker/generators/smallGridPitch.scenario.test.ts
+++ b/src/features/generation/worker/generators/smallGridPitch.scenario.test.ts
@@ -1,22 +1,28 @@
 /**
- * Small-grid-pitch generation scenarios.
+ * Generation across the designer's whole grid-pitch range.
  *
- * The designer accepts a grid pitch anywhere in 1-200mm
- * (`DESIGNER_GRID_UNIT_MM_MIN`/`_MAX`), and every tapered section along the
- * socket, box and lid profiles derives its size and its corner radius from the
- * same inset. Flooring those independently let the radius outgrow the rectangle
- * it was rounding, which brepjs answers with a hard
- * `Bug in Sketcher2d.tangentArc` rather than a clamp: bins threw below a 6.5mm
- * pitch and stack-grid lids below 6mm (#4218).
+ * The designer accepts a 1-200mm pitch (`DESIGNER_GRID_UNIT_MM_MIN`/`_MAX`),
+ * and every tapered section along the socket, box, lip, taper, lid and
+ * baseplate profiles derives its size and its corner radius from the same
+ * inset. `safeSectionRect` is what keeps a section's radius under half its own
+ * shorter side; brepjs answers a violation with a hard
+ * `Bug in Sketcher2d.tangentArc` rather than a clamp.
+ *
+ * Several of these builders sit behind a try/catch that falls back to simpler
+ * geometry, so a structural assertion alone cannot tell a built feature from a
+ * silently dropped one. The differential cases below compare a feature on
+ * against off and require the two to differ.
  *
  *   pnpm run test:run src/features/generation/worker/generators/smallGridPitch.scenario
  */
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
-import { initBrepjs } from './__kernel-tests__/wasmInit';
-import { assertStructurallyValid } from './__kernel-tests__/meshAssertions';
+import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
+import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams } from '@/features/bin-designer/types';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { CellMask } from '@/shared/utils/cellMask';
 import { generateBin } from './binGenerator';
 import { generateLid } from './lidOrchestrator';
 
@@ -24,8 +30,13 @@ beforeAll(async () => {
   await initBrepjs();
 }, 120_000);
 
-/** Spans the designer's range, clustered where the profile insets bite. */
-const PITCHES = [1, 2, 3, 4, 6, 6.5, 7, 12, 42] as const;
+/** Both ends of the designer's range, clustered where the profile insets bite. */
+const PITCHES = [1, 2, 3, 4, 6, 6.5, 7, 12, 42, 200] as const;
+
+/** The pitch at which every section is driven to its floor. */
+const MIN_PITCH = 1;
+
+const NO_OP = (): void => {};
 
 function params(pitch: number, stackableTop: boolean): BinParams {
   return {
@@ -44,7 +55,14 @@ function params(pitch: number, stackableTop: boolean): BinParams {
   };
 }
 
-describe('small grid pitch', () => {
+/** 2x2 L-shape with one cell cleared, at half-bin mask resolution. */
+const L_MASK: CellMask = {
+  cols: 4,
+  rows: 4,
+  cells: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0],
+};
+
+describe('grid pitch range', () => {
   it.each(PITCHES)('builds a bin at a %smm pitch', (pitch) => {
     assertStructurallyValid(generateBin(params(pitch, false), undefined, true), `bin @ ${pitch}mm`);
   });
@@ -61,11 +79,117 @@ describe('small grid pitch', () => {
     if (lid) assertStructurallyValid(lid, `stack lid @ ${pitch}mm`);
   });
 
+  it.each(PITCHES)('builds a baseplate at a %smm pitch', (pitch) => {
+    const plate: ResolvedBaseplateParams = {
+      width: 3,
+      depth: 3,
+      gridUnitMm: pitch,
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2.4,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      fractionalEdgeX: 'end',
+      fractionalEdgeY: 'end',
+      lightweight: true,
+    };
+    assertStructurallyValid(getGenerateBaseplate()(plate, NO_OP, true), `baseplate @ ${pitch}mm`);
+  });
+
+  it('builds the preview path, which uses a different socket builder', () => {
+    // `buildSimplifiedCellSocket` serves preview/lightweight generation and
+    // carries its own section sampler, so an export-only sweep never reaches it.
+    for (const pitch of [MIN_PITCH, 4, 42]) {
+      assertStructurallyValid(
+        generateBin(params(pitch, false), undefined, false),
+        `preview bin @ ${pitch}mm`
+      );
+    }
+  });
+
+  it('builds the stacking-lip-only top, whose cutter spans the whole footprint', () => {
+    const p = params(MIN_PITCH, true);
+    const lid = generateLid({ ...p, lid: { ...p.lid, stackLipOnly: true } }, undefined, true);
+    expect(lid).not.toBeNull();
+    if (lid) assertStructurallyValid(lid, 'stack-lip-only lid');
+  });
+
+  it('builds a polygon lid, whose sections round through the mask builder', () => {
+    // The mask builder squares off a corner below its own arc threshold, so a
+    // section radius under that floor would give one loft two corner topologies.
+    const p: BinParams = { ...params(MIN_PITCH, true), width: 2, depth: 2, cellMask: L_MASK };
+    assertStructurallyValid(generateBin(p, undefined, true), 'polygon bin');
+    const lid = generateLid(p, undefined, true);
+    expect(lid).not.toBeNull();
+    if (lid) assertStructurallyValid(lid, 'polygon lid');
+    const lipOnly = generateLid({ ...p, lid: { ...p.lid, stackLipOnly: true } }, undefined, true);
+    expect(lipOnly).not.toBeNull();
+    if (lipOnly) assertStructurallyValid(lipOnly, 'polygon stack-lip-only lid');
+  });
+
+  it('builds a half-unit bin whose footprint is narrower than twice the box radius', () => {
+    // 0.5 units at an 18mm pitch is an 8.5mm body against a fixed 3.75mm corner
+    // radius, so the footprint cap binds while the foot still clears
+    // MIN_FOOT_TILE_MM and survives.
+    const p: BinParams = { ...params(18, false), width: 0.5, depth: 1 };
+    assertStructurallyValid(generateBin(p, undefined, true), 'half-unit bin @ 18mm');
+  });
+
+  it('rejects a bin with no printable foot by name, not by kernel crash', () => {
+    // 0.5 units at the minimum pitch is a 0.5mm foot, under MIN_FOOT_TILE_MM, so
+    // every cell is dropped. That is a domain rejection and must stay one — the
+    // footprint floor exists so this never reaches brepjs as a degenerate draw.
+    const p: BinParams = { ...params(MIN_PITCH, false), width: 0.5, depth: 1 };
+    expect(() => generateBin(p, undefined, true)).toThrow(/at least one cell required/);
+  });
+
   it('builds a non-square pitch whose axes straddle the old threshold', () => {
     const p = { ...params(42, true), gridUnitMm: 4, gridUnitMmY: 20 };
     assertStructurallyValid(generateBin(p, undefined, true), 'bin @ 4x20mm');
     const lid = generateLid(p, undefined, true);
     expect(lid).not.toBeNull();
     if (lid) assertStructurallyValid(lid, 'stack lid @ 4x20mm');
+  });
+});
+
+describe('grid pitch range — features survive rather than falling back', () => {
+  it('keeps the stacking lip at the minimum pitch', () => {
+    // `shellStage` catches a failed lip build and returns the bare body, so a
+    // structural assertion passes on a bin that quietly lost its lip.
+    const base = params(MIN_PITCH, false);
+    const withLip = generateBin(
+      { ...base, base: { ...base.base, stackingLip: true } },
+      undefined,
+      true
+    );
+    const without = generateBin(
+      { ...base, base: { ...base.base, stackingLip: false } },
+      undefined,
+      true
+    );
+    assertStructurallyValid(withLip, 'lipped bin @ 1mm');
+    expect(boundingBox(withLip.vertices).maxZ).toBeGreaterThan(boundingBox(without.vertices).maxZ);
+  });
+
+  it('keeps the outer wall taper at the minimum pitch', () => {
+    // `buildBinBox` catches a failed tapered loft and falls back to a plain
+    // shell, which reads as a valid bin that simply is not tapered.
+    const base = params(MIN_PITCH, false);
+    const overhang = { enabled: true, left: 2, right: 2, front: 2, back: 2 };
+    const taper = {
+      enabled: true,
+      profile: 'chamfer' as const,
+      bandHeight: 4,
+      left: 2,
+      right: 2,
+      front: 2,
+      back: 2,
+    };
+    const tapered = generateBin({ ...base, overhang: { ...overhang, taper } }, undefined, true);
+    const straight = generateBin({ ...base, overhang }, undefined, true);
+    assertStructurallyValid(tapered, 'tapered bin @ 1mm');
+    expect(tapered.indices.length).not.toBe(straight.indices.length);
   });
 });

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -433,10 +433,12 @@ export function buildSimplifiedCellSocket(cellW_mm: number, cellD_mm: number): S
   const Z3 = -SOCKET_HEIGHT;
 
   const sectionAt = (z: number, inset: number): Sketch => {
-    const w = cellW_mm - 2 * inset;
-    const d = cellD_mm - 2 * inset;
-    const r = Math.max(cornerR - inset, 0.1);
-    return drawRoundedRectangle(w, d, r).sketchOnPlane('XY', z) as Sketch;
+    const { width, depth, radius } = safeSectionRect(
+      cellW_mm - 2 * inset,
+      cellD_mm - 2 * inset,
+      cornerR - inset
+    );
+    return drawRoundedRectangle(width, depth, radius).sketchOnPlane('XY', z) as Sketch;
   };
 
   const s1 = sectionAt(Z1, INSET_TOP);

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -29,6 +29,7 @@ import {
   CORNER_RADIUS,
   COPLANAR_MARGIN,
   pocketCornerRadius,
+  safeSectionRect,
   SOCKET_HEIGHT,
   SOCKET_BIG_TAPER,
   SOCKET_VERTICAL_PART,
@@ -394,10 +395,12 @@ export function buildSingleCellSocket(cellW_mm: number, cellD_mm: number): Shape
 
   // Helper to create a rounded rect sketch at a given Z with a given inset
   const sectionAt = (z: number, inset: number): Sketch => {
-    const w = cellW_mm - 2 * inset;
-    const d = cellD_mm - 2 * inset;
-    const r = Math.max(cornerR - inset, 0.1);
-    return drawRoundedRectangle(w, d, r).sketchOnPlane('XY', z) as Sketch;
+    const { width, depth, radius } = safeSectionRect(
+      cellW_mm - 2 * inset,
+      cellD_mm - 2 * inset,
+      cornerR - inset
+    );
+    return drawRoundedRectangle(width, depth, radius).sketchOnPlane('XY', z) as Sketch;
   };
 
   // Build 5 cross-sections matching the socket profile breakpoints

--- a/src/features/generation/worker/generators/taperedOuter.ts
+++ b/src/features/generation/worker/generators/taperedOuter.ts
@@ -17,7 +17,7 @@
 
 import { drawRoundedRectangle, cut, unwrap } from 'brepjs';
 import type { Shape3D, Sketch, ValidSolid, DisposalScope } from 'brepjs';
-import { BOX_CORNER_RADIUS, COPLANAR_MARGIN } from './generatorTypes';
+import { BOX_CORNER_RADIUS, COPLANAR_MARGIN, safeSectionRect } from './generatorTypes';
 import type { ResolvedTaper } from './overhang';
 
 const FILLET_SECTION_MM = 2.5;
@@ -89,13 +89,17 @@ function taperSampler(
     const ir = insetAt(taper.right, z);
     const iFront = insetAt(taper.front, z);
     const ib = insetAt(taper.back, z);
-    const w = Math.max(outerW - il - ir - 2 * shrink, 0.2);
-    const d = Math.max(outerD - iFront - ib - 2 * shrink, 0.2);
+    const { width, depth, radius } = safeSectionRect(
+      outerW - il - ir - 2 * shrink,
+      outerD - iFront - ib - 2 * shrink,
+      BOX_CORNER_RADIUS - shrink
+    );
     // Asymmetric insets shift the section center; add the overhang recenter.
     const cx = offX + (il - ir) / 2;
     const cy = offY + (iFront - ib) / 2;
-    const r = Math.max(Math.min(BOX_CORNER_RADIUS - shrink, w / 2 - 0.1, d / 2 - 0.1), 0.1);
-    return drawRoundedRectangle(w, d, r).translate(cx, cy).sketchOnPlane('XY', z) as Sketch;
+    return drawRoundedRectangle(width, depth, radius)
+      .translate(cx, cy)
+      .sketchOnPlane('XY', z) as Sketch;
   };
 
   // z-levels from `bottom` to `top`: chamfer needs only the band break; fillet
@@ -170,8 +174,11 @@ export function buildTaperedLofts(
   const nr = insetAt(taper.right, zNarrow);
   const nf = insetAt(taper.front, zNarrow);
   const nb = insetAt(taper.back, zNarrow);
-  const nw = Math.max(outerW - nl - nr - 2 * wallThickness, 0.2);
-  const nd = Math.max(outerD - nf - nb - 2 * wallThickness, 0.2);
+  const { width: nw, depth: nd } = safeSectionRect(
+    outerW - nl - nr - 2 * wallThickness,
+    outerD - nf - nb - 2 * wallThickness,
+    BOX_CORNER_RADIUS - wallThickness
+  );
   const ncx = offX + (nl - nr) / 2;
   const ncy = offY + (nf - nb) / 2;
 


### PR DESCRIPTION
Closes #4218.

## The defect

Every tapered section along the socket, box, lip, taper, lid and baseplate profiles derives its size and its corner radius from the same inset, then floors the two independently. The radius reaches its floor first and stays pinned there while the size keeps shrinking past it, so a small enough grid pitch produces a radius wider than the rectangle it is rounding.

brepjs does not clamp that. `drawRoundedRectangle` sketches each corner arc tangent to the side before it, so at exactly half the shorter side that side has no length left and it raises `Bug in Sketcher2d.tangentArc: You need a previous curve to sketch a tangent arc`. The threshold is exactly `r >= min(w, d) / 2`, at every scale.

## Blast radius

Wider than #4218 described. The designer accepts a 1-200mm grid pitch (`DESIGNER_GRID_UNIT_MM_MIN`/`_MAX`), and eight call sites had the pattern:

| Part | Symptom below the threshold | Site |
| --- | --- | --- |
| Bin base socket | threw at 6.5mm | `socketBuilder.ts` `sectionAt` |
| Bin socket, preview path | threw | `socketBuilder.ts` `buildSimplifiedCellSocket` |
| Bin body footprint | threw at 2mm | `boxBuilder.ts` `makeFootprint` / `makeInnerFootprint` |
| **Stacking lip** | **silently dropped** | `boxTopShape.ts` loft + swept footprint |
| **Outer wall taper** | **silently dropped** | `taperedOuter.ts` sections |
| Baseplate pockets | threw | `baseplatePockets.ts` |
| Stack-grid lid | threw at 6mm | `lidStackGrid.ts` (the reported one) |
| Plain lid perimeter | threw at 3mm | `lidProfile.ts` `buildOutlineDrawing` |

Two of those are worse than a crash. `shellStage` catches a failed lip build and returns the bare body; `buildBinBox` catches a failed tapered loft and falls back to a plain shell. A bin at a small pitch therefore built, validated, and exported cleanly while shipping no stacking lip and no taper.

The plain bin case is the notable find: any pitch of 6.5mm or under threw outright, with nothing in the UI preventing that pitch.

## The fix

`safeSectionRect(width, depth, radius)` clamps all three as a set, so the radius is capped against the size that survived its own floor rather than against the raw one.

The floors are **derived, not chosen**. `maskPolygon`'s `buildLoopDrawing` squares off any corner under `MIN_ARC_RADIUS`, and a squared section inside a loft of rounded ones gives the loft sections differing curve counts — which a ruled loft cannot bridge. So `MIN_SECTION_MM = MIN_SECTION_RADIUS_MM / MAX_SECTION_RADIUS_FRACTION`, which makes it arithmetically impossible for the cap to push a radius below the floor the mask path needs. That relationship is asserted directly against the exported `MIN_ARC_RADIUS`.

`capSectionRadius` is the cap alone, for the extruded footprint in `boxBuilder` where a squared corner is a legitimate result and the caller's own zero floor has to survive (a wall thicker than `BOX_CORNER_RADIUS` squares the cavity corner, and a scenario covers it).

`integratedLipBuilder.ts` already had a local `cappedRadius` doing this correctly and is left alone.

## Verification

`smallGridPitch.scenario.test.ts` builds bin, plain lid, stack-grid lid and baseplate across the full 1-200mm range, plus the preview path (`forExport = false`), the stack-lip-only branch, a partial-mask polygon bin and lid, a non-square pitch, and a half-unit bin whose footprint is narrower than twice the box radius. A bin with no printable foot is asserted to fail by its named domain guard rather than a kernel bug.

Because two builders fall back silently, structural validity alone proves nothing there. Two differential cases compare a feature on against off and require the two to differ. Both were confirmed to fail without the fix — the taper one reports `expected 14988 not to be 14988`, i.e. the tapered bin came out byte-identical to the untapered one.

`generatorConstants.test.ts` pins `radius < min(w, d) / 2` and `radius >= MIN_ARC_RADIUS` at every scale and inset. `__kernel-tests__/roundedRectLimit.test.ts` asserts the brepjs threshold from both sides — worth re-running on a brepjs bump, since the limit is a measured property of the sketcher rather than a documented one.

1,985 existing geometry tests pass with no snapshot churn: `binGenerator.scenario` (813), lid + baseplate + export + assembly (992), and all 11 `generators-heavy` files (180). The caps never bind at normal pitches, so nothing in the shipping range moves.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2