### PR TITLE
fix: finger catch lip height is now flush when stacking lip is disabled

### DIFF
--- a/src/shared/utils/slideLidPlan.test.ts
+++ b/src/shared/utils/slideLidPlan.test.ts
@@ -494,12 +494,9 @@ describe('finger catch', () => {
     expect(g.plate.trailingX - g.plate.pullDepthMm).toBeGreaterThan(TRAVEL_INNER / 2);
   });
 
-  it('stands the lip height above the rim on a flush lid', () => {
+  it('ends flush with the wall top when the bin has no stacking lip', () => {
     const g = geometryOf({ slide: { ...catchConfig, placement: 'flush' }, hasLip: false });
-    expect(g.plate.pullReachMm).toBeCloseTo(
-      g.plateTopBelowWallTopMm + GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP,
-      9
-    );
+    expect(g.plate.pullReachMm).toBeCloseTo(g.plateTopBelowWallTopMm, 9);
   });
 
   it('has no depth on the other pulls', () => {

--- a/src/shared/utils/slideLidPlan.ts
+++ b/src/shared/utils/slideLidPlan.ts
@@ -680,8 +680,8 @@ export function resolveSlideLidPlan(input: SlideLidPlanInput): SlideLidPlan {
   // plate's full width, up to the lip's top plane, and only as thick as the
   // entry wall less one clearance. Not a millimetre deeper: the lip's inward
   // overhang is still there above the cavity and the bar has to slide under it.
-  // On a flush or lipless bin nothing is above the rim, so the same rise reads
-  // as a rim of its own.
+  // On a lipless bin the catch ends at the wall top: adding the absent lip's
+  // height would leave it standing far above the remaining sides.
   const isCatch = slide.pull === 'catch';
   const pullSpan = isCatch ? plateSpan : Math.min(Math.max(plateSpan * 0.3, 12), 40);
   const pullReach =
@@ -690,7 +690,8 @@ export function resolveSlideLidPlan(input: SlideLidPlanInput): SlideLidPlan {
       : slide.pull === 'notch'
         ? 5
         : isCatch
-          ? plateTopBelowWallTop + GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP
+          ? plateTopBelowWallTop +
+            (input.hasLip ? GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP : 0)
           : 0;
   const pullDepth = isCatch ? Math.max(0, input.entryWallThicknessMm - c) : 0;
 


### PR DESCRIPTION
## Why

The finger catch introduced in #4162 has a height which exceeds the other sides. 

<img width="568" height="337" alt="Screenshot 2026-09-10 at 10 05 19 am" src="https://github.com/user-attachments/assets/4f40b651-d3fb-449c-ba81-b695446e19db" />

## Changes

This PR fixes that so the height is flush with the remaining sides. Stacking lip catch height is unaffected.

<img width="846" height="493" alt="Screenshot 2026-09-11 at 11 12 12 am" src="https://github.com/user-attachments/assets/0218846d-4ec7-45f2-8f8f-ec86df717b13" />

## Risk

I have manually printed this part and it worked for my needs:

<details>
<summary>Screenshots</summary>
<img width="3072" height="4080" alt="PXL_20260911_022516198" src="https://github.com/user-attachments/assets/b44d57f7-069e-4c94-a02d-a0043a6e5da1" />
<img width="3072" height="4080" alt="PXL_20260911_022657257" src="https://github.com/user-attachments/assets/6210d19f-ee52-4c69-a870-bcafe602d27d" />
</details>

---

<sub>Title format, lint, types, i18n, tests, coverage and bundle size are gated by
`pr-title.yml`, the pre-commit hooks and CI. No need to restate them here.</sub>
