### PR TITLE
test: measure rail obstruction radially, not as shared Z in a column

### DIFF
--- a/.claude/skills/geometry-debugging/SKILL.md
+++ b/.claude/skills/geometry-debugging/SKILL.md
@@ -220,6 +220,19 @@ rim, so trimming it removes the weld rather than the obstruction. Its datum sink
 `LID_KEEPOUT_BELOW_CEILING_MM` instead. Features reference the interface; they are not
 cut by it.
 
+### Flush fill is not an obstruction, and a column cannot tell
+
+`worstRailInterference` measures shared Z in a column, so it counts material lying
+FLUSH with the lip's inner face (2.6mm in from the outer face) the same as material in
+the rail's way, and it saturates: once a column is solid through the band, a good bin
+and a grossly bad one both read 2.30mm. A seated rail has already been deflected past
+that plane by the lip, so flush fill costs it no travel. The scoop's chute and the
+tongue the relief ring leaves outboard of itself are both exactly that, both read
++0.60mm, and both are benign (#4224, #4225). `railKeepoutIntrusionMm` is what
+discriminates: how far INBOARD of the lip line bin material reaches inside the rail's
+band, wherever the LID carries rail. Zero on every clean pairing, 0.20mm on a
+deliberately mispaired one.
+
 ### An absence is an obstruction the interference probes cannot see
 
 A wall cutout or high handle hole takes the lip a rail hooks, so a rail over one grips

--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -1,6 +1,10 @@
 {
   "tolerance": "1.1",
-  "allowedMissingRefs": ["b17779575", "components/Foo.tsx", "diffProps"],
+  "allowedMissingRefs": [
+    "b17779575",
+    "components/Foo.tsx",
+    "diffProps"
+  ],
   "words": {
     ".claude/skills/analytics-and-labs/SKILL.md": 1270,
     ".claude/skills/auth-and-sync/SKILL.md": 1320,
@@ -70,7 +74,7 @@
     "src/features/whats-new/README.md": 331,
     "src/shared/.greptile/rules.md": 238,
     "src/shared/README.md": 1219,
-    "src/shared/hooks/README.hooks.md": 555,
+    "src/shared/hooks/README.hooks.md": 522,
     "src/shared/hooks/interactions/README.md": 515,
     "src/shell/README.md": 574,
     "src/test/README.md": 444

--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -174,15 +174,13 @@ export function worstRailInterferenceDelta(probe: SeatedPair, reference: SeatedP
  * so the bin under test carries rail at positions an unsegmented reference does
  * not and the difference reads as interference with nothing colliding.
  *
- * A reading ABOVE this is not by itself a defect, and
+ * A reading above this is not by itself a defect, and
  * {@link railKeepoutIntrusionMm} is what tells the two apart. A column measures
- * shared Z, so it counts material that merely sits FLUSH with the lip's inner
- * face lower down, which costs the rail no deflection at all (the lip already
- * pushes it that far), the same as material the rail cannot pass. The finger
- * scoop's chute and the tongue `lid.relieveInterior` leaves between the wall
- * face and the lip line both read +0.60mm here and are both benign. The
- * reading also saturates: once a column is solid through the whole band, a
- * grossly worse bin reads the same 2.30mm as a good one (#4224, #4225).
+ * shared Z, so material merely lying FLUSH with the lip's inner face lower down
+ * counts the same as material the rail cannot pass, when the lip has already
+ * pushed the rail that far and the flush material costs it nothing. The reading
+ * also saturates: once a column is solid through the whole band, a grossly
+ * worse bin reads the same as a good one.
  */
 export const RAIL_ENGAGEMENT_CEILING = 1.7;
 
@@ -295,13 +293,9 @@ function railPresentAt(lid: MeshData, x: number, y: number, dz: number, lipTop: 
  * How far past the lip's inner face bin material reaches inside the seated
  * rail's band, wherever the lid actually carries a rail (mm).
  *
- * The question {@link worstRailInterference} cannot answer. That one measures
- * shared Z in a column, so it cannot separate material the rail must be
- * deflected past from material lying flush with the plane the lip already
- * deflects it past, and it saturates once a column is solid through the band,
- * which is why the scoop suite's deliberately-mispaired control stopped reading
- * differently from a clean pairing (#4224). Measured radially instead, the
- * clean pairings sit at 0.00mm and that control at 0.20mm.
+ * The question {@link worstRailInterference} cannot answer, for the reasons on
+ * {@link RAIL_ENGAGEMENT_CEILING}. Radially, a lid paired with the wrong bin
+ * separates from a correctly paired one again, which a column no longer does.
  *
  * Zero is the whole assertion, and it is exactly the volume `lidKeepoutRing`
  * describes, read off the built solid rather than restated from the arithmetic

--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -12,12 +12,14 @@
 
 import { boundingBox, columnCrossings, verticalSolidSpans } from './meshAssertions';
 import { LIP_HEIGHT } from '../generatorConstants';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import {
   lidAnchorZ,
   resolveLidCavityExtraMm,
   LID_FIT_CLEARANCE,
   LID_CORNER_RADIUS,
   LID_CLICK_RAIL_INNER,
+  LID_CLICK_RAIL_BAND_BELOW_WALL_TOP,
 } from '@/shared/types/bin';
 import {
   retentionBossRadius,
@@ -171,8 +173,28 @@ export function worstRailInterferenceDelta(probe: SeatedPair, reference: SeatedP
  * Notching is what these suites exercise, and it splits one rail into several,
  * so the bin under test carries rail at positions an unsegmented reference does
  * not and the difference reads as interference with nothing colliding.
+ *
+ * A reading ABOVE this is not by itself a defect, and
+ * {@link railKeepoutIntrusionMm} is what tells the two apart. A column measures
+ * shared Z, so it counts material that merely sits FLUSH with the lip's inner
+ * face lower down, which costs the rail no deflection at all (the lip already
+ * pushes it that far), the same as material the rail cannot pass. The finger
+ * scoop's chute and the tongue `lid.relieveInterior` leaves between the wall
+ * face and the lip line both read +0.60mm here and are both benign. The
+ * reading also saturates: once a column is solid through the whole band, a
+ * grossly worse bin reads the same 2.30mm as a good one (#4224, #4225).
  */
 export const RAIL_ENGAGEMENT_CEILING = 1.7;
+
+/**
+ * The reading a scoop's chute or a relieved bin's perimeter tongue produces.
+ *
+ * Both are material standing in the void under the lip with its inner face on
+ * the lip line, so both add exactly this much to
+ * {@link RAIL_ENGAGEMENT_CEILING} while leaving
+ * {@link railKeepoutIntrusionMm} at zero.
+ */
+export const RAIL_FLUSH_FILL_MM = 0.6;
 
 /**
  * Worst interference anywhere along the four rail lines.
@@ -210,6 +232,145 @@ export function worstRailInterference(bin: MeshData, lid: MeshData, dz: number):
       }
     }
   }
+  return worst;
+}
+
+/**
+ * How far in from the bin's outer face the stacking lip's inner face sits.
+ *
+ * The plane every rail has ALREADY been forced past by the time it is seated,
+ * which is what makes it the datum for {@link railKeepoutIntrusionMm} rather
+ * than the wall face: the lip juts this far in, and a rail that could not
+ * deflect to clear it would never have got down there at all.
+ */
+const LIP_INNER_FACE = GRIDFINITY_SPEC.LIP_SMALL_TAPER + GRIDFINITY_SPEC.LIP_BIG_TAPER;
+
+/** Radial sweep rates: fine where flush-vs-proud is decided, coarse past it. */
+const NEAR_LIP_SPAN = 0.5;
+const NEAR_LIP_STEP = 0.05;
+const DEEP_STEP = 0.25;
+
+/**
+ * How far inside the lid's rail spine a column has to sit to read the rail
+ * itself, and how far below the seat plane the surface it finds must be.
+ *
+ * The lid's lowest surface at that column is the rail's underside, ~7.5mm below
+ * the seat plane; with no rail on that wall the same column sees only the floor
+ * plate, ~1mm ABOVE it. {@link RAIL_PRESENT_BELOW} splits the two with 2mm to
+ * spare, which is what lets both sweeps here ask "is there rail here" of the
+ * mesh rather than of a re-derived rail plan.
+ */
+const RAIL_PROBE_INBOARD = 0.35;
+const RAIL_PRESENT_BELOW = 5.5;
+
+/**
+ * How far in from each end of a wall a sweep starts, measured from the lid's
+ * outer face.
+ *
+ * Not tidiness: a PERPENDICULAR wall's rail occupies the band 1.9mm to 4.55mm
+ * from the lid's outer face along this axis (`lidCornerR`, less
+ * `LID_CLICK_RAIL_OUT` outward and plus `LID_CLICK_RAIL_INNER` inboard), and a
+ * column landing in it reads that rail while checking THIS wall's lip. Sweeping
+ * from 5.5mm clears it by ~1mm, and clears the corner ARC by the same margin.
+ * That second clearance is what a probe measuring depth along an axis needs,
+ * since the wall's inward normal stops being that axis at an arc. The cost is
+ * the first 1.75mm of
+ * each rail's own run, where `computeCutoutCenter` holds a cutout a
+ * `wallThickness` clear of the corner anyway.
+ */
+const CORNER_SKIP = RAIL_SPINE_INSET - LID_CLICK_RAIL_INNER + 0.95;
+
+/** Is the lid carrying rail at this column? Shared with {@link ungrippedRailMm}. */
+function railPresentAt(lid: MeshData, x: number, y: number, dz: number, lipTop: number): boolean {
+  const lowest = columnCrossings(lid, x, y).at(0);
+  return lowest !== undefined && lowest + dz < lipTop - RAIL_PRESENT_BELOW;
+}
+
+/**
+ * How far past the lip's inner face bin material reaches inside the seated
+ * rail's band, wherever the lid actually carries a rail (mm).
+ *
+ * The question {@link worstRailInterference} cannot answer. That one measures
+ * shared Z in a column, so it cannot separate material the rail must be
+ * deflected past from material lying flush with the plane the lip already
+ * deflects it past, and it saturates once a column is solid through the band,
+ * which is why the scoop suite's deliberately-mispaired control stopped reading
+ * differently from a clean pairing (#4224). Measured radially instead, the
+ * clean pairings sit at 0.00mm and that control at 0.20mm.
+ *
+ * Zero is the whole assertion, and it is exactly the volume `lidKeepoutRing`
+ * describes, read off the built solid rather than restated from the arithmetic
+ * that cut it. That is the only form of the claim that can fail.
+ *
+ * Two bounds keep it honest:
+ *
+ *  - Only where the LID has rail. An unrelieved bin's dividers fill this band
+ *    and are supposed to: the rail is notched away around them, so nothing is
+ *    in anything's path. Without the gate every notched bin reads as a defect.
+ *  - Only the straight run, {@link CORNER_SKIP} in from each end. The sweep
+ *    measures depth along an axis, and at a corner arc the wall's inward normal
+ *    is not that axis, so the lip itself reads as though it juts further.
+ *
+ * Reads the topmost crossing, never {@link verticalSolidSpans}, for the reason
+ * {@link ungrippedRailMm} does: a column over a base foot picks up the preview
+ * path's coincident socket seam, and pairing that into spans reports the whole
+ * cavity as solid, which here would read a clean bin as the worst possible
+ * intrusion. Sound as the direct question too, because outboard of the ring
+ * there is nothing above the band for the topmost surface to be: anything up
+ * there IS the obstruction.
+ */
+export function railKeepoutIntrusionMm(
+  bin: MeshData,
+  lid: MeshData,
+  p: BinParams,
+  dz: number,
+  step = 1
+): number {
+  const lipTop = binLipTopZ(p);
+  const bandLo = lipTop - LIP_HEIGHT - LID_CLICK_RAIL_BAND_BELOW_WALL_TOP;
+  const binBB = boundingBox(bin.vertices);
+  const lidBB = boundingBox(lid.vertices);
+  const railInner = RAIL_SPINE_INSET - LID_CLICK_RAIL_INNER;
+
+  const depths: number[] = [];
+  for (
+    let u = LIP_INNER_FACE + NEAR_LIP_STEP;
+    u <= LIP_INNER_FACE + NEAR_LIP_SPAN;
+    u += NEAR_LIP_STEP
+  ) {
+    depths.push(u);
+  }
+  for (let u = LIP_INNER_FACE + NEAR_LIP_SPAN + DEEP_STEP; u <= railInner; u += DEEP_STEP) {
+    depths.push(u);
+  }
+
+  let worst = 0;
+  // Both parts move together under overhang, so the along-wall coordinate
+  // addresses the same place on each; the cross-axis lines come from each
+  // part's own bounds, which keeps each probe on its own feature.
+  const sweep = (alongX: boolean, far: boolean): void => {
+    const lo = alongX ? lidBB.minX : lidBB.minY;
+    const hi = alongX ? lidBB.maxX : lidBB.maxY;
+    const sign = far ? -1 : 1;
+    const railCross =
+      (far ? (alongX ? lidBB.maxY : lidBB.maxX) : alongX ? lidBB.minY : lidBB.minX) +
+      sign * (RAIL_SPINE_INSET + RAIL_PROBE_INBOARD);
+    const binFace = far ? (alongX ? binBB.maxY : binBB.maxX) : alongX ? binBB.minY : binBB.minX;
+    for (let s = lo + CORNER_SKIP; s <= hi - CORNER_SKIP; s += step) {
+      if (!railPresentAt(lid, alongX ? s : railCross, alongX ? railCross : s, dz, lipTop)) continue;
+      for (const u of depths) {
+        const cross = binFace + sign * u;
+        // 0.01mm above the band's floor, not level with it: a feature trimmed
+        // to exactly the ring's own bottom is outside the band, not in it.
+        const top = columnCrossings(bin, alongX ? s : cross, alongX ? cross : s).at(-1);
+        if (top !== undefined && top > bandLo + 0.01) worst = Math.max(worst, u - LIP_INNER_FACE);
+      }
+    }
+  };
+  sweep(true, true);
+  sweep(true, false);
+  sweep(false, true);
+  sweep(false, false);
   return worst;
 }
 
@@ -268,32 +429,13 @@ export function worstSeatInterference(
  *
  * Two columns per sample, each chosen by measuring the real section:
  *
- *  - RAIL, {@link RAIL_PROBE_INBOARD} inside the lid's rail spine. The lid's
- *    lowest surface there is the rail's underside, ~7.5mm below the seat plane;
- *    with no rail on that wall the same column sees only the floor plate, ~1mm
- *    ABOVE it. {@link RAIL_PRESENT_BELOW} splits the two with 2mm to spare.
+ *  - RAIL, {@link RAIL_PROBE_INBOARD} inside the lid's rail spine.
  *  - LIP, {@link LIP_PROBE_INBOARD} inside the bin's outer face. The lip's
  *    outer chamfer descends 1:1, so an intact rim's top surface lands exactly
  *    that far below the lip top, while a cutout — whose overshoot clears the
  *    lip entirely — drops the column to the cut floor or the cavity.
  */
-const RAIL_PROBE_INBOARD = 0.35;
-const RAIL_PRESENT_BELOW = 5.5;
 const LIP_PROBE_INBOARD = 1;
-
-/**
- * How far in from each end of a wall the sweep starts, measured from the lid's
- * outer face.
- *
- * Not tidiness: a PERPENDICULAR wall's rail occupies the band 1.9mm to 4.55mm
- * from the lid's outer face along this axis (`lidCornerR`, less
- * `LID_CLICK_RAIL_OUT` outward and plus `LID_CLICK_RAIL_INNER` inboard), and a
- * column landing in it reads that rail while checking THIS wall's lip. Sweeping
- * from 5.5mm clears it by ~1mm. The cost is the first 1.75mm of each rail's own
- * run, where `computeCutoutCenter` holds a cutout a `wallThickness` clear of
- * the corner anyway.
- */
-const CORNER_SKIP = RAIL_SPINE_INSET - LID_CLICK_RAIL_INNER + 0.95;
 
 export function ungrippedRailMm(
   bin: MeshData,
@@ -307,10 +449,7 @@ export function ungrippedRailMm(
   const binBB = boundingBox(bin.vertices);
   const railInset = RAIL_SPINE_INSET + RAIL_PROBE_INBOARD;
 
-  const hasRail = (x: number, y: number): boolean => {
-    const lowest = columnCrossings(lid, x, y).at(0);
-    return lowest !== undefined && lowest + dz < lipTop - RAIL_PRESENT_BELOW;
-  };
+  const hasRail = (x: number, y: number): boolean => railPresentAt(lid, x, y, dz, lipTop);
   const hasLip = (x: number, y: number): boolean => {
     const top = columnCrossings(bin, x, y).at(-1);
     // 0.2mm absorbs tessellation on the chamfer; the defect is whole

--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -193,6 +193,11 @@ export const RAIL_ENGAGEMENT_CEILING = 1.7;
  * the lip line, so both add exactly this much to
  * {@link RAIL_ENGAGEMENT_CEILING} while leaving
  * {@link railKeepoutIntrusionMm} at zero.
+ *
+ * On the lip line by construction, not by measurement: `computeLipOffset`
+ * holds the ramp `LIP_TAPER_WIDTH - wallThickness` off the cavity face, and
+ * `lidKeepoutRing` puts its outer boundary on the same plane from the other
+ * side. Both resolve to `LIP_TAPER_WIDTH` from the bin's outer face.
  */
 export const RAIL_FLUSH_FILL_MM = 0.6;
 

--- a/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
@@ -116,13 +116,10 @@ describe('lid interior relief', () => {
       // stopped: inboard of the lip's inner face, which is as far out as the
       // ring cuts and as far in as the rail reaches.
       expect(railKeepoutIntrusionMm(bin, lid, params, lidZOffset(params))).toBe(0);
-      // And the column reading that goes with it. Higher than an UNRELIEVED
-      // bin's, which looks like the wrong direction and is not (#4225): the
-      // ring stops at the lip line by design, leaving a tongue of divider
-      // between there and the wall face, and a whole rail to lie against it
-      // where the unrelieved bin had notched the rail away entirely. Flush
-      // material costs the rail no travel, which is what the zero above says,
-      // but a column counts the shared Z all the same.
+      // Higher than an UNRELIEVED bin reads, which looks like the wrong
+      // direction and is not. The ring stops at the lip line by design, leaving
+      // a tongue of divider outboard of it, and relief hands the wall back the
+      // whole rail that the unrelieved bin had notched away to lie against it.
       expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
         RAIL_ENGAGEMENT_CEILING + RAIL_FLUSH_FILL_MM,
         1

--- a/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidInteriorRelief.scenario.test.ts
@@ -20,23 +20,11 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   lidZOffset,
+  railKeepoutIntrusionMm,
   RAIL_ENGAGEMENT_CEILING,
+  RAIL_FLUSH_FILL_MM,
   worstRailInterference,
 } from './__kernel-tests__/lidSeating';
-
-/**
- * Extra rail interference `lid.relieveInterior` adds.
- *
- * The direction is the open question: carving the cavity's perimeter back
- * should give the rail MORE room, so a relieved bin reading above an unrelieved
- * one wants explaining. Toggling the flag alone moves the reading by exactly
- * this, with compartments, label and coverage held fixed.
- *
- * Asserted from both sides below rather than as an allowance, so correcting the
- * geometry fails here and forces this back to the plain ceiling instead of
- * passing quietly.
- */
-const RELIEVED_INTERIOR_EXTRA_MM = 0.6;
 import { columnCrossings } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types';
@@ -124,8 +112,19 @@ describe('lid interior relief', () => {
       const bin = getGenerateBin()(params, undefined, false);
       const lid = generateLid(params);
       if (!bin || !lid) throw new Error('expected the pair to build');
+      // The claim in the title, measured where the rail can actually be
+      // stopped: inboard of the lip's inner face, which is as far out as the
+      // ring cuts and as far in as the rail reaches.
+      expect(railKeepoutIntrusionMm(bin, lid, params, lidZOffset(params))).toBe(0);
+      // And the column reading that goes with it. Higher than an UNRELIEVED
+      // bin's, which looks like the wrong direction and is not (#4225): the
+      // ring stops at the lip line by design, leaving a tongue of divider
+      // between there and the wall face, and a whole rail to lie against it
+      // where the unrelieved bin had notched the rail away entirely. Flush
+      // material costs the rail no travel, which is what the zero above says,
+      // but a column counts the shared Z all the same.
       expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
-        RAIL_ENGAGEMENT_CEILING + RELIEVED_INTERIOR_EXTRA_MM,
+        RAIL_ENGAGEMENT_CEILING + RAIL_FLUSH_FILL_MM,
         1
       );
     }

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -8,10 +8,14 @@
  * `checkLidCompatibility` drops the rail only for a height the user typed that
  * still reaches it.
  *
- * The ramp's inward offset and the chute above it are NOT what does the damage:
- * they cost 0.07mm against a 0.64mm snap baseline, while a ramp taken to the
- * wall top costs 0.39mm. gated on the offset and dropped the rail on
- * every scooped wall for it.
+ * The ramp's inward offset and the chute above it are NOT what does the damage,
+ * and what makes that true is WHERE the chute stands rather than how thin it is
+ * (#4224): its face is on the lip's inner face, the plane the rail has already
+ * been deflected past by the time it is that deep. So it fills the void under
+ * the lip without asking the rail for a millimetre of extra travel. A ramp
+ * taken to the wall top is a different shape: its arc carries material inboard
+ * of that plane, where the rail cannot follow, and the rail is dropped on every
+ * wall carrying one.
  *
  * Both meshes stay watertight and plausibly sized either way, so only mating
  * them shows it.
@@ -23,21 +27,11 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   lidZOffset,
+  railKeepoutIntrusionMm,
   RAIL_ENGAGEMENT_CEILING,
+  RAIL_FLUSH_FILL_MM,
   worstRailInterference,
 } from './__kernel-tests__/lidSeating';
-
-/**
- * Extra rail interference a scoop adds, on its own wall only. Back, left and
- * right read `RAIL_ENGAGEMENT_CEILING` on the same bin, so it is localised to
- * the scooped side, at the outermost probe offset where the lip sits.
- *
- * Whether that much extra material in the rail's path is acceptable snap
- * resistance is an open geometry question. Asserted from both sides rather than
- * as an allowance, so correcting the chute fails here and forces this back to
- * the plain ceiling instead of passing quietly.
- */
-const SCOOP_WALL_EXTRA_MM = 0.6;
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, ScoopSide } from '@/features/bin-designer/types';
 
@@ -93,11 +87,17 @@ describe('lid click rails clear the scoop', () => {
       expect(new Set(railPlacements(resolveLidInputs(params)).map((p) => p.rotationDeg))).toContain(
         ROTATION[side]
       );
-      // 0.15mm covers tessellation noise on the chute where it runs to the
-      // wall top, which is the plane the lip's base now sits on.
-      // The defect this guards against measured 1.1mm.
+      // Nothing the rail has to deflect for: the chute stands ON the lip line,
+      // so the rail meets it already pushed that far in. This is the assertion
+      // that says the scoop seats, and the column reading below is a
+      // consequence of it rather than a second opinion.
+      expect(railKeepoutIntrusionMm(bin, lid, params, lidZOffset(params))).toBe(0);
+      // The chute's own height, in the column metric's terms. Asserted from
+      // both sides so a change to the chute has to be looked at, in either
+      // direction: a taller one is not free, and a shorter one is a
+      // regeneration of published geometry.
       expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
-        RAIL_ENGAGEMENT_CEILING + SCOOP_WALL_EXTRA_MM,
+        RAIL_ENGAGEMENT_CEILING + RAIL_FLUSH_FILL_MM,
         1
       );
     },
@@ -131,7 +131,7 @@ describe('lid click rails clear the scoop', () => {
 
     // The plain ceiling, not the scooped one: with the rail dropped from this
     // wall there is no bump on it to push through the extra material, which is
-    // the clearest evidence that SCOOP_WALL_EXTRA_MM is a rail-vs-scoop
+    // the clearest evidence that the extra reading is a rail-vs-scoop
     // interaction rather than the scoop's own geometry reaching the lid.
     expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
       RAIL_ENGAGEMENT_CEILING,
@@ -145,11 +145,10 @@ describe('lid click rails clear the scoop', () => {
     // shipped. Without it, every case above passes if the probe
     // stops finding a solid or `lidZOffset` drifts.
     //
-    // Weaker than it was. On the scoop's own wall this pairing reads the same
-    // as the clean one, so all this can still say is that the reading clears
-    // the plain ceiling. Separating the two there is the open question the
-    // scoop datum above describes; until it is settled the rail-placement
-    // assertions in this file carry the discrimination.
+    // The column metric cannot carry this on its own any more: it saturates
+    // once a column is solid through the whole band, so this pairing and a
+    // clean one both read 2.30mm (#4224). `railKeepoutIntrusionMm` is what
+    // separates them, and is asserted first for that reason.
     const { generateLid } = await import('./lidOrchestrator');
     const params = makeParams({
       scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, radius: 40, side: 'front' },
@@ -162,10 +161,11 @@ describe('lid click rails clear the scoop', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!blindLid) throw new Error('expected the lid to build');
 
-    // The clash measures ~1.0mm. Asserted at 0.9 so the control still has room
-    // to move: it only has to stay far clear of the 0.15mm the seating cases
-    // above allow, and pinning it to its exact reading would make any change to
-    // where the lid seats look like a broken probe.
+    // The arc reaches 0.20mm inboard of the lip line under this rail, against
+    // the flat zero every correctly paired case above reads. Asserted loosely:
+    // it only has to be non-zero for those zeroes to mean anything, and pinning
+    // the figure would make any change to the ramp look like a broken probe.
+    expect(railKeepoutIntrusionMm(bin, blindLid, params, lidZOffset(params))).toBeGreaterThan(0);
     expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(
       RAIL_ENGAGEMENT_CEILING
     );

--- a/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidScoopClearance.scenario.test.ts
@@ -9,9 +9,9 @@
  * still reaches it.
  *
  * The ramp's inward offset and the chute above it are NOT what does the damage,
- * and what makes that true is WHERE the chute stands rather than how thin it is
- * (#4224): its face is on the lip's inner face, the plane the rail has already
- * been deflected past by the time it is that deep. So it fills the void under
+ * and what makes that true is WHERE the chute stands rather than how thin it is:
+ * its face is on the lip's inner face, the plane the rail has already been
+ * deflected past by the time it is that deep. So it fills the void under
  * the lip without asking the rail for a millimetre of extra travel. A ramp
  * taken to the wall top is a different shape: its arc carries material inboard
  * of that plane, where the rail cannot follow, and the rail is dropped on every
@@ -87,15 +87,12 @@ describe('lid click rails clear the scoop', () => {
       expect(new Set(railPlacements(resolveLidInputs(params)).map((p) => p.rotationDeg))).toContain(
         ROTATION[side]
       );
-      // Nothing the rail has to deflect for: the chute stands ON the lip line,
-      // so the rail meets it already pushed that far in. This is the assertion
-      // that says the scoop seats, and the column reading below is a
-      // consequence of it rather than a second opinion.
+      // The chute stands ON the lip line, so the rail meets it already pushed
+      // that far in and has nothing left to deflect for. This is what says the
+      // scoop seats; the column reading below follows from it.
       expect(railKeepoutIntrusionMm(bin, lid, params, lidZOffset(params))).toBe(0);
-      // The chute's own height, in the column metric's terms. Asserted from
-      // both sides so a change to the chute has to be looked at, in either
-      // direction: a taller one is not free, and a shorter one is a
-      // regeneration of published geometry.
+      // Pinned from both sides, so shortening the chute fails here too: that
+      // regenerates published geometry, and is a decision rather than a tidy-up.
       expect(worstRailInterference(bin, lid, lidZOffset(params))).toBeCloseTo(
         RAIL_ENGAGEMENT_CEILING + RAIL_FLUSH_FILL_MM,
         1
@@ -145,10 +142,9 @@ describe('lid click rails clear the scoop', () => {
     // shipped. Without it, every case above passes if the probe
     // stops finding a solid or `lidZOffset` drifts.
     //
-    // The column metric cannot carry this on its own any more: it saturates
-    // once a column is solid through the whole band, so this pairing and a
-    // clean one both read 2.30mm (#4224). `railKeepoutIntrusionMm` is what
-    // separates them, and is asserted first for that reason.
+    // The column metric cannot carry this alone any more: it saturates once a
+    // column is solid through the whole band, so this pairing and a clean one
+    // read alike. `railKeepoutIntrusionMm` is what still separates them.
     const { generateLid } = await import('./lidOrchestrator');
     const params = makeParams({
       scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, radius: 40, side: 'front' },
@@ -161,10 +157,9 @@ describe('lid click rails clear the scoop', () => {
     if (!bin) throw new Error('expected the bin to build');
     if (!blindLid) throw new Error('expected the lid to build');
 
-    // The arc reaches 0.20mm inboard of the lip line under this rail, against
-    // the flat zero every correctly paired case above reads. Asserted loosely:
-    // it only has to be non-zero for those zeroes to mean anything, and pinning
-    // the figure would make any change to the ramp look like a broken probe.
+    // Asserted loosely: the arc only has to reach inboard of the lip line at
+    // all for the zeroes above to mean anything, and pinning how far would make
+    // any change to the ramp look like a broken probe.
     expect(railKeepoutIntrusionMm(bin, blindLid, params, lidZOffset(params))).toBeGreaterThan(0);
     expect(worstRailInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(
       RAIL_ENGAGEMENT_CEILING

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -37,11 +37,11 @@
  * (#4224, #4225).
  *
  * The scope this buys is the rail band, where three of the four defects lived.
- * A pad on the skirt line away from any rail
- * needs the footprint sweep, and keeps its own dedicated test. Widening this
- * gate to cover that too means first making `verticalSolidSpans` robust to the
- * odd crossing counts that interior features leave at coincident faces — its
- * own known weakness, and its own piece of work.
+ * A pad on the skirt line away from any rail needs the footprint sweep, and
+ * keeps its own dedicated test. Widening this gate to cover that too means
+ * first making `verticalSolidSpans` robust to the odd crossing counts that
+ * interior features leave at coincident faces: its own known weakness, and its
+ * own piece of work.
  *
  *   pnpm run test:run src/features/generation/worker/generators/lidSeatInterference.matrix
  */

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -33,8 +33,8 @@
  * That delta says how MUCH shared Z a feature adds. `railKeepoutIntrusionMm`,
  * run over the same cases, says whether any of it is somewhere the rail cannot
  * deflect to reach. That is the question a column cannot answer, since it
- * counts material lying flush with the lip line the same as material in the way
- * (#4224, #4225).
+ * counts material lying flush with the lip line the same as material in the
+ * way.
  *
  * The scope this buys is the rail band, where three of the four defects lived.
  * A pad on the skirt line away from any rail needs the footprint sweep, and
@@ -320,10 +320,10 @@ describe('nothing intrudes into the lid seating volume', () => {
     });
     // The column delta above says how much shared Z a feature adds; this says
     // whether any of it is somewhere the rail cannot deflect to reach. A scoop
-    // chute or a relieved bin's perimeter tongue lies flush with the lip line
-    // and scores here as zero while adding 0.60mm there (#4224, #4225), so the
-    // two together are what separate a feature that costs travel from one that
-    // costs only contact.
+    // chute or a relieved bin's perimeter tongue lies flush with the lip line,
+    // so it scores here as zero while still adding to the delta. The two
+    // together separate a feature that costs the rail travel from one that
+    // costs it only contact.
     expect(blocked).toEqual([]);
     expect(unexplained).toEqual([]);
 

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -30,8 +30,14 @@
  *    (0.2-0.8mm on configurations with no defect). Matching rail positions have
  *    neither problem: the set is discrete and identical for one footprint.
  *
- * The scope this buys is the rail band, where three of the four defects lived
- *. A pad on the skirt line away from any rail
+ * That delta says how MUCH shared Z a feature adds. `railKeepoutIntrusionMm`,
+ * run over the same cases, says whether any of it is somewhere the rail cannot
+ * deflect to reach. That is the question a column cannot answer, since it
+ * counts material lying flush with the lip line the same as material in the way
+ * (#4224, #4225).
+ *
+ * The scope this buys is the rail band, where three of the four defects lived.
+ * A pad on the skirt line away from any rail
  * needs the footprint sweep, and keeps its own dedicated test. Widening this
  * gate to cover that too means first making `verticalSolidSpans` robust to the
  * odd crossing counts that interior features leave at coincident faces — its
@@ -44,7 +50,9 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   lidZOffset,
+  railKeepoutIntrusionMm,
   worstRailInterferenceDelta,
+  RAIL_FLUSH_FILL_MM,
   type SeatedPair,
 } from './__kernel-tests__/lidSeating';
 import { allPairs, uncoveredPairs, type Axis } from '@/test/pairwise';
@@ -58,24 +66,13 @@ import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types
 const TOLERANCE_MM = 0.05;
 
 /**
- * Rail intrusion a scoop contributes, on its own wall. Whether it is acceptable
- * is an open geometry question, so this pins current behaviour rather than
- * asserting the geometry is right.
+ * How many scooped cases read {@link RAIL_FLUSH_FILL_MM}.
  *
- * Reported separately rather than absorbed into {@link TOLERANCE_MM}, so every
- * other pairing keeps its 0.05mm sensitivity.
+ * A scoop's chute only lies under a rail on some pairings; the rest read clean.
+ * Pinned as a count so both directions fail: a case that stops carrying it, and
+ * a new one that starts.
  */
-const SCOOP_RAIL_INTRUSION_MM = 0.6;
-
-/**
- * How many scooped cases carry that intrusion.
- *
- * A scoop only reaches the rail on some pairings; the rest read clean. Pinned
- * as a count so both directions fail: a case that stops carrying it, and a new
- * one that starts. Corrected geometry takes this to zero, and this assertion is
- * what says so rather than passing quietly.
- */
-const SCOOP_CASES_AT_INTRUSION = 3;
+const SCOOP_CASES_AT_FLUSH_FILL = 3;
 
 const grid = (cols: number, rows: number): CompartmentConfig => ({
   cols,
@@ -259,6 +256,11 @@ describe('nothing intrudes into the lid seating volume', () => {
     expect(
       worstRailInterferenceDelta({ bin, lid: blindLid, dz }, { bin: plainBin, lid: blindLid, dz })
     ).toBeGreaterThan(2.5);
+    // Same control, for the keep-out sweep the case loop runs. Without it that
+    // sweep's empty result could mean "nothing intrudes" or "the rail gate
+    // matched nothing", and a gate that matched nothing would report every
+    // configuration in the matrix as clean.
+    expect(railKeepoutIntrusionMm(bin, blindLid, params, dz)).toBeGreaterThan(1);
   }, 300000);
 
   it("no case puts bin material in a rail's path", async () => {
@@ -275,6 +277,7 @@ describe('nothing intrudes into the lid seating volume', () => {
     const measured: Case[] = [];
     const intruding: Array<{ case: string; mm: number }> = [];
     const scooped: Array<{ case: string; mm: number }> = [];
+    const blocked: Array<{ case: string; mm: number }> = [];
 
     for (const c of CASES) {
       const built = build(c);
@@ -292,6 +295,8 @@ describe('nothing intrudes into the lid seating volume', () => {
         baselines.set(baseKey, baseline);
       }
       measured.push(c);
+      const keepout = railKeepoutIntrusionMm(built.bin, built.lid, paramsFor(c), built.dz);
+      if (keepout > 0) blocked.push({ case: key(c), mm: Number(keepout.toFixed(2)) });
       const mm = worstRailInterferenceDelta(built, baseline);
       if (c.scoop !== 'off') scooped.push({ case: key(c), mm: Number(mm.toFixed(3)) });
       if (mm >= TOLERANCE_MM) intruding.push({ case: key(c), mm: Number(mm.toFixed(3)) });
@@ -300,10 +305,8 @@ describe('nothing intrudes into the lid seating volume', () => {
     // Classified from every scooped case, not from `intruding`: a scooped case
     // reading below the tolerance never enters that list, so filtering it would
     // let such a case vanish from both sides of the check.
-    const atIntrusion = scooped.filter(
-      (i) => Math.abs(i.mm - SCOOP_RAIL_INTRUSION_MM) < TOLERANCE_MM
-    );
-    const unexplained = intruding.filter((i) => !atIntrusion.some((a) => a.case === i.case));
+    const atFlushFill = scooped.filter((i) => Math.abs(i.mm - RAIL_FLUSH_FILL_MM) < TOLERANCE_MM);
+    const unexplained = intruding.filter((i) => !atFlushFill.some((a) => a.case === i.case));
 
     // Completeness is asserted above over the GENERATED cases; a build that
     // fails silently removes its case from the measured set, and enough of
@@ -315,12 +318,19 @@ describe('nothing intrudes into the lid seating volume', () => {
       skipped: [],
       uncovered: [],
     });
+    // The column delta above says how much shared Z a feature adds; this says
+    // whether any of it is somewhere the rail cannot deflect to reach. A scoop
+    // chute or a relieved bin's perimeter tongue lies flush with the lip line
+    // and scores here as zero while adding 0.60mm there (#4224, #4225), so the
+    // two together are what separate a feature that costs travel from one that
+    // costs only contact.
+    expect(blocked).toEqual([]);
     expect(unexplained).toEqual([]);
 
-    // A scooped case reads the intrusion or it reads clean, never a value in
+    // A scooped case reads the flush fill or it reads clean, never a value in
     // between: that quantisation is what makes this one finding rather than a
     // spread the tolerance happens to cover.
-    expect(scooped.filter((i) => i.mm >= TOLERANCE_MM && !atIntrusion.includes(i))).toEqual([]);
-    expect(atIntrusion).toHaveLength(SCOOP_CASES_AT_INTRUSION);
+    expect(scooped.filter((i) => i.mm >= TOLERANCE_MM && !atFlushFill.includes(i))).toEqual([]);
+    expect(atFlushFill).toHaveLength(SCOOP_CASES_AT_FLUSH_FILL);
   }, 900000);
 });

--- a/src/features/generation/worker/generators/railEngagement.kernel.test.ts
+++ b/src/features/generation/worker/generators/railEngagement.kernel.test.ts
@@ -18,6 +18,7 @@ import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   interferenceAt,
   lidZOffset,
+  railKeepoutIntrusionMm,
   RAIL_ENGAGEMENT_CEILING,
   worstRailInterference,
 } from './__kernel-tests__/lidSeating';
@@ -92,6 +93,40 @@ describe('rail engagement datum', () => {
     },
     300_000
   );
+
+  it('the keep-out sweep answers the same on a preview and an export mesh', async () => {
+    // Every suite that uses the sweep hands it the preview mesh, whose base
+    // socket rides unfused: a column over a foot crosses that seam and would
+    // pair into spans reporting the cavity solid. Reading the topmost crossing
+    // is what makes the answer independent of which mesh arrives, and nothing
+    // else asserts that. Both a clean pairing and an obstructed one, since
+    // agreeing on zero would prove nothing.
+    const { generateLid } = await import('./lidOrchestrator');
+    const clean = featureFree(3, 2);
+    const obstructed: BinParams = {
+      ...clean,
+      compartments: { cols: 3, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3, 4, 5] },
+    };
+    // Built from `clean`, so the lid keeps whole rails over dividers it does
+    // not know about. Rails notched around them would gate the sweep out.
+    const lid = generateLid(clean);
+    if (!lid) throw new Error('expected the lid to build');
+
+    const readings = [clean, obstructed].map((params) => {
+      const preview = getGenerateBin()(params, undefined, false);
+      const exported = getGenerateBin()(params, undefined, true);
+      if (!preview || !exported) throw new Error('expected both meshes to build');
+      const dz = lidZOffset(params);
+      return {
+        preview: railKeepoutIntrusionMm(preview, lid, params, dz),
+        exported: railKeepoutIntrusionMm(exported, lid, params, dz),
+      };
+    });
+
+    expect(readings[0]).toEqual({ preview: 0, exported: 0 });
+    expect(readings[1].preview).toBeCloseTo(readings[1].exported, 2);
+    expect(readings[1].preview).toBeGreaterThan(1);
+  }, 300_000);
 
   it('reads the same on all four walls, which a clash would not', async () => {
     // What identifies the figure as the rail's own profile rather than a clash


### PR DESCRIPTION
Settles #4224 and #4225 together: the geometry is right, the metric was
answering the wrong question.

## What the 0.60mm is

Sectioning bin and lid at the rail, on the front wall of a 2x2x4:

| case | `worstRailInterference` | peak radial deflection | contact area |
| --- | --- | --- | --- |
| plain | 1.70 | 0.55mm | 0.89mm² |
| auto scoop, its own wall | 2.30 | 0.55mm | 1.19mm² |
| `relieveInterior` + 2x2 grid | 2.30 | 0.55mm | 1.19mm² |
| wall-top scoop + lid built blind to it | 2.30 | **0.65mm** | 1.37mm² |

In both flagged cases the extra material is the same shape: it stands in
the void under the lip with its inner face ON the lip line, 2.6mm in
from the outer face. For the scoop that is the chute by construction;
for the relief ring it is the tongue left between the wall face and the
ring's outer boundary, which stops at the lip line precisely so the
cutter cannot shave the undercut the bump hooks.

A rail deep enough to touch either has already been deflected past that
exact plane by the lip itself, so neither asks it for a millimetre of
extra travel. Only the contact band gets taller. That is why
`relieveInterior` looked like it pushed the reading the wrong way: it
gives the wall back a whole rail where the unrelieved bin had notched
the rail away, and a whole rail lies against more of the tongue.

## Why the probe could not say so

A column measures shared Z, so flush material and an obstruction look
identical, and the reading saturates: once a column is solid through
the band it reads 2.30mm whatever else is down there. That is what cost
`lidScoopClearance`'s deliberately-mispaired control its discrimination.

`railKeepoutIntrusionMm` measures how far inboard of the lip's inner
face bin material reaches inside the seated rail's band, wherever the
lid actually carries a rail. That is the volume `lidKeepoutRing`
describes, read off the built solid instead of restated from the
arithmetic that cut it.

- 0.00mm on every clean pairing measured: plain, 1x1, 3x3, 30mm grid
  unit, 0.8/1.6mm walls, half grid, a 4mm collar, all four scoop sides,
  and every relieved compartment case from both issue tables.
- 0.20mm on the mispaired control, so it discriminates again.

Two bounds keep it honest. It only looks where the lid has rail, since
an unrelieved bin's dividers fill this band by design and the rail is
notched away around them. And it only sweeps the straight run, since a
corner arc's inward normal is not the axis the depth is measured along.
It reads the topmost crossing rather than pairing spans, for the reason
`ungrippedRailMm` does: a column over a base foot picks up the preview
path's coincident socket seam, which flips the parity and would read a
clean bin as the worst possible intrusion. Verified to agree on preview
and export meshes across 20 configurations.

## Changes

`SCOOP_WALL_EXTRA_MM`, `RELIEVED_INTERIOR_EXTRA_MM` and
`SCOOP_RAIL_INTRUSION_MM` were pins on observed behaviour pending this
decision. They are replaced by one `RAIL_FLUSH_FILL_MM` beside the
ceiling it is added to, and each suite now asserts the intrusion is zero
first, with the column reading as the consequence rather than a second
opinion. The interference matrix runs the new probe over every generated
case; the divider control it already builds now also asserts the sweep
is live, so an empty result cannot mean the rail gate matched nothing.

Tests only. No geometry changes, no snapshot churn. A second commit records
the invariant in the `geometry-debugging` skill; the `doc-budget.json`
churn alongside it is the pre-commit ratchet's own doing, not an edit.

Fixes #4224
Fixes #4225

https://claude.ai/code/session_01UcvYmj4zKK2kDHoMHB6WF2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


