### PR TITLE
fix: clear the plug on a snap-fit lid so the rail is not fighting a press fit

### DIFF
--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -966,7 +966,9 @@ export function useLidSection() {
       // from the resolver rather than re-testing the predicate, so the hint
       // can't claim a relief the geometry didn't actually apply.
       magneticClearanceMm: LID_MAGNETIC_EXTRA_CLEARANCE,
-      hasMagneticRelief: resolveLidMateRelief(params) > 0,
+      // Attachment-gated: a snap-fit lid also gets a plug relief now, but this
+      // hint sits under the magnetic branch and speaks only to the magnets.
+      hasMagneticRelief: params.lid.attachment === 'magnetic' && resolveLidMateRelief(params) > 0,
       disabledReason,
       stackingLipMissing,
       disabledRails,

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -966,8 +966,8 @@ export function useLidSection() {
       // from the resolver rather than re-testing the predicate, so the hint
       // can't claim a relief the geometry didn't actually apply.
       magneticClearanceMm: LID_MAGNETIC_EXTRA_CLEARANCE,
-      // Attachment-gated: a snap-fit lid also gets a plug relief now, but this
-      // hint sits under the magnetic branch and speaks only to the magnets.
+      // Gated to magnetic: a snap-fit lid also carries a plug relief, but this
+      // hint renders only under the magnetic branch.
       hasMagneticRelief: params.lid.attachment === 'magnetic' && resolveLidMateRelief(params) > 0,
       disabledReason,
       stackingLipMissing,

--- a/src/features/bin-designer/types/lid.test.ts
+++ b/src/features/bin-designer/types/lid.test.ts
@@ -126,23 +126,19 @@ describe('resolveLidMateRelief', () => {
     );
   });
 
-  // A click rail hooks the lip and carries the retention, so the plug should
-  // clear the lip rather than grip it as a press fit (#4233).
   it('relieves the plug on a snap-fit (click-rail) lid', () => {
     expect(
       resolveLidMateRelief(params({ attachment: 'clickRails', clickRails: rails(true) }))
     ).toBeCloseTo(LID_SNAP_PLUG_CLEARANCE, 6);
   });
 
-  // A click-rail lid with every rail turned off has no snap to hold it, so it
-  // is really a friction fit and must keep the full grip.
+  // Every rail off is a friction fit, which keeps the full grip.
   it('withholds the relief from a click-rail lid with no rails', () => {
     expect(
       resolveLidMateRelief(params({ attachment: 'clickRails', clickRails: rails(false) }))
     ).toBe(0);
   });
 
-  // No lip to hook: the rail grips nothing, so the lid falls back to friction.
   it('withholds the relief from a click-rail lid on a lip-less bin', () => {
     const noLip = params(
       { attachment: 'clickRails', clickRails: rails(true) },

--- a/src/features/bin-designer/types/lid.test.ts
+++ b/src/features/bin-designer/types/lid.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_LID_CONFIG,
   LID_FIT_CLEARANCE,
   LID_MAGNETIC_EXTRA_CLEARANCE,
+  LID_SNAP_PLUG_CLEARANCE,
   LID_TOP_THICKNESS_BASE,
   LID_TOP_THICKNESS_MIN_MM,
   LID_TOP_THICKNESS_MAX_MM,
@@ -112,9 +113,10 @@ describe('resolveLidMateRelief', () => {
     lid: { ...DEFAULT_BIN_PARAMS.lid, ...lid },
   });
 
-  it('relieves nothing on friction and click-rail lids', () => {
+  const rails = (on: boolean) => ({ front: on, back: on, left: on, right: on });
+
+  it('relieves nothing on a friction lid', () => {
     expect(resolveLidMateRelief(params({ attachment: 'friction' }))).toBe(0);
-    expect(resolveLidMateRelief(params({ attachment: 'clickRails' }))).toBe(0);
   });
 
   it('relieves the plug when the design actually gets retention magnets', () => {
@@ -122,6 +124,31 @@ describe('resolveLidMateRelief', () => {
       LID_MAGNETIC_EXTRA_CLEARANCE,
       6
     );
+  });
+
+  // A click rail hooks the lip and carries the retention, so the plug should
+  // clear the lip rather than grip it as a press fit (#4233).
+  it('relieves the plug on a snap-fit (click-rail) lid', () => {
+    expect(
+      resolveLidMateRelief(params({ attachment: 'clickRails', clickRails: rails(true) }))
+    ).toBeCloseTo(LID_SNAP_PLUG_CLEARANCE, 6);
+  });
+
+  // A click-rail lid with every rail turned off has no snap to hold it, so it
+  // is really a friction fit and must keep the full grip.
+  it('withholds the relief from a click-rail lid with no rails', () => {
+    expect(
+      resolveLidMateRelief(params({ attachment: 'clickRails', clickRails: rails(false) }))
+    ).toBe(0);
+  });
+
+  // No lip to hook: the rail grips nothing, so the lid falls back to friction.
+  it('withholds the relief from a click-rail lid on a lip-less bin', () => {
+    const noLip = params(
+      { attachment: 'clickRails', clickRails: rails(true) },
+      { base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } }
+    );
+    expect(resolveLidMateRelief(noLip)).toBe(0);
   });
 
   // A magnetic lid without a lip, or on a polygon footprint, generates NO
@@ -154,8 +181,10 @@ describe('resolveLidMateRelief', () => {
   // which is the visible joint with the bin. Sub-millimetre so it relieves the
   // grip without letting the lid wander on its magnets.
   it('stays well under the wall it is cut from', () => {
-    expect(LID_MAGNETIC_EXTRA_CLEARANCE).toBeGreaterThan(0);
-    expect(LID_MAGNETIC_EXTRA_CLEARANCE).toBeLessThan(LID_FIT_CLEARANCE);
+    for (const relief of [LID_MAGNETIC_EXTRA_CLEARANCE, LID_SNAP_PLUG_CLEARANCE]) {
+      expect(relief).toBeGreaterThan(0);
+      expect(relief).toBeLessThan(LID_FIT_CLEARANCE);
+    }
   });
 });
 

--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -70,21 +70,33 @@ export const LID_MIN_CORNER_RADIUS = 0.1;
 export const LID_MAGNETIC_EXTRA_CLEARANCE = 0.15;
 
 /**
- * The plug relief this design actually gets — {@link LID_MAGNETIC_EXTRA_CLEARANCE}
- * on a magnetic lid, zero on every other.
+ * Per-side plug relief (mm) for a snap-fit (click-rail) lid, for the same reason
+ * a magnetic lid gets {@link LID_MAGNETIC_EXTRA_CLEARANCE}: the rail hooks the
+ * lip's undercut and supplies the retention, so the plug only locates the lid.
+ * At zero relief the plug's outer face lands flush on the lip's inner face, a
+ * friction fit the rail has to press through before it can deflect and catch —
+ * the lid reads as press-fit, not snap-fit (#4233). Held on the plug alone, off
+ * {@link lidAnchorZ}, as the magnetic relief is: perimeter and seat plane stay put.
+ */
+export const LID_SNAP_PLUG_CLEARANCE = 0.15;
+
+/**
+ * Per-side plug relief — {@link LID_MAGNETIC_EXTRA_CLEARANCE} on a magnetic lid,
+ * {@link LID_SNAP_PLUG_CLEARANCE} on a snap-fit one, zero on a friction lid.
  *
- * The predicate mirrors the GEOMETRIC half of `usesMagneticLid` — a magnetic
- * lid on a lip-less or polygon bin falls back to a plain friction fit (no
- * corner bosses are generated), so it must keep the full grip or it would
- * rattle. It deliberately omits that helper's `lid.enabled` term: a disabled
- * lid is never generated, so its relief is never consumed.
+ * Both reliefs need the GEOMETRIC half of `usesMagneticLid` (stacking lip +
+ * rectangular footprint): without a lip to hook or bosses to seat, either lid is
+ * a plain friction fit that must keep full grip or rattle — and a click-rail lid
+ * with every rail off is that same fallback. Omits `usesMagneticLid`'s
+ * `lid.enabled` term: a disabled lid is never generated, so never consumes this.
  */
 export function resolveLidMateRelief(params: LidGeometrySource): number {
-  const magnetic =
-    params.lid.attachment === 'magnetic' &&
-    params.base.stackingLip &&
-    !isPartialMask(params.cellMask);
-  return magnetic ? LID_MAGNETIC_EXTRA_CLEARANCE : 0;
+  if (!params.base.stackingLip || isPartialMask(params.cellMask)) return 0;
+  if (params.lid.attachment === 'magnetic') return LID_MAGNETIC_EXTRA_CLEARANCE;
+  const rails = params.lid.clickRails;
+  const hasRail = rails.front || rails.back || rails.left || rails.right;
+  if (params.lid.attachment === 'clickRails' && hasRail) return LID_SNAP_PLUG_CLEARANCE;
+  return 0;
 }
 
 /** Lid outer corner radius (mm) BEFORE clearance subtraction. Lid-specific —

--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -70,25 +70,18 @@ export const LID_MIN_CORNER_RADIUS = 0.1;
 export const LID_MAGNETIC_EXTRA_CLEARANCE = 0.15;
 
 /**
- * Per-side plug relief (mm) for a snap-fit (click-rail) lid, for the same reason
- * a magnetic lid gets {@link LID_MAGNETIC_EXTRA_CLEARANCE}: the rail hooks the
- * lip's undercut and supplies the retention, so the plug only locates the lid.
- * At zero relief the plug's outer face lands flush on the lip's inner face, a
- * friction fit the rail has to press through before it can deflect and catch —
- * the lid reads as press-fit, not snap-fit (#4233). Held on the plug alone, off
- * {@link lidAnchorZ}, as the magnetic relief is: perimeter and seat plane stay put.
+ * Per-side plug relief (mm) for a snap-fit (click-rail) lid. The rail hooks the
+ * lip and supplies the retention, so the plug only locates the lid; at zero
+ * relief its outer face lands flush on the lip and the lid presses on rather
+ * than snapping. Confined to the plug like {@link LID_MAGNETIC_EXTRA_CLEARANCE}.
  */
 export const LID_SNAP_PLUG_CLEARANCE = 0.15;
 
 /**
- * Per-side plug relief — {@link LID_MAGNETIC_EXTRA_CLEARANCE} on a magnetic lid,
- * {@link LID_SNAP_PLUG_CLEARANCE} on a snap-fit one, zero on a friction lid.
- *
- * Both reliefs need the GEOMETRIC half of `usesMagneticLid` (stacking lip +
- * rectangular footprint): without a lip to hook or bosses to seat, either lid is
- * a plain friction fit that must keep full grip or rattle — and a click-rail lid
- * with every rail off is that same fallback. Omits `usesMagneticLid`'s
- * `lid.enabled` term: a disabled lid is never generated, so never consumes this.
+ * Per-side plug relief: a magnetic or snap-fit lid backs the plug off the lip so
+ * it does not fight the retention. Withheld without a lip to hook or a
+ * rectangular footprint, and from a click-rail lid with every rail off, since
+ * each of those is a plain friction fit that has to keep full grip.
  */
 export function resolveLidMateRelief(params: LidGeometrySource): number {
   if (!params.base.stackingLip || isPartialMask(params.cellMask)) return 0;

--- a/src/features/generation/worker/generators/lidClickRail.ts
+++ b/src/features/generation/worker/generators/lidClickRail.ts
@@ -85,17 +85,23 @@ function clickShape2D(wallBottomZ: number, cavityWallX: number): Drawing {
   const chamferApexX = chamferApexXForCavityWall(cavityWallX);
   const chamferTopY = yTop + (chamferApexX - LID_CLICK_RAIL_INNER);
 
-  return draw([chamferApexX, yTop])
-    .lineTo([LID_CLICK_RAIL_OUT, yTop])
-    .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y1])
-    .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y2])
-    .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y3])
-    .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y4])
-    .lineTo([0, y5])
-    .lineTo([LID_CLICK_RAIL_INNER, y5])
-    .lineTo([LID_CLICK_RAIL_INNER, yTop])
-    .lineTo([chamferApexX, chamferTopY])
-    .close();
+  return (
+    draw([chamferApexX, yTop])
+      .lineTo([LID_CLICK_RAIL_OUT, yTop])
+      .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y1])
+      .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y2])
+      // Exit chamfer steps OUTWARD past the bump body on purpose: this lower ledge
+      // is the surface that hooks the lip's bottom chamfer, so it carries ~0.5mm of
+      // the rail's engagement (railEngagement.kernel pins the total). Relieving it
+      // inward reads as a cleaner profile but drops the catch (#4207 regression).
+      .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y3])
+      .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y4])
+      .lineTo([0, y5])
+      .lineTo([LID_CLICK_RAIL_INNER, y5])
+      .lineTo([LID_CLICK_RAIL_INNER, yTop])
+      .lineTo([chamferApexX, chamferTopY])
+      .close()
+  );
 }
 
 /**

--- a/src/features/generation/worker/generators/lidClickRail.ts
+++ b/src/features/generation/worker/generators/lidClickRail.ts
@@ -90,10 +90,9 @@ function clickShape2D(wallBottomZ: number, cavityWallX: number): Drawing {
       .lineTo([LID_CLICK_RAIL_OUT, yTop])
       .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y1])
       .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET, y2])
-      // Exit chamfer steps OUTWARD past the bump body on purpose: this lower ledge
-      // is the surface that hooks the lip's bottom chamfer, so it carries ~0.5mm of
-      // the rail's engagement (railEngagement.kernel pins the total). Relieving it
-      // inward reads as a cleaner profile but drops the catch (#4207 regression).
+      // Steps OUTWARD past the bump body on purpose: this lower ledge is the
+      // surface that hooks the lip, so relieving it inward (a cleaner-looking
+      // profile) loses the catch.
       .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y3])
       .lineTo([LID_CLICK_RAIL_OUT - LID_CLICK_RAIL_INSET + LID_CLICK_RAIL_EXIT_CHAMFER, y4])
       .lineTo([0, y5])

--- a/src/shared/utils/lidCutoutPlan.test.ts
+++ b/src/shared/utils/lidCutoutPlan.test.ts
@@ -258,11 +258,8 @@ describe('lidCutoutWindow', () => {
   });
 
   it('is the same width whatever the attachment costs in fit clearance', () => {
-    // `span = width * pitch - 2 * LID_CORNER_RADIUS - 2 * margin`: the outer
-    // footprint and the cavity inset are both measured off LID_FIT_CLEARANCE.
-    // A magnetic or snap-fit lid's plug relief lands below the seam, nowhere near
-    // the window, so switching attachment mode cannot silently move a user's holes
-    // even though both carry a relief the friction fit does not.
+    // A magnetic or snap-fit lid's plug relief lands below the seam, clear of the
+    // cutout window, so switching attachment mode cannot silently move a user's holes.
     const magnetic = params({ attachment: 'magnetic' });
     const rails = params({ attachment: 'clickRails' });
     expect(resolveLidMateRelief(magnetic)).toBeGreaterThan(0);

--- a/src/shared/utils/lidCutoutPlan.test.ts
+++ b/src/shared/utils/lidCutoutPlan.test.ts
@@ -259,13 +259,14 @@ describe('lidCutoutWindow', () => {
 
   it('is the same width whatever the attachment costs in fit clearance', () => {
     // `span = width * pitch - 2 * LID_CORNER_RADIUS - 2 * margin`: the outer
-    // footprint and the cavity inset are both measured off LID_FIT_CLEARANCE,
-    // and a magnetic lid's relief lands below the seam, nowhere near the window.
-    // So switching attachment mode cannot silently move a user's holes.
+    // footprint and the cavity inset are both measured off LID_FIT_CLEARANCE.
+    // A magnetic or snap-fit lid's plug relief lands below the seam, nowhere near
+    // the window, so switching attachment mode cannot silently move a user's holes
+    // even though both carry a relief the friction fit does not.
     const magnetic = params({ attachment: 'magnetic' });
     const rails = params({ attachment: 'clickRails' });
     expect(resolveLidMateRelief(magnetic)).toBeGreaterThan(0);
-    expect(resolveLidMateRelief(rails)).toBe(0);
+    expect(resolveLidMateRelief(rails)).toBeGreaterThan(0);
 
     const w = lidCutoutWindow(magnetic)!;
     expect(w.spanW).toBeCloseTo(lidCutoutWindow(rails)!.spanW, 5);


### PR DESCRIPTION
## Summary
- A click-rail (snap-fit) lid inherited the friction plug: at `mateRelief = 0` its mating skirt lands flush on the lip's inner face (`lidCornerR - LIP_BIG_TAPER`), so the rail had to press through a zero-clearance friction fit before it could deflect and catch.
- #4213 gave the rail a real catch but left that plug in place, so the lid fought **both** the friction jam and the new rail interference. That is the "worse than before" the reporter saw in #4233.
- Fix: `resolveLidMateRelief` now returns `LID_SNAP_PLUG_CLEARANCE` (0.15mm/side) for a click-rail lid on a lipped, rectangular bin. Same plug-only relief a magnetic lid already gets, for the same reason: the positive retention (the rail) carries the lid, the plug only locates it. Held on the plug alone and off `lidAnchorZ`, so the outer perimeter stays flush and the seated plane does not move.

## Verified on the built solids
Cross-section at the front-wall midline of a 2x2x3 click-rail lid seated on its bin, at the vertical plug/lip mating face:

| | lip inner face (Y) | lid plug outer face (Y) | gap |
| --- | --- | --- | --- |
| before | 39.85 | 39.85 | 0.00mm (press fit) |
| after | 39.85 | 39.70 | 0.15mm (snap clearance) |

- Rail catch unchanged: `railEngagement.kernel` still reads the 1.7mm ceiling on all four walls; `lidClickRailSeating.scenario` still catches on 2x2 / 3x3 / 2x3.
- 329 lid tests pass (seating, interference matrix, retention, clearance suites, generator scenarios), zero triangleCount snapshot churn (a 0.15mm face shift keeps the topology).

## Deliberately not changed
The reporter's second screenshot (the "broken profile") shows the rail's exit-chamfer ledge stepping outward past the bump body. That ledge is the surface that hooks the lip's bottom chamfer and carries about 0.5mm of the rail's engagement. Relieving it inward looks like a cleaner profile but drops the catch and regresses #4207 (measured: engagement 1.7 to 1.2, 3x3x6 catch to 0). Left as-is, now documented in `clickShape2D` so it is not "cleaned up" by mistake.

## #4234, investigated here, not fixed
Reproduced and measured the stack-grid artifacts: nothing protrudes above the grid surface (Zmax = SOCKET_HEIGHT exactly), and the remaining slivers are near-zero-area (0 to 0.09 mm2) thin walls at the perimeter/corner, where the per-cell pocket's arc is tangent to the slab's perimeter arc. That is the structural tangency already adjudicated in #4215 / #4214 (baseplates carry the same signature); no cutter growth removes it without deviating from the socket profile. Explained on the issue.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `resolveLidMateRelief` unit tests (snap gets 0.15, friction / no-rail / lip-less / polygon get 0)
- [x] Full lid suite green (329 tests): seating, interference, retention, clearance, generator scenarios
- [x] `railEngagement.kernel` + `lidClickRailSeating.scenario` confirm the catch is preserved

https://claude.ai/code/session_01TPnKjSjtgfjF2HZCNv3N12


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

