### PR TITLE
fix(test): probe the click rail on its own spine

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -80,9 +80,9 @@ export interface SeatedPair {
  * Distance from the lid's outer face to a click rail's spine.
  *
  * `railPlacementsForRectangle` insets every rail by `lidCornerR`, which
- * `resolveLidInputs` derives as `LID_CORNER_RADIUS - LID_FIT_CLEARANCE`. A
- * probe aimed at `LID_CORNER_RADIUS` sits 0.25mm inboard of that and reads the
- * cavity wall instead of the bump, so it reports clean through real engagement.
+ * `resolveLidInputs` derives as `LID_CORNER_RADIUS - LID_FIT_CLEARANCE`. Aim a
+ * probe at `LID_CORNER_RADIUS` instead and it lands on the cavity wall, where
+ * it reads clean whatever the rail is doing.
  */
 const RAIL_SPINE_INSET = LID_CORNER_RADIUS - LID_FIT_CLEARANCE;
 
@@ -116,10 +116,15 @@ function railProbePositions(lid: MeshData): Array<readonly [number, number]> {
  *
  * {@link worstRailInterference} is not zero on a good bin at every footprint:
  * its outer offsets sample the rail bump inside the lip's undercut, and that
- * overlap is the snap fit engaging, not a defect. Measured at 0.7mm on a plain
- * 1x2 with no interior features whatever, and 0 on a 2x2 — a property of the
- * footprint, which is why an absolute threshold cannot serve a matrix that
- * varies the footprint.
+ * overlap is the snap fit engaging, not a defect. It is
+ * {@link RAIL_ENGAGEMENT_CEILING} on every footprint from 1x2 up and 0.60mm on
+ * a 1x1 — a property of the footprint, which is why an absolute threshold
+ * cannot serve a matrix that varies the footprint.
+ *
+ * Only sound where the feature leaves rail PLACEMENT alone. A feature that
+ * notches rails changes which positions carry one, and the difference then
+ * reads as interference with nothing colliding; those suites compare against
+ * the ceiling instead.
  *
  * Comparing the two maxima would hide a small real clash behind a larger floor,
  * so this walks matching positions instead. Sound here in a way the same trick
@@ -152,24 +157,20 @@ export function worstRailInterferenceDelta(probe: SeatedPair, reference: SeatedP
 /**
  * Highest {@link worstRailInterference} a correctly seating bin reads.
  *
- * A clean bin does not read zero. The rail bump protrudes
- * `LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET` (1.55mm) past its spine and sits
- * inside the lip's undercut, which is the snap fit engaging rather than a
- * clash. Measured 1.70mm on every footprint that carries a full rail, so a
- * clearance assertion is `< RAIL_ENGAGEMENT_CEILING + tolerance` and keeps
+ * A clean bin does not read zero: the rail bump sits inside the lip's undercut,
+ * and that shared Z is the snap fit engaging rather than a clash. So a
+ * clearance assertion is `< RAIL_ENGAGEMENT_CEILING + tolerance`, keeping
  * whatever sensitivity its tolerance buys.
  *
- * Do NOT state these as a delta against the same bin with the feature off.
- * Notching is what these suites exercise, and it splits one rail into several:
- * the probe then carries rail at positions the unsegmented reference does not,
- * and the difference reads as interference with nothing colliding. Measured on
- * a 2x1 grid at 50% coverage, where both bins read 1.70mm absolute while the
- * delta reads 0.60mm.
+ * Every footprint from 1x2 up reads this. A 1x1 reads 0.60mm, so a suite that
+ * adds one needs its own datum; none of the current rail suites goes below 2u.
+ * `railEngagement.kernel.test.ts` pins the figure and checks it stands on all
+ * four walls, which is what separates the rail's own profile from a clash.
  *
- * A 1x1 reads 0.60mm instead, so a suite that adds one needs its own datum
- * rather than this ceiling. None of the current rail suites goes below 2u.
- *
- * `railEngagement.kernel.test.ts` pins the number.
+ * Do NOT restate these as a delta against the same bin with the feature off.
+ * Notching is what these suites exercise, and it splits one rail into several,
+ * so the bin under test carries rail at positions an unsegmented reference does
+ * not and the difference reads as interference with nothing colliding.
  */
 export const RAIL_ENGAGEMENT_CEILING = 1.7;
 

--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -17,6 +17,7 @@ import {
   resolveLidCavityExtraMm,
   LID_FIT_CLEARANCE,
   LID_CORNER_RADIUS,
+  LID_CLICK_RAIL_INNER,
 } from '@/shared/types/bin';
 import {
   retentionBossRadius,
@@ -76,6 +77,16 @@ export interface SeatedPair {
 }
 
 /**
+ * Distance from the lid's outer face to a click rail's spine.
+ *
+ * `railPlacementsForRectangle` insets every rail by `lidCornerR`, which
+ * `resolveLidInputs` derives as `LID_CORNER_RADIUS - LID_FIT_CLEARANCE`. A
+ * probe aimed at `LID_CORNER_RADIUS` sits 0.25mm inboard of that and reads the
+ * cavity wall instead of the bump, so it reports clean through real engagement.
+ */
+const RAIL_SPINE_INSET = LID_CORNER_RADIUS - LID_FIT_CLEARANCE;
+
+/**
  * Every probe position {@link worstRailInterference} visits, for a given lid.
  *
  * A fixed discrete set derived from the lid's own bounds, which is what lets
@@ -85,8 +96,8 @@ function railProbePositions(lid: MeshData): Array<readonly [number, number]> {
   const bb = boundingBox(lid.vertices);
   const cx = (bb.minX + bb.maxX) / 2;
   const cy = (bb.minY + bb.maxY) / 2;
-  const spineX = (bb.maxX - bb.minX) / 2 - LID_CORNER_RADIUS;
-  const spineY = (bb.maxY - bb.minY) / 2 - LID_CORNER_RADIUS;
+  const spineX = (bb.maxX - bb.minX) / 2 - RAIL_SPINE_INSET;
+  const spineY = (bb.maxY - bb.minY) / 2 - RAIL_SPINE_INSET;
   const out: Array<readonly [number, number]> = [];
   for (const off of RAIL_PROBE_OFFSETS) {
     for (let y = cy - spineY; y <= cy + spineY; y += 1) {
@@ -139,6 +150,30 @@ export function worstRailInterferenceDelta(probe: SeatedPair, reference: SeatedP
 }
 
 /**
+ * Highest {@link worstRailInterference} a correctly seating bin reads.
+ *
+ * A clean bin does not read zero. The rail bump protrudes
+ * `LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET` (1.55mm) past its spine and sits
+ * inside the lip's undercut, which is the snap fit engaging rather than a
+ * clash. Measured 1.70mm on every footprint that carries a full rail, so a
+ * clearance assertion is `< RAIL_ENGAGEMENT_CEILING + tolerance` and keeps
+ * whatever sensitivity its tolerance buys.
+ *
+ * Do NOT state these as a delta against the same bin with the feature off.
+ * Notching is what these suites exercise, and it splits one rail into several:
+ * the probe then carries rail at positions the unsegmented reference does not,
+ * and the difference reads as interference with nothing colliding. Measured on
+ * a 2x1 grid at 50% coverage, where both bins read 1.70mm absolute while the
+ * delta reads 0.60mm.
+ *
+ * A 1x1 reads 0.60mm instead, so a suite that adds one needs its own datum
+ * rather than this ceiling. None of the current rail suites goes below 2u.
+ *
+ * `railEngagement.kernel.test.ts` pins the number.
+ */
+export const RAIL_ENGAGEMENT_CEILING = 1.7;
+
+/**
  * Worst interference anywhere along the four rail lines.
  *
  * Sweeps a small band of X/Y offsets around each rail's spine rather than the
@@ -156,8 +191,8 @@ export function worstRailInterference(bin: MeshData, lid: MeshData, dz: number):
   const bb = boundingBox(lid.vertices);
   const cx = (bb.minX + bb.maxX) / 2;
   const cy = (bb.minY + bb.maxY) / 2;
-  const spineX = (bb.maxX - bb.minX) / 2 - LID_CORNER_RADIUS;
-  const spineY = (bb.maxY - bb.minY) / 2 - LID_CORNER_RADIUS;
+  const spineX = (bb.maxX - bb.minX) / 2 - RAIL_SPINE_INSET;
+  const spineY = (bb.maxY - bb.minY) / 2 - RAIL_SPINE_INSET;
 
   let worst = 0;
   for (const off of RAIL_PROBE_OFFSETS) {
@@ -257,7 +292,7 @@ const LIP_PROBE_INBOARD = 1;
  * run, where `computeCutoutCenter` holds a cutout a `wallThickness` clear of
  * the corner anyway.
  */
-const CORNER_SKIP = LID_CORNER_RADIUS + 1.5;
+const CORNER_SKIP = RAIL_SPINE_INSET - LID_CLICK_RAIL_INNER + 0.95;
 
 export function ungrippedRailMm(
   bin: MeshData,
@@ -269,7 +304,7 @@ export function ungrippedRailMm(
   const lipTop = binLipTopZ(p);
   const lidBB = boundingBox(lid.vertices);
   const binBB = boundingBox(bin.vertices);
-  const railInset = LID_CORNER_RADIUS - LID_FIT_CLEARANCE + RAIL_PROBE_INBOARD;
+  const railInset = RAIL_SPINE_INSET + RAIL_PROBE_INBOARD;
 
   const hasRail = (x: number, y: number): boolean => {
     const lowest = columnCrossings(lid, x, y).at(0);

--- a/src/features/generation/worker/generators/lidCutoutGrip.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidCutoutGrip.scenario.test.ts
@@ -22,6 +22,7 @@ import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   lidZOffset,
   ungrippedRailMm,
+  RAIL_ENGAGEMENT_CEILING,
   worstRailInterference,
   worstSeatInterference,
 } from './__kernel-tests__/lidSeating';
@@ -232,7 +233,7 @@ describe('lid click rails keep lip to grip', () => {
       expect(ungrippedRailMm(bin, lid, params, dz)).toBe(0);
 
       // Controls. Segmenting must not have moved a rail into something.
-      expect(worstRailInterference(bin, lid, dz)).toBeLessThan(0.05);
+      expect(worstRailInterference(bin, lid, dz)).toBeLessThan(RAIL_ENGAGEMENT_CEILING + 0.05);
       if (c.fullSweep) {
         const plain = { ...params, walls: DEFAULT_BIN_PARAMS.walls, handles: handles([]) };
         const plainBin = getGenerateBin()(plain, undefined, false);
@@ -270,6 +271,6 @@ describe('lid click rails keep lip to grip', () => {
     // The whole front rail hangs over the opening. Interference sees none of
     // it, which is the reason this probe exists.
     expect(ungrippedRailMm(bin, blindLid, params, dz)).toBeGreaterThan(30);
-    expect(worstRailInterference(bin, blindLid, dz)).toBeLessThan(0.05);
+    expect(worstRailInterference(bin, blindLid, dz)).toBeLessThan(RAIL_ENGAGEMENT_CEILING + 0.05);
   }, 300000);
 });

--- a/src/features/generation/worker/generators/lidDividerClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidDividerClearance.scenario.test.ts
@@ -23,6 +23,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   lidZOffset,
+  RAIL_ENGAGEMENT_CEILING,
   worstRailInterference,
   worstSeatInterference,
 } from './__kernel-tests__/lidSeating';
@@ -305,7 +306,7 @@ describe('lid click rails clear compartment dividers', () => {
 
       // 0.05mm absorbs mesh tessellation noise on the curved corner blends;
       // the defect this guards against measured 3.10mm.
-      expect(worstRailInterference(bin, lid, dz)).toBeLessThan(0.05);
+      expect(worstRailInterference(bin, lid, dz)).toBeLessThan(RAIL_ENGAGEMENT_CEILING + 0.05);
 
       if (c.fullSweep) {
         const plain = { ...params, compartments: ONE };
@@ -349,7 +350,7 @@ describe('lid click rails clear compartment dividers', () => {
     const dz = lidZOffset(params);
     // 2.8mm on the rail lines; the footprint sweep sees the same clash plus
     // the 0.5mm lip fit every bin has.
-    expect(worstRailInterference(bin, blindLid, dz)).toBeGreaterThan(2.5);
+    expect(worstRailInterference(bin, blindLid, dz)).toBeGreaterThan(RAIL_ENGAGEMENT_CEILING + 1);
     expect(worstSeatInterference(bin, blindLid, dz).mm).toBeGreaterThan(2.5);
   }, 300000);
 });

--- a/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
@@ -18,7 +18,25 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
-import { lidZOffset, worstRailInterference } from './__kernel-tests__/lidSeating';
+import {
+  lidZOffset,
+  RAIL_ENGAGEMENT_CEILING,
+  worstRailInterference,
+} from './__kernel-tests__/lidSeating';
+
+/**
+ * Extra rail interference `lid.relieveInterior` adds.
+ *
+ * Measured, NOT validated, and the direction is the surprising part: carving
+ * the cavity's perimeter back should give the rail MORE room, so a relieved bin
+ * reading above an unrelieved one wants explaining. Toggling the flag alone on
+ * otherwise identical params moves the reading between the ceiling and this,
+ * with compartments, label and coverage held fixed.
+ *
+ * Pinned as its own named number so the figure stays greppable while that is
+ * settled, rather than disappearing into a wider threshold.
+ */
+const RELIEVED_INTERIOR_EXTRA_MM = 0.6;
 import { columnCrossings } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types';
@@ -106,7 +124,9 @@ describe('lid interior relief', () => {
       const bin = getGenerateBin()(params, undefined, false);
       const lid = generateLid(params);
       if (!bin || !lid) throw new Error('expected the pair to build');
-      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.05);
+      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
+        RAIL_ENGAGEMENT_CEILING + RELIEVED_INTERIOR_EXTRA_MM + 0.05
+      );
     }
   }, 300000);
 

--- a/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
@@ -27,14 +27,14 @@ import {
 /**
  * Extra rail interference `lid.relieveInterior` adds.
  *
- * Measured, NOT validated, and the direction is the surprising part: carving
- * the cavity's perimeter back should give the rail MORE room, so a relieved bin
- * reading above an unrelieved one wants explaining. Toggling the flag alone on
- * otherwise identical params moves the reading between the ceiling and this,
- * with compartments, label and coverage held fixed.
+ * The direction is the open question: carving the cavity's perimeter back
+ * should give the rail MORE room, so a relieved bin reading above an unrelieved
+ * one wants explaining. Toggling the flag alone moves the reading by exactly
+ * this, with compartments, label and coverage held fixed.
  *
- * Pinned as its own named number so the figure stays greppable while that is
- * settled, rather than disappearing into a wider threshold.
+ * Asserted from both sides below rather than as an allowance, so correcting the
+ * geometry fails here and forces this back to the plain ceiling instead of
+ * passing quietly.
  */
 const RELIEVED_INTERIOR_EXTRA_MM = 0.6;
 import { columnCrossings } from './__kernel-tests__/meshAssertions';
@@ -124,8 +124,9 @@ describe('lid interior relief', () => {
       const bin = getGenerateBin()(params, undefined, false);
       const lid = generateLid(params);
       if (!bin || !lid) throw new Error('expected the pair to build');
-      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
-        RAIL_ENGAGEMENT_CEILING + RELIEVED_INTERIOR_EXTRA_MM + 0.05
+      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
+        RAIL_ENGAGEMENT_CEILING + RELIEVED_INTERIOR_EXTRA_MM,
+        1
       );
     }
   }, 300000);

--- a/src/features/generation/worker/generators/lidLabelTabClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidLabelTabClearance.scenario.test.ts
@@ -17,7 +17,11 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
-import { lidZOffset, worstRailInterference } from './__kernel-tests__/lidSeating';
+import {
+  lidZOffset,
+  RAIL_ENGAGEMENT_CEILING,
+  worstRailInterference,
+} from './__kernel-tests__/lidSeating';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, LabelTabEdges, LabelTabSupport } from '@/features/bin-designer/types';
 
@@ -198,7 +202,9 @@ describe('lid click rails clear label tabs', () => {
 
       // 0.05mm absorbs mesh tessellation noise on the curved corner blends;
       // the defect this guards against measured 1.25mm.
-      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.05);
+      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
+        RAIL_ENGAGEMENT_CEILING + 0.05
+      );
 
       if (c.expectAnchorRails !== undefined) {
         const { railPlacements } = await import('./lidClickRail');
@@ -236,6 +242,8 @@ describe('lid click rails clear label tabs', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!blindLid) throw new Error('expected the lid to build');
 
-    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(1);
+    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(
+      RAIL_ENGAGEMENT_CEILING + 0.4
+    );
   }, 300000);
 });

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -28,19 +28,14 @@ import {
 } from './__kernel-tests__/lidSeating';
 
 /**
- * Extra rail interference a scoop adds, on its own wall only.
+ * Extra rail interference a scoop adds, on its own wall only. Back, left and
+ * right read `RAIL_ENGAGEMENT_CEILING` on the same bin, so it is localised to
+ * the scooped side, at the outermost probe offset where the lip sits.
  *
- * Measured, NOT validated. The probe only became able to see it once it moved
- * onto the rail's true spine; before that it sat 0.25mm inboard and read the
- * cavity wall. Back, left and right all read `RAIL_ENGAGEMENT_CEILING` on the
- * same bin, so the contribution is localised to the scooped side, at the
- * outermost probe offset where the lip sits.
- *
- * Pinned as its own named number rather than folded into a rounder threshold
- * because whether 0.60mm of extra material in the rail's path is acceptable
- * snap resistance is an open geometry question, and a round threshold would
- * bury it. If the scoop's chute is corrected, this drops to zero and the
- * assertions below should tighten back to the ceiling.
+ * Whether that much extra material in the rail's path is acceptable snap
+ * resistance is an open geometry question. Asserted from both sides rather than
+ * as an allowance, so correcting the chute fails here and forces this back to
+ * the plain ceiling instead of passing quietly.
  */
 const SCOOP_WALL_EXTRA_MM = 0.6;
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
@@ -101,8 +96,9 @@ describe('lid click rails clear the scoop', () => {
       // 0.15mm covers tessellation noise on the chute where it runs to the
       // wall top, which is the plane the lip's base now sits on.
       // The defect this guards against measured 1.1mm.
-      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
-        RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM + 0.15
+      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
+        RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM,
+        1
       );
     },
     300000
@@ -133,8 +129,13 @@ describe('lid click rails clear the scoop', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!lid) throw new Error('expected the lid to build');
 
-    expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
-      RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM + 0.15
+    // The plain ceiling, not the scooped one: with the rail dropped from this
+    // wall there is no bump on it to push through the extra material, which is
+    // the clearest evidence that SCOOP_WALL_EXTRA_MM is a rail-vs-scoop
+    // interaction rather than the scoop's own geometry reaching the lid.
+    expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
+      RAIL_ENGAGEMENT_CEILING,
+      1
     );
   }, 300000);
 
@@ -143,6 +144,12 @@ describe('lid click rails clear the scoop', () => {
     // paired with a lid built as though the scoop were not there, which is what
     // shipped. Without it, every case above passes if the probe
     // stops finding a solid or `lidZOffset` drifts.
+    //
+    // Weaker than it was. On the scoop's own wall this pairing reads the same
+    // as the clean one, so all this can still say is that the reading clears
+    // the plain ceiling. Separating the two there is the open question the
+    // scoop datum above describes; until it is settled the rail-placement
+    // assertions in this file carry the discrimination.
     const { generateLid } = await import('./lidOrchestrator');
     const params = makeParams({
       scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, radius: 40, side: 'front' },
@@ -159,11 +166,6 @@ describe('lid click rails clear the scoop', () => {
     // to move: it only has to stay far clear of the 0.15mm the seating cases
     // above allow, and pinning it to its exact reading would make any change to
     // where the lid seats look like a broken probe.
-    // Only that the clash clears the plain ceiling. On the scoop's own wall the
-    // clean and the mispaired lid now read the SAME 2.30mm, so this probe no
-    // longer separates them there — which is itself the open question above.
-    // The rail-placement assertions in this file carry the discrimination until
-    // it is settled.
     expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(
       RAIL_ENGAGEMENT_CEILING
     );

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -21,7 +21,28 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
-import { lidZOffset, worstRailInterference } from './__kernel-tests__/lidSeating';
+import {
+  lidZOffset,
+  RAIL_ENGAGEMENT_CEILING,
+  worstRailInterference,
+} from './__kernel-tests__/lidSeating';
+
+/**
+ * Extra rail interference a scoop adds, on its own wall only.
+ *
+ * Measured, NOT validated. The probe only became able to see it once it moved
+ * onto the rail's true spine; before that it sat 0.25mm inboard and read the
+ * cavity wall. Back, left and right all read `RAIL_ENGAGEMENT_CEILING` on the
+ * same bin, so the contribution is localised to the scooped side, at the
+ * outermost probe offset where the lip sits.
+ *
+ * Pinned as its own named number rather than folded into a rounder threshold
+ * because whether 0.60mm of extra material in the rail's path is acceptable
+ * snap resistance is an open geometry question, and a round threshold would
+ * bury it. If the scoop's chute is corrected, this drops to zero and the
+ * assertions below should tighten back to the ceiling.
+ */
+const SCOOP_WALL_EXTRA_MM = 0.6;
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, ScoopSide } from '@/features/bin-designer/types';
 
@@ -80,7 +101,9 @@ describe('lid click rails clear the scoop', () => {
       // 0.15mm covers tessellation noise on the chute where it runs to the
       // wall top, which is the plane the lip's base now sits on.
       // The defect this guards against measured 1.1mm.
-      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.15);
+      expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
+        RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM + 0.15
+      );
     },
     300000
   );
@@ -110,7 +133,9 @@ describe('lid click rails clear the scoop', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!lid) throw new Error('expected the lid to build');
 
-    expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.15);
+    expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeLessThan(
+      RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM + 0.15
+    );
   }, 300000);
 
   it('the probe can see a real clash', async () => {
@@ -134,6 +159,13 @@ describe('lid click rails clear the scoop', () => {
     // to move: it only has to stay far clear of the 0.15mm the seating cases
     // above allow, and pinning it to its exact reading would make any change to
     // where the lid seats look like a broken probe.
-    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(0.9);
+    // Only that the clash clears the plain ceiling. On the scoop's own wall the
+    // clean and the mispaired lid now read the SAME 2.30mm, so this probe no
+    // longer separates them there — which is itself the open question above.
+    // The rail-placement assertions in this file carry the discrimination until
+    // it is settled.
+    expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(
+      RAIL_ENGAGEMENT_CEILING
+    );
   }, 300000);
 });

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -57,6 +57,22 @@ import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types
  */
 const TOLERANCE_MM = 0.05;
 
+/**
+ * Rail intrusion a scoop contributes, on its own wall.
+ *
+ * Measured once the probe moved onto the rail's true spine; the earlier
+ * position sat 0.25mm inboard and read the cavity wall instead of the bump, so
+ * no case in this matrix could see it. Reproduces by toggling the scoop alone
+ * on otherwise identical params, and is localised to the scooped side.
+ *
+ * Reported separately rather than absorbed into {@link TOLERANCE_MM}: every
+ * other pairing keeps its 0.05mm sensitivity, and a scoop case that drifts off
+ * this figure in either direction stops being excused. Whether 0.60mm in the
+ * rail's path is acceptable is an open geometry question, so this is a pin on
+ * current behaviour, not a statement that it is correct.
+ */
+const SCOOP_RAIL_INTRUSION_MM = 0.6;
+
 const grid = (cols: number, rows: number): CompartmentConfig => ({
   cols,
   rows,
@@ -275,6 +291,15 @@ describe('nothing intrudes into the lid seating volume', () => {
       if (mm >= TOLERANCE_MM) intruding.push({ case: key(c), mm: Number(mm.toFixed(3)) });
     }
 
+    // A scooped case carries the known contribution above. Split rather than
+    // dropped, so the figure stays visible and a scoop case that moves off it
+    // lands back in `intruding`.
+    const scooped = intruding.filter(
+      (i) =>
+        !i.case.includes('scoop=off') && Math.abs(i.mm - SCOOP_RAIL_INTRUSION_MM) < TOLERANCE_MM
+    );
+    const unexplained = intruding.filter((i) => !scooped.includes(i));
+
     // Completeness is asserted above over the GENERATED cases; a build that
     // fails silently removes its case from the measured set, and enough of
     // those could drop every instance of a value pair while the total skip
@@ -285,6 +310,9 @@ describe('nothing intrudes into the lid seating volume', () => {
       skipped: [],
       uncovered: [],
     });
-    expect(intruding).toEqual([]);
+    expect(unexplained).toEqual([]);
+    // Every scooped case reads the same figure, which is what makes it one
+    // finding rather than a spread the tolerance happens to cover.
+    expect(new Set(scooped.map((i) => i.mm))).toEqual(new Set([SCOOP_RAIL_INTRUSION_MM]));
   }, 900000);
 });

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -22,9 +22,9 @@
  *    lip's undercut is overlap in the nominal solid model, because that is what
  *    a snap fit is. It reads 0.5-1.1mm on a perfectly good bin.
  * 2. Not an absolute rail threshold either. The rail sweep's outer offsets
- *    sample that same snap, so it is 0 on a 2x2 and 0.7mm on a 1x2 with no
- *    interior features at all — a property of the footprint, and a matrix that
- *    varies the footprint cannot use one number.
+ *    sample that same snap, so a feature-free bin reads 1.7mm on every
+ *    footprint here and 0.6mm on a 1x1 — a property of the footprint, and a
+ *    matrix that varies the footprint cannot use one number.
  * 3. Not max-against-max. That hides a small clash behind a larger floor, and
  *    over a 2D grid it also reports where the two grids happened to land
  *    (0.2-0.8mm on configurations with no defect). Matching rail positions have
@@ -58,20 +58,24 @@ import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types
 const TOLERANCE_MM = 0.05;
 
 /**
- * Rail intrusion a scoop contributes, on its own wall.
+ * Rail intrusion a scoop contributes, on its own wall. Whether it is acceptable
+ * is an open geometry question, so this pins current behaviour rather than
+ * asserting the geometry is right.
  *
- * Measured once the probe moved onto the rail's true spine; the earlier
- * position sat 0.25mm inboard and read the cavity wall instead of the bump, so
- * no case in this matrix could see it. Reproduces by toggling the scoop alone
- * on otherwise identical params, and is localised to the scooped side.
- *
- * Reported separately rather than absorbed into {@link TOLERANCE_MM}: every
- * other pairing keeps its 0.05mm sensitivity, and a scoop case that drifts off
- * this figure in either direction stops being excused. Whether 0.60mm in the
- * rail's path is acceptable is an open geometry question, so this is a pin on
- * current behaviour, not a statement that it is correct.
+ * Reported separately rather than absorbed into {@link TOLERANCE_MM}, so every
+ * other pairing keeps its 0.05mm sensitivity.
  */
 const SCOOP_RAIL_INTRUSION_MM = 0.6;
+
+/**
+ * How many scooped cases carry that intrusion.
+ *
+ * A scoop only reaches the rail on some pairings; the rest read clean. Pinned
+ * as a count so both directions fail: a case that stops carrying it, and a new
+ * one that starts. Corrected geometry takes this to zero, and this assertion is
+ * what says so rather than passing quietly.
+ */
+const SCOOP_CASES_AT_INTRUSION = 3;
 
 const grid = (cols: number, rows: number): CompartmentConfig => ({
   cols,
@@ -270,6 +274,7 @@ describe('nothing intrudes into the lid seating volume', () => {
     const skipped: string[] = [];
     const measured: Case[] = [];
     const intruding: Array<{ case: string; mm: number }> = [];
+    const scooped: Array<{ case: string; mm: number }> = [];
 
     for (const c of CASES) {
       const built = build(c);
@@ -288,17 +293,17 @@ describe('nothing intrudes into the lid seating volume', () => {
       }
       measured.push(c);
       const mm = worstRailInterferenceDelta(built, baseline);
+      if (c.scoop !== 'off') scooped.push({ case: key(c), mm: Number(mm.toFixed(3)) });
       if (mm >= TOLERANCE_MM) intruding.push({ case: key(c), mm: Number(mm.toFixed(3)) });
     }
 
-    // A scooped case carries the known contribution above. Split rather than
-    // dropped, so the figure stays visible and a scoop case that moves off it
-    // lands back in `intruding`.
-    const scooped = intruding.filter(
-      (i) =>
-        !i.case.includes('scoop=off') && Math.abs(i.mm - SCOOP_RAIL_INTRUSION_MM) < TOLERANCE_MM
+    // Classified from every scooped case, not from `intruding`: a scooped case
+    // reading below the tolerance never enters that list, so filtering it would
+    // let such a case vanish from both sides of the check.
+    const atIntrusion = scooped.filter(
+      (i) => Math.abs(i.mm - SCOOP_RAIL_INTRUSION_MM) < TOLERANCE_MM
     );
-    const unexplained = intruding.filter((i) => !scooped.includes(i));
+    const unexplained = intruding.filter((i) => !atIntrusion.some((a) => a.case === i.case));
 
     // Completeness is asserted above over the GENERATED cases; a build that
     // fails silently removes its case from the measured set, and enough of
@@ -311,8 +316,11 @@ describe('nothing intrudes into the lid seating volume', () => {
       uncovered: [],
     });
     expect(unexplained).toEqual([]);
-    // Every scooped case reads the same figure, which is what makes it one
-    // finding rather than a spread the tolerance happens to cover.
-    expect(new Set(scooped.map((i) => i.mm))).toEqual(new Set([SCOOP_RAIL_INTRUSION_MM]));
+
+    // A scooped case reads the intrusion or it reads clean, never a value in
+    // between: that quantisation is what makes this one finding rather than a
+    // spread the tolerance happens to cover.
+    expect(scooped.filter((i) => i.mm >= TOLERANCE_MM && !atIntrusion.includes(i))).toEqual([]);
+    expect(atIntrusion).toHaveLength(SCOOP_CASES_AT_INTRUSION);
   }, 900000);
 });

--- a/src/features/generation/worker/generators/railEngagement.kernel.test.ts
+++ b/src/features/generation/worker/generators/railEngagement.kernel.test.ts
@@ -16,13 +16,15 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
+  interferenceAt,
   lidZOffset,
   RAIL_ENGAGEMENT_CEILING,
   worstRailInterference,
 } from './__kernel-tests__/lidSeating';
+import { boundingBox } from './__kernel-tests__/meshAssertions';
+import { LID_FIT_CLEARANCE, LID_CORNER_RADIUS } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
-import { LID_CLICK_RAIL_OUT } from '@/shared/types/bin';
-import { LID_CLICK_RAIL_INSET } from './lidConstants';
 import type { BinParams } from '@/shared/types/bin';
 
 beforeAll(async () => {
@@ -55,6 +57,28 @@ async function floorFor(width: number, depth: number): Promise<number> {
   return worstRailInterference(bin, lid, lidZOffset(params));
 }
 
+/** Worst reading on each of the four rail lines, taken separately. */
+function wallReadings(bin: MeshData, lid: MeshData, dz: number): number[] {
+  const bb = boundingBox(lid.vertices);
+  const cx = (bb.minX + bb.maxX) / 2;
+  const cy = (bb.minY + bb.maxY) / 2;
+  const inset = LID_CORNER_RADIUS - LID_FIT_CLEARANCE;
+  const sx = (bb.maxX - bb.minX) / 2 - inset;
+  const sy = (bb.maxY - bb.minY) / 2 - inset;
+  const walls = [0, 0, 0, 0];
+  for (const off of [-0.6, -0.2, 0, 0.6, 1.4]) {
+    for (let s = -sx; s <= sx; s += 1) {
+      walls[0] = Math.max(walls[0], interferenceAt(bin, lid, cx + s, cy - sy - off, dz));
+      walls[1] = Math.max(walls[1], interferenceAt(bin, lid, cx + s, cy + sy + off, dz));
+    }
+    for (let s = -sy; s <= sy; s += 1) {
+      walls[2] = Math.max(walls[2], interferenceAt(bin, lid, cx - sx - off, cy + s, dz));
+      walls[3] = Math.max(walls[3], interferenceAt(bin, lid, cx + sx + off, cy + s, dz));
+    }
+  }
+  return walls;
+}
+
 describe('rail engagement datum', () => {
   it.each([
     [2, 2],
@@ -69,12 +93,17 @@ describe('rail engagement datum', () => {
     300_000
   );
 
-  it('the ceiling is the rail bump reaching into the lip, not slack', () => {
-    // The bump protrudes OUT - INSET past the spine. The measured ceiling sits
-    // just above it, which is what identifies the reading as the snap fit
-    // rather than a clash someone tuned a threshold around.
-    const designedReach = LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET;
-    expect(RAIL_ENGAGEMENT_CEILING).toBeGreaterThanOrEqual(designedReach);
-    expect(RAIL_ENGAGEMENT_CEILING - designedReach).toBeLessThan(0.5);
-  });
+  it('reads the same on all four walls, which a clash would not', async () => {
+    // What identifies the figure as the rail's own profile rather than a clash
+    // someone tuned a threshold around. A clash sits on the wall that carries
+    // the feature causing it; the snap fit is on every wall that carries rail.
+    const { generateLid } = await import('./lidOrchestrator');
+    const params = featureFree(3, 2);
+    const bin = getGenerateBin()(params, undefined, false);
+    const lid = generateLid(params);
+    if (!bin || !lid) throw new Error('expected the pair to build');
+    for (const mm of wallReadings(bin, lid, lidZOffset(params))) {
+      expect(mm).toBeCloseTo(RAIL_ENGAGEMENT_CEILING, 2);
+    }
+  }, 300_000);
 });

--- a/src/features/generation/worker/generators/railEngagement.kernel.test.ts
+++ b/src/features/generation/worker/generators/railEngagement.kernel.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pins the datum every rail-clearance assertion is stated against.
+ *
+ * `worstRailInterference` does not read zero on a bin that seats perfectly: the
+ * click rail's bump protrudes past its spine and sits inside the stacking lip's
+ * undercut, which is the snap fit engaging. Every clearance suite therefore
+ * asserts `< RAIL_ENGAGEMENT_CEILING + tolerance`, and that only means anything
+ * while the ceiling matches what a feature-free bin actually measures.
+ *
+ * If this fails, the rail profile or the probe moved. Re-measure and update the
+ * constant deliberately — do not widen the tolerances that depend on it.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/railEngagement.kernel
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import {
+  lidZOffset,
+  RAIL_ENGAGEMENT_CEILING,
+  worstRailInterference,
+} from './__kernel-tests__/lidSeating';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { LID_CLICK_RAIL_OUT } from '@/shared/types/bin';
+import { LID_CLICK_RAIL_INSET } from './lidConstants';
+import type { BinParams } from '@/shared/types/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 180_000);
+
+/** A bin with a click-rail lid and nothing inside it to clash with. */
+function featureFree(width: number, depth: number): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width,
+    depth,
+    height: 6,
+    lid: {
+      ...DEFAULT_BIN_PARAMS.lid,
+      enabled: true,
+      attachment: 'clickRails',
+      clickRails: { front: true, back: true, left: true, right: true },
+      relieveInterior: false,
+    },
+  };
+}
+
+async function floorFor(width: number, depth: number): Promise<number> {
+  const { generateLid } = await import('./lidOrchestrator');
+  const params = featureFree(width, depth);
+  const bin = getGenerateBin()(params, undefined, false);
+  const lid = generateLid(params);
+  if (!bin || !lid) throw new Error(`expected the ${width}x${depth} pair to build`);
+  return worstRailInterference(bin, lid, lidZOffset(params));
+}
+
+describe('rail engagement datum', () => {
+  it.each([
+    [2, 2],
+    [2, 3],
+    [3, 2],
+    [3, 3],
+  ])(
+    'a feature-free %ix%i reads the ceiling',
+    async (w, d) => {
+      expect(await floorFor(w, d)).toBeCloseTo(RAIL_ENGAGEMENT_CEILING, 2);
+    },
+    300_000
+  );
+
+  it('the ceiling is the rail bump reaching into the lip, not slack', () => {
+    // The bump protrudes OUT - INSET past the spine. The measured ceiling sits
+    // just above it, which is what identifies the reading as the snap fit
+    // rather than a clash someone tuned a threshold around.
+    const designedReach = LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET;
+    expect(RAIL_ENGAGEMENT_CEILING).toBeGreaterThanOrEqual(designedReach);
+    expect(RAIL_ENGAGEMENT_CEILING - designedReach).toBeLessThan(0.5);
+  });
+});


### PR DESCRIPTION
Closes #4212.

## The defect

`railProbePositions` and `worstRailInterference` derived the rail spine from `LID_CORNER_RADIUS`:

```ts
const spineX = (bb.maxX - bb.minX) / 2 - LID_CORNER_RADIUS;
```

Every real placement uses `lidCornerR`, which `resolveLidInputs` derives as `LID_CORNER_RADIUS - LID_FIT_CLEARANCE`. The probes therefore sat 0.25mm inboard of the rail and sampled the cavity wall, reporting clean through the engagement they were aimed at. `ungrippedRailMm` already used the correct formula, so the three disagreed with each other.

All three now share `RAIL_SPINE_INSET`. `CORNER_SKIP` is expressed from the same datum and keeps its existing 5.5mm, so its sweep is unchanged.

## What the corrected probe reads

A bin that seats perfectly does not read zero: the rail bump sits inside the lip's undercut, and that shared Z is the snap fit engaging. Measured on feature-free bins:

```
 footprint |  worstRailInterference
       1x1 | 0.6000
       1x2 | 1.7000
       2x1 | 1.7000
       2x2 | 1.7000
       2x3 | 1.7000
       3x2 | 1.7000
       3x3 | 1.7000
       4x2 | 1.7000
```

`RAIL_ENGAGEMENT_CEILING` captures that and the clearance assertions are restated against it, keeping the 0.05mm and 0.15mm tolerances they already had. Sensitivity is unchanged: the defects they guard measured 3.10mm, 1.25mm and 1.1mm. No suite here goes below 2u, so the 1x1 figure does not arise.

`railEngagement.kernel.test.ts` pins the figure across four footprints and checks it holds on **all four walls** of a clean bin. That is what separates the rail's own profile from a clash, since a clash sits on the wall carrying the feature that causes it.

## Not delta-based

The issue proposed converting these to deltas. That is wrong for these suites, and measurably so. Notching is what they exercise, and it splits one rail into several, so the bin under test carries rail at positions an unsegmented reference does not:

```
coverage= 50  one compartment  worstRailInterference=1.7000  rails=4
coverage= 50  2x1 grid         worstRailInterference=1.7000  rails=6
```

Both read 1.70mm absolute. The delta between them reads 0.60mm, with nothing colliding.

The clash controls did move, for a different reason: `worstRailInterference` is a max over positions, so a clash competes with the engagement floor rather than adding to it. `> 2.5` became `> CEILING + 1`, not `> CEILING + 2.5`.

## Two findings this surfaced

Both are pre-existing geometry that no probe could see before. Both are asserted from **both** sides, so corrected geometry fails here and forces a deliberate update rather than passing quietly:

- **#4224** — a scoop adds 0.60mm, on its own wall only. The pairwise matrix reaches the same figure independently through its own delta. Sharpened during review: the wall-top case, whose rail is dropped, reads the plain ceiling, which places the extra on the rail interacting with the scoop rather than the scoop reaching the lid alone.
- **#4225** — `relieveInterior` adds 0.60mm, which is the wrong direction for a feature that carves the cavity back to give the rail room.

Neither is claimed correct.

In the matrix, scooped cases are classified from every scooped case rather than by filtering the intruding list, so one dropping below the tolerance cannot leave both sides of the check. Measured distribution: 3 of 11 carry the intrusion, 8 read clean. The assertions are that no scooped case sits between clean and the pinned figure, and that exactly `SCOOP_CASES_AT_INTRUSION` carry it.

## Verification

- 317 lid tests pass (`generators/lid*` plus the new datum file), including the full `lidSeatInterference.matrix` pairwise sweep.
- 47 further seating tests pass: `slideLidSeating`, `binStackSeating`, `hingeSwing.scenario`, `slottedLipPocket`.

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2