### PR TITLE
fix: level the proud nub at stack-grid cross junctions (#4234)

### DIFF
--- a/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidGenerator.scenario.test.ts
@@ -11,7 +11,11 @@ import { loadTestFonts } from '@/test/loadTestFonts';
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
-import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
+import {
+  assertStructurallyValid,
+  boundingBox,
+  verticalSolidSpans,
+} from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import {
   LID_FIT_CLEARANCE,
@@ -497,6 +501,73 @@ describe('lid generation and export scenarios', () => {
       expect(flat).not.toBeNull();
       expect(plain).not.toBeNull();
       expect(flat!.triangleCount).toBe(plain!.triangleCount);
+    });
+  });
+
+  describe('stack-grid junction relief (#4234)', () => {
+    // Highest solid top at (x,y) that sits within the stack-grid slab band.
+    const crestZ = (
+      mesh: { vertices: Float32Array; indices: Uint32Array },
+      x: number,
+      y: number
+    ) => {
+      let top = -Infinity;
+      for (const [lo, hi] of verticalSolidSpans(mesh as never, x, y)) {
+        if (hi <= 5.05 && hi > 0.01 && hi > top && lo < hi) top = hi;
+      }
+      return top;
+    };
+    // Max crest over a small disc. The nub fans a few mm down each divider arm.
+    const crestNear = (
+      mesh: { vertices: Float32Array; indices: Uint32Array },
+      x: number,
+      y: number
+    ) => {
+      let m = -Infinity;
+      for (let dx = -3.5; dx <= 3.5; dx += 0.5)
+        for (let dy = -3.5; dy <= 3.5; dy += 0.5) m = Math.max(m, crestZ(mesh, x + dx, y + dy));
+      return m;
+    };
+
+    it('a cross junction no longer stands proud of the divider crest', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      // 3×3: pitch-42 grid, dividers at x,y = ±21, interior crossings at
+      // (±21, ±21). Before the relief each crossing kept a ~0.3mm nub at the
+      // full SOCKET_HEIGHT while the divider runs were shaved to the socket rim.
+      const mesh = generateLid(
+        makeParams({ stackableTop: true }, { width: 3, depth: 3, height: 3 })
+      );
+      expect(mesh).not.toBeNull();
+      assertStructurallyValid(mesh!, '3x3 stackable lid');
+
+      const baseline = Math.max(
+        crestZ(mesh!, 21, 0),
+        crestZ(mesh!, -21, 0),
+        crestZ(mesh!, 0, 21),
+        crestZ(mesh!, 0, -21)
+      );
+      expect(baseline).toBeGreaterThan(0); // the divider is really there
+      for (const [x, y] of [
+        [21, 21],
+        [21, -21],
+        [-21, 21],
+        [-21, -21],
+      ] as const) {
+        // Flush with the divider (the relief floor sits one CLEARANCE/2 rim
+        // above the shaved crest), not the +0.3mm proud nub it replaced.
+        expect(crestNear(mesh!, x, y) - baseline).toBeLessThan(0.12);
+      }
+    });
+
+    it('leaves the perimeter ring lip at full height', async () => {
+      const { generateLid } = await import('./lidOrchestrator');
+      const mesh = generateLid(
+        makeParams({ stackableTop: true }, { width: 3, depth: 3, height: 3 })
+      );
+      expect(mesh).not.toBeNull();
+      // The relief only touches interior crossings; the ring's stacking lip
+      // must still top out at SOCKET_HEIGHT for an upper bin to register on.
+      expect(boundingBox(mesh!.vertices).maxZ).toBeCloseTo(5, 3);
     });
   });
 

--- a/src/features/generation/worker/generators/lidStackGrid.test.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isLidCellFilled, type LidCellGrid } from './lidStackGrid';
+import { collectJunctions, isLidCellFilled, type LidCellGrid } from './lidStackGrid';
 import { buildFullMask, type CellMask } from '@/shared/utils/cellMask';
 import type { CellInfo } from './cellDecomposition';
 
@@ -60,5 +60,49 @@ describe('isLidCellFilled', () => {
     const mask = clear(buildFullMask(2, 2), 1, 1);
     expect(isLidCellFilled(grid(2, 2, mask), cellAt(0, 0, 1, 1, 2, 2))).toBe(false);
     expect(isLidCellFilled(grid(2, 2, mask), cellAt(1, 1, 1, 1, 2, 2))).toBe(true);
+  });
+});
+
+describe('collectJunctions', () => {
+  // Cell-boundary lines for an N-cell axis centred on the origin, e.g. N=3 at
+  // pitch 42 → [-63, -21, 21, 63].
+  const lines = (n: number): number[] =>
+    Array.from({ length: n + 1 }, (_, k) => k * GRID - (n * GRID) / 2);
+
+  it('returns only the interior crossings, never a boundary line', () => {
+    const js = collectJunctions(lines(3), lines(3));
+    // 3×3 has one interior line per axis at ±21 → four interior crossings.
+    expect(js).toHaveLength(4);
+    expect(js).toEqual(
+      expect.arrayContaining([
+        [-21, -21],
+        [-21, 21],
+        [21, -21],
+        [21, 21],
+      ])
+    );
+    const flat = js.flat();
+    // No outer boundary coordinate (±63) leaks in; that is where the ring's
+    // full-height lip and its rounded corners live.
+    expect(flat).not.toContain(63);
+    expect(flat).not.toContain(-63);
+  });
+
+  it('drops both outer lines, so a single-column grid has no crossings', () => {
+    // 1×3: the only X lines are the two outer edges, so there is no interior
+    // divider to cross, so nothing to relieve, and the ring is left intact.
+    expect(collectJunctions(lines(1), lines(3))).toHaveLength(0);
+  });
+
+  it('has no interior crossing on a 1×1 grid', () => {
+    expect(collectJunctions(lines(1), lines(1))).toHaveLength(0);
+  });
+
+  it('deduplicates repeated corner coordinates before crossing them', () => {
+    // forEachCell reports each shared boundary twice (once per adjacent cell);
+    // the crossings must not multiply with the duplicates.
+    const xs = [-63, -21, -21, 21, 21, 63];
+    const ys = [-63, -21, -21, 21, 21, 63];
+    expect(collectJunctions(xs, ys)).toHaveLength(4);
   });
 });

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -15,7 +15,12 @@
 
 import { drawRoundedRectangle, unwrap, translate, cutAll } from 'brepjs';
 import type { Shape3D, DisposalScope, Drawing, Sketch, ValidSolid } from 'brepjs';
-import { COPLANAR_OVERLAP, pocketCornerRadius, safeSectionRect } from './generatorConstants';
+import {
+  COPLANAR_OVERLAP,
+  CORNER_RADIUS,
+  pocketCornerRadius,
+  safeSectionRect,
+} from './generatorConstants';
 import { SOCKET_HEIGHT, SOCKET_BIG_TAPER, SOCKET_TAPER_WIDTH, CLEARANCE } from './generatorTypes';
 import { LID_COPLANAR_MARGIN } from './lidConstants';
 import { isRegionFilled } from '@/shared/utils/cellMask';
@@ -132,6 +137,69 @@ function buildStackLipCutter(inputs: LidInputs): Shape3D {
   });
 }
 
+/**
+ * Junction relief: shave the proud nub off each grid junction.
+ *
+ * Where two dividers cross, or a divider meets the perimeter ring, the four
+ * surrounding pocket corners are rounded, so their cutters leave a small square
+ * of slab standing at the full `SOCKET_HEIGHT` while the straight divider runs
+ * on either side are shaved to the socket rim (`SOCKET_HEIGHT - CLEARANCE/2`) by
+ * the pockets' full-width top openings. That leftover nub reads as a raised flap
+ * on the grid top (it stands ~0.3mm proud of the dividers).
+ *
+ * Cutting from the rim height upward removes exactly the proud material:
+ * everything at or below the rim is already gone, so the cutter only bites the
+ * nub. That is why the footprint can be generous (over a divider run or a
+ * pocket it re-cuts empty space) without reaching the seating taper below the
+ * rim (no bin foot ever lands on a divider crossing) or narrowing the pockets.
+ */
+const JUNCTION_RELIEF_FLOOR_Z = SOCKET_HEIGHT - CLEARANCE / 2;
+// Half-footprint of the relief. The nub fans ~one pocket-corner-radius down each
+// divider arm from the crossing (the arms stay proud until the perpendicular
+// pockets' rounded corners have curved clear), so the cutter has to reach that
+// far to take the whole star, not just the centre.
+const JUNCTION_RELIEF_HALF_MM = CORNER_RADIUS;
+const JUNCTION_RELIEF_CORNER_MM = 0.5;
+
+/** One relief cutter at the origin; callers translate a copy to each junction. */
+function buildJunctionReliefCutter(): Shape3D {
+  const side = 2 * JUNCTION_RELIEF_HALF_MM;
+  const top = SOCKET_HEIGHT + LID_COPLANAR_MARGIN;
+  const sketch = drawRoundedRectangle(side, side, JUNCTION_RELIEF_CORNER_MM).sketchOnPlane(
+    'XY',
+    JUNCTION_RELIEF_FLOOR_Z
+  ) as Sketch;
+  return sketch.extrude(top - JUNCTION_RELIEF_FLOOR_Z);
+}
+
+/**
+ * Interior crossing positions that carry a proud junction nub: every crossing
+ * of an INTERIOR cell-boundary line with another. The outer boundary lines are
+ * excluded, so both the four ring corners and the T-junctions where a divider
+ * meets an edge are left alone. A crossing surrounded by pockets on all sides
+ * is where an over-generous relief only re-cuts empty pocket space, never the
+ * perimeter lip. Derived from the same cell decomposition the pockets use, so it
+ * tracks half and fractional cells without a second source of truth.
+ */
+export function collectJunctions(
+  cornerXs: readonly number[],
+  cornerYs: readonly number[]
+): Array<readonly [number, number]> {
+  const interior = (vals: readonly number[]): number[] => {
+    const uniq = [...new Set(vals.map((v) => Math.round(v * 1e4) / 1e4))].sort((a, b) => a - b);
+    return uniq.slice(1, -1); // drop the two outer boundary lines
+  };
+  const xs = interior(cornerXs);
+  const ys = interior(cornerYs);
+  const out: Array<readonly [number, number]> = [];
+  for (const x of xs) {
+    for (const y of ys) {
+      out.push([x, y] as const);
+    }
+  }
+  return out;
+}
+
 /** The slice of {@link LidInputs} that locates a cell against the mask. */
 export type LidCellGrid = Pick<
   LidInputs,
@@ -184,10 +252,16 @@ export function buildStackGrid(scope: DisposalScope, inputs: LidInputs): Shape3D
   if (inputs.stackLipOnly) {
     pockets.push(scope.register(buildStackLipCutter(inputs)));
   } else {
+    const cornerXs: number[] = [];
+    const cornerYs: number[] = [];
     forEachCell(
       cellsX,
       cellsY,
       (cell) => {
+        const hx = (cell.widthUnits * gridUnitMm) / 2;
+        const hy = (cell.depthUnits * gridUnitMmY) / 2;
+        cornerXs.push(cell.centerX - hx, cell.centerX + hx);
+        cornerYs.push(cell.centerY - hy, cell.centerY + hy);
         if (!isLidCellFilled(inputs, cell)) return;
         const pocket = buildLidStackPocketCutter(
           cell.widthUnits * gridUnitMm,
@@ -205,6 +279,20 @@ export function buildStackGrid(scope: DisposalScope, inputs: LidInputs): Shape3D
         fractionalEdgeY: inputs.fractionalEdgeY,
       }
     );
+
+    // Relief the proud junction nubs. Skipped for cellMask lids: their grid is
+    // irregular and the ring follows the polygon outline, so a square relief
+    // could bite a real edge rather than an interior crossing.
+    if (!inputs.cellMask) {
+      const junctions = collectJunctions(cornerXs, cornerYs);
+      if (junctions.length > 0) {
+        const base = buildJunctionReliefCutter();
+        for (const [x, y] of junctions) {
+          pockets.push(scope.register(translate(base, [x, y, 0])));
+        }
+        base.delete();
+      }
+    }
   }
 
   if (pockets.length > 0) {


### PR DESCRIPTION
## What

Stackable-lid grids left a small square of slab standing at the full socket height wherever two interior dividers cross, while the divider runs around it were shaved to the socket rim. That ~0.3mm nub read as a raised flap on the grid top (the artifact reported in #4234).

## Fix

Relieve each interior crossing back to the rim. The cut floor sits at `SOCKET_HEIGHT - CLEARANCE/2`, so it removes only material standing above the divider crest and never reaches the seating taper (no bin foot ever lands on a divider crossing) or narrows the pockets. Junction positions come from the same cell decomposition the pockets use, so half and fractional grids track automatically.

Scoped to interior crossings, which are surrounded by pockets on all sides, so an over-generous cutter only re-cuts empty pocket space. T-junctions where a divider meets an edge, and the four ring corners, are left alone so the perimeter keeps its full-height stacking lip.

## Verification

- New scenario test (`lidGenerator.scenario`): on a 3x3 stackable lid every cross junction crest is now flush with the divider crest (was +0.3mm proud), and the ring lip still tops out at `SOCKET_HEIGHT`.
- New unit test (`lidStackGrid`): the junction enumeration returns interior crossings only, drops both outer boundary lines, dedups shared corners, and is empty on 1xN and 1x1 grids.
- Measured before/after on the real mesh: worst cross-junction proudness dropped from +0.300mm to +0.050mm; mesh stays watertight and manifold; 377 lid-related tests pass.
- Rendered a grazing before/after at a cross junction: the raised flap is gone.

## Scope / follow-up

The divider-to-ring T-junctions are left as-is. Relieving them risks lowering the stacking-lip crown (which must stay at full height for an upper bin to register), and their join to the ring is a subtle ramp rather than a proud flap. Can revisit if reported.

https://claude.ai/code/session_0151dN9etcdZVnAZqmDscSfC

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

